### PR TITLE
Dynamic camera — sculpted spline + banking into turns

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -5,7 +5,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "chrome-devtools-mcp@latest"
+        "chrome-devtools-mcp@1.4.0"
       ],
       "env": {}
     },
@@ -14,7 +14,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@upstash/context7-mcp@latest"
+        "@upstash/context7-mcp@3.2.2"
       ],
       "env": {}
     }

--- a/components/CameraRig.tsx
+++ b/components/CameraRig.tsx
@@ -6,31 +6,54 @@ import { curve } from "@/lib/spline";
 import { useScrollStore } from "@/lib/scrollStore";
 
 const clamp01 = (v: number) => Math.min(1, Math.max(0, v));
+const clamp = (v: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, v));
 
 export function CameraRig() {
   const look = useRef(new Vector3(0, 0, -1));
+  const pos = useRef(new Vector3());
+  const tan = useRef(new Vector3());
+  const tanAhead = useRef(new Vector3());
+  const desiredLook = useRef(new Vector3());
+  const roll = useRef(0);
   const ready = useRef(false);
 
   useFrame((state, delta) => {
     // Read t via getState() (not a selector) so the rig never re-renders on scroll.
     const t = clamp01(useScrollStore.getState().t);
-    const pos = curve.getPointAt(t);
-    const tangent = curve.getTangentAt(t);
-    const desiredLook = pos.clone().add(tangent.multiplyScalar(10));
+    curve.getPointAt(t, pos.current);
+    curve.getTangentAt(t, tan.current);
+    curve.getTangentAt(clamp01(t + 0.02), tanAhead.current);
 
-    // Frame-rate-independent smoothing: the camera lerps toward the spline target,
-    // so it never teleports and eases to rest when scrolling stops.
-    const a = 1 - Math.exp(-4 * delta);
+    // Look a little ahead along the path.
+    desiredLook.current.copy(pos.current).addScaledVector(tan.current, 14);
 
+    // Bank into horizontal turns: roll toward the inside of the curve so sweeping turns
+    // read as banked flight rather than a flat pan.
+    const heading = Math.atan2(tan.current.x, -tan.current.z);
+    const headingAhead = Math.atan2(tanAhead.current.x, -tanAhead.current.z);
+    let dHeading = headingAhead - heading;
+    dHeading = Math.atan2(Math.sin(dHeading), Math.cos(dHeading)); // wrap to [-π, π]
+    const targetRoll = clamp(-dHeading * 3.0, -0.45, 0.45);
+
+    // Frame-rate-independent smoothing: position, look target, and bank all ease.
+    const a = 1 - Math.exp(-3.5 * delta);
     if (!ready.current) {
-      state.camera.position.copy(pos);
-      look.current.copy(desiredLook);
+      state.camera.position.copy(pos.current);
+      look.current.copy(desiredLook.current);
+      roll.current = targetRoll;
       ready.current = true;
     } else {
-      state.camera.position.lerp(pos, a);
-      look.current.lerp(desiredLook, a);
+      state.camera.position.lerp(pos.current, a);
+      look.current.lerp(desiredLook.current, a);
+      roll.current += (targetRoll - roll.current) * a;
     }
+
+    // Idle sway, independent of scroll, so paused frames still breathe.
+    const sway = Math.sin(state.clock.elapsedTime * 0.35) * 0.02;
+
+    state.camera.up.set(0, 1, 0);
     state.camera.lookAt(look.current);
+    state.camera.rotateZ(roll.current + sway);
   });
 
   return null;

--- a/lib/spline.ts
+++ b/lib/spline.ts
@@ -3,14 +3,14 @@ import { CatmullRomCurve3, Vector3 } from "three";
 /** Number of scene regions laid along the spline. */
 export const SCENE_COUNT = 11;
 
-// A gentle forward-flying corridor with slight lateral/vertical drift, so the camera
-// move reads as flight rather than a straight rail. Scenes are placed along this curve;
-// the same curve drives both the camera (CameraRig) and scene placement (SceneManager),
-// so the camera literally flies through each scene region.
+// A sculpted 3D flight path: sweeping left/right turns plus elevation changes, so the
+// camera banks and re-frames continuously instead of flying straight down a tunnel. The
+// same curve drives both the camera (CameraRig) and scene placement (SceneManager), so
+// scenes always sit along the flight path and the camera flies through each region.
 const points: Vector3[] = Array.from({ length: SCENE_COUNT + 2 }, (_, i) => {
-  const z = -i * 20;
-  const x = Math.sin(i * 0.6) * 8;
-  const y = Math.cos(i * 0.4) * 4;
+  const z = -i * 24;
+  const x = Math.sin(i * 0.8) * 18 + Math.cos(i * 1.7) * 6;
+  const y = Math.sin(i * 0.55 + 0.4) * 11;
   return new Vector3(x, y, z);
 });
 


### PR DESCRIPTION
Camera was flying straight down a tunnel. This makes it dynamic:

- **Sculpted spline** — sweeping left/right turns + elevation changes replace the gentle wiggle, so the camera continuously changes heading and altitude.
- **Banking** — the camera rolls into horizontal turns (aircraft-style, clamped ±0.45 rad), so turns read as banked flight and each scene is framed from a varied angle.
- **Idle sway** — a subtle scroll-independent roll oscillation so paused frames still breathe.

Camera and scene boxes share the same curve, so scenes stay on the flight path.

Also **pins the MCP servers** in `.mcp.json` (`chrome-devtools-mcp@1.4.0`, `@upstash/context7-mcp@3.2.2`) instead of `@latest`, closing the security-review finding about an unpinned dependency auto-executed by the MCP client.

Verified: `tsc --noEmit` clean, banking visible in-browser across the journey, no console errors, still ~480 FPS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
