### PR TITLE
Livelier, dynamic camera flight + reduced-motion a11y

### DIFF
--- a/components/CameraRig.tsx
+++ b/components/CameraRig.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useRef } from "react";
 import { useFrame } from "@react-three/fiber";
-import { Vector3, type PerspectiveCamera } from "three";
+import { Vector3, PerspectiveCamera } from "three";
 import { curve, SCENE_COUNT } from "@/lib/spline";
 import { useScrollStore } from "@/lib/scrollStore";
 
@@ -10,8 +10,19 @@ const clamp = (v: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, v
 
 const BASE_FOV = 62;
 const TWO_PI = Math.PI * 2;
-// How strongly the camera dwells at scenes and accelerates between them (0 = uniform).
+
+// Camera feel tuning.
+// WHIP MUST stay < 1 to keep u monotonic: du/dt = 1 + WHIP·cos(2πN·t) ≥ 1 − WHIP.
+// WHIP = 1 freezes the camera at each scene edge; WHIP > 1 makes it briefly reverse.
 const WHIP = 0.7;
+const BANK_GAIN = 3.5;
+const MAX_BANK = 0.6; // rad
+const LOOK_AHEAD = 16; // world units ahead the camera aims
+const FOV_SPEED_GAIN = 0.35;
+const MAX_FOV_BOOST = 14; // deg above BASE_FOV
+const CORKSCREW_AMP = 0.1; // rad, peaks mid-transition, zero at scenes
+const SWAY_A = 0.02; // rad
+const SWAY_B = 0.025; // rad
 
 export function CameraRig() {
   const look = useRef(new Vector3(0, 0, -1));
@@ -25,27 +36,33 @@ export function CameraRig() {
   const ready = useRef(false);
 
   useFrame((state, delta) => {
-    // Read t via getState() (not a selector) so the rig never re-renders on scroll.
-    const t = clamp01(useScrollStore.getState().t);
+    // Read via getState() (not a selector) so the rig never re-renders on scroll.
+    const { t, reducedMotion } = useScrollStore.getState();
+    const scroll = clamp01(t);
 
-    // Dwell at each scene, whip between them: remap scroll -> path parameter so a
-    // constant scroll speed yields a rhythmic slow-fast-slow ride. u == t at every scene
-    // center and boundary (sin term is 0 there), so scene placement/mounting stay aligned.
-    const u = clamp01(t + (WHIP / (TWO_PI * SCENE_COUNT)) * Math.sin(TWO_PI * SCENE_COUNT * t));
+    // Dwell at each scene, whip between them: remap scroll -> path parameter so a constant
+    // scroll speed yields a rhythmic slow-fast-slow ride. u == t at every scene center and
+    // boundary (sin term is 0 there), so scene placement/mounting stay aligned.
+    const u = clamp01(
+      scroll + (WHIP / (TWO_PI * SCENE_COUNT)) * Math.sin(TWO_PI * SCENE_COUNT * scroll),
+    );
 
     curve.getPointAt(u, pos.current);
     curve.getTangentAt(u, tan.current);
     curve.getTangentAt(clamp01(u + 0.02), tanAhead.current);
 
     // Look ahead along the path so the camera leads into turns.
-    desiredLook.current.copy(pos.current).addScaledVector(tan.current, 16);
+    desiredLook.current.copy(pos.current).addScaledVector(tan.current, LOOK_AHEAD);
 
-    // Bank into horizontal turns: roll toward the inside of the curve.
+    // Bank into horizontal turns. Reduced motion keeps the (user-driven) forward flight
+    // but damps the autonomous vestibular triggers — bank, corkscrew, sway, FOV pulse —
+    // that cause motion sickness.
     const heading = Math.atan2(tan.current.x, -tan.current.z);
     const headingAhead = Math.atan2(tanAhead.current.x, -tanAhead.current.z);
     let dHeading = headingAhead - heading;
     dHeading = Math.atan2(Math.sin(dHeading), Math.cos(dHeading)); // wrap to [-π, π]
-    const targetRoll = clamp(-dHeading * 3.5, -0.6, 0.6);
+    const bankLimit = reducedMotion ? MAX_BANK * 0.25 : MAX_BANK;
+    const targetRoll = clamp(-dHeading * BANK_GAIN, -bankLimit, bankLimit);
 
     // Frame-rate-independent smoothing for position, look target, and bank.
     const a = 1 - Math.exp(-4 * delta);
@@ -61,26 +78,32 @@ export function CameraRig() {
       roll.current += (targetRoll - roll.current) * a;
     }
 
-    // Speed → FOV: widens during whips between scenes, settles at each scene.
+    // Speed → FOV: widens during whips, settles at scenes. Held flat under reduced motion.
     const speed = state.camera.position.distanceTo(prev.current) / Math.max(delta, 1e-3);
     prev.current.copy(state.camera.position);
-    const targetFov = BASE_FOV + clamp(speed * 0.35, 0, 14);
+    const targetFov = reducedMotion
+      ? BASE_FOV
+      : BASE_FOV + clamp(speed * FOV_SPEED_GAIN, 0, MAX_FOV_BOOST);
     fov.current += (targetFov - fov.current) * (1 - Math.exp(-4 * delta));
-    const cam = state.camera as PerspectiveCamera;
-    if (cam.isPerspectiveCamera) {
-      cam.fov = fov.current;
-      cam.updateProjectionMatrix();
+    // Only touch the projection matrix when the FOV has actually moved (it asymptotes).
+    if (state.camera instanceof PerspectiveCamera && Math.abs(state.camera.fov - fov.current) > 0.01) {
+      state.camera.fov = fov.current;
+      state.camera.updateProjectionMatrix();
     }
 
-    // Idle sway (scroll-independent) + a gentle corkscrew that peaks mid-transition and is
-    // flat at each scene, so whips feel kinetic without disorienting at the dwell points.
-    const time = state.clock.elapsedTime;
-    const sway = Math.sin(time * 0.35) * 0.02 + Math.sin(time * 0.13) * 0.025;
-    const corkscrew = Math.sin(u * TWO_PI * SCENE_COUNT) * 0.1;
+    // Idle sway + a gentle corkscrew that peaks mid-transition and is flat at each scene.
+    // Both off under reduced motion.
+    let extraRoll = 0;
+    if (!reducedMotion) {
+      const time = state.clock.elapsedTime;
+      const sway = Math.sin(time * 0.35) * SWAY_A + Math.sin(time * 0.13) * SWAY_B;
+      const corkscrew = Math.sin(u * TWO_PI * SCENE_COUNT) * CORKSCREW_AMP;
+      extraRoll = sway + corkscrew;
+    }
 
     state.camera.up.set(0, 1, 0);
     state.camera.lookAt(look.current);
-    state.camera.rotateZ(roll.current + sway + corkscrew);
+    state.camera.rotateZ(roll.current + extraRoll);
   });
 
   return null;

--- a/components/CameraRig.tsx
+++ b/components/CameraRig.tsx
@@ -1,20 +1,24 @@
 "use client";
 import { useRef } from "react";
 import { useFrame } from "@react-three/fiber";
-import { Vector3 } from "three";
+import { Vector3, type PerspectiveCamera } from "three";
 import { curve } from "@/lib/spline";
 import { useScrollStore } from "@/lib/scrollStore";
 
 const clamp01 = (v: number) => Math.min(1, Math.max(0, v));
 const clamp = (v: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, v));
 
+const BASE_FOV = 62;
+
 export function CameraRig() {
   const look = useRef(new Vector3(0, 0, -1));
   const pos = useRef(new Vector3());
+  const prev = useRef(new Vector3());
   const tan = useRef(new Vector3());
   const tanAhead = useRef(new Vector3());
   const desiredLook = useRef(new Vector3());
   const roll = useRef(0);
+  const fov = useRef(BASE_FOV);
   const ready = useRef(false);
 
   useFrame((state, delta) => {
@@ -27,18 +31,18 @@ export function CameraRig() {
     // Look a little ahead along the path.
     desiredLook.current.copy(pos.current).addScaledVector(tan.current, 14);
 
-    // Bank into horizontal turns: roll toward the inside of the curve so sweeping turns
-    // read as banked flight rather than a flat pan.
+    // Bank into horizontal turns: roll toward the inside of the curve.
     const heading = Math.atan2(tan.current.x, -tan.current.z);
     const headingAhead = Math.atan2(tanAhead.current.x, -tanAhead.current.z);
     let dHeading = headingAhead - heading;
     dHeading = Math.atan2(Math.sin(dHeading), Math.cos(dHeading)); // wrap to [-π, π]
-    const targetRoll = clamp(-dHeading * 3.0, -0.45, 0.45);
+    const targetRoll = clamp(-dHeading * 3.5, -0.6, 0.6);
 
-    // Frame-rate-independent smoothing: position, look target, and bank all ease.
+    // Frame-rate-independent smoothing for position, look target, and bank.
     const a = 1 - Math.exp(-3.5 * delta);
     if (!ready.current) {
       state.camera.position.copy(pos.current);
+      prev.current.copy(pos.current);
       look.current.copy(desiredLook.current);
       roll.current = targetRoll;
       ready.current = true;
@@ -48,8 +52,20 @@ export function CameraRig() {
       roll.current += (targetRoll - roll.current) * a;
     }
 
-    // Idle sway, independent of scroll, so paused frames still breathe.
-    const sway = Math.sin(state.clock.elapsedTime * 0.35) * 0.02;
+    // Speed → FOV: widen when flying fast for a sense of rush, settle when idle.
+    const speed = state.camera.position.distanceTo(prev.current) / Math.max(delta, 1e-3);
+    prev.current.copy(state.camera.position);
+    const targetFov = BASE_FOV + clamp(speed * 0.35, 0, 12);
+    fov.current += (targetFov - fov.current) * (1 - Math.exp(-4 * delta));
+    const cam = state.camera as PerspectiveCamera;
+    if (cam.isPerspectiveCamera) {
+      cam.fov = fov.current;
+      cam.updateProjectionMatrix();
+    }
+
+    // Idle sway (scroll-independent), two frequencies for organic drift.
+    const time = state.clock.elapsedTime;
+    const sway = Math.sin(time * 0.35) * 0.02 + Math.sin(time * 0.13) * 0.025;
 
     state.camera.up.set(0, 1, 0);
     state.camera.lookAt(look.current);

--- a/components/CameraRig.tsx
+++ b/components/CameraRig.tsx
@@ -2,13 +2,16 @@
 import { useRef } from "react";
 import { useFrame } from "@react-three/fiber";
 import { Vector3, type PerspectiveCamera } from "three";
-import { curve } from "@/lib/spline";
+import { curve, SCENE_COUNT } from "@/lib/spline";
 import { useScrollStore } from "@/lib/scrollStore";
 
 const clamp01 = (v: number) => Math.min(1, Math.max(0, v));
 const clamp = (v: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, v));
 
 const BASE_FOV = 62;
+const TWO_PI = Math.PI * 2;
+// How strongly the camera dwells at scenes and accelerates between them (0 = uniform).
+const WHIP = 0.7;
 
 export function CameraRig() {
   const look = useRef(new Vector3(0, 0, -1));
@@ -24,12 +27,18 @@ export function CameraRig() {
   useFrame((state, delta) => {
     // Read t via getState() (not a selector) so the rig never re-renders on scroll.
     const t = clamp01(useScrollStore.getState().t);
-    curve.getPointAt(t, pos.current);
-    curve.getTangentAt(t, tan.current);
-    curve.getTangentAt(clamp01(t + 0.02), tanAhead.current);
 
-    // Look a little ahead along the path.
-    desiredLook.current.copy(pos.current).addScaledVector(tan.current, 14);
+    // Dwell at each scene, whip between them: remap scroll -> path parameter so a
+    // constant scroll speed yields a rhythmic slow-fast-slow ride. u == t at every scene
+    // center and boundary (sin term is 0 there), so scene placement/mounting stay aligned.
+    const u = clamp01(t + (WHIP / (TWO_PI * SCENE_COUNT)) * Math.sin(TWO_PI * SCENE_COUNT * t));
+
+    curve.getPointAt(u, pos.current);
+    curve.getTangentAt(u, tan.current);
+    curve.getTangentAt(clamp01(u + 0.02), tanAhead.current);
+
+    // Look ahead along the path so the camera leads into turns.
+    desiredLook.current.copy(pos.current).addScaledVector(tan.current, 16);
 
     // Bank into horizontal turns: roll toward the inside of the curve.
     const heading = Math.atan2(tan.current.x, -tan.current.z);
@@ -39,7 +48,7 @@ export function CameraRig() {
     const targetRoll = clamp(-dHeading * 3.5, -0.6, 0.6);
 
     // Frame-rate-independent smoothing for position, look target, and bank.
-    const a = 1 - Math.exp(-3.5 * delta);
+    const a = 1 - Math.exp(-4 * delta);
     if (!ready.current) {
       state.camera.position.copy(pos.current);
       prev.current.copy(pos.current);
@@ -52,10 +61,10 @@ export function CameraRig() {
       roll.current += (targetRoll - roll.current) * a;
     }
 
-    // Speed → FOV: widen when flying fast for a sense of rush, settle when idle.
+    // Speed → FOV: widens during whips between scenes, settles at each scene.
     const speed = state.camera.position.distanceTo(prev.current) / Math.max(delta, 1e-3);
     prev.current.copy(state.camera.position);
-    const targetFov = BASE_FOV + clamp(speed * 0.35, 0, 12);
+    const targetFov = BASE_FOV + clamp(speed * 0.35, 0, 14);
     fov.current += (targetFov - fov.current) * (1 - Math.exp(-4 * delta));
     const cam = state.camera as PerspectiveCamera;
     if (cam.isPerspectiveCamera) {
@@ -63,13 +72,15 @@ export function CameraRig() {
       cam.updateProjectionMatrix();
     }
 
-    // Idle sway (scroll-independent), two frequencies for organic drift.
+    // Idle sway (scroll-independent) + a gentle corkscrew that peaks mid-transition and is
+    // flat at each scene, so whips feel kinetic without disorienting at the dwell points.
     const time = state.clock.elapsedTime;
     const sway = Math.sin(time * 0.35) * 0.02 + Math.sin(time * 0.13) * 0.025;
+    const corkscrew = Math.sin(u * TWO_PI * SCENE_COUNT) * 0.1;
 
     state.camera.up.set(0, 1, 0);
     state.camera.lookAt(look.current);
-    state.camera.rotateZ(roll.current + sway);
+    state.camera.rotateZ(roll.current + sway + corkscrew);
   });
 
   return null;

--- a/components/Canvas3D.tsx
+++ b/components/Canvas3D.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { Canvas } from "@react-three/fiber";
+import { Stars, Sparkles } from "@react-three/drei";
 import { CameraRig } from "./CameraRig";
 import { SceneManager } from "./SceneManager";
 import { PerfHUD } from "./PerfHUD";
@@ -12,12 +13,27 @@ export function Canvas3D() {
         frameloop="always"
         dpr={[1, 2]}
         gl={{ antialias: true, powerPreference: "high-performance" }}
-        camera={{ fov: 60, near: 0.1, far: 1000, position: [0, 0, 5] }}
+        camera={{ fov: 62, near: 0.1, far: 1000, position: [0, 0, 5] }}
       >
         <color attach="background" args={["#05060a"]} />
-        <fog attach="fog" args={["#05060a", 25, 140]} />
+        <fog attach="fog" args={["#05060a", 60, 400]} />
         <ambientLight intensity={0.4} />
         <directionalLight position={[10, 20, 10]} intensity={1.2} />
+
+        {/* Ambient depth + motion so the flight never reads as an empty void. Distant
+            starfield for parallax + near light-motes that stream past for a speed cue.
+            Both animate on their own, independent of scroll. */}
+        <Stars radius={300} depth={120} count={3500} factor={4} saturation={0} fade speed={0.6} />
+        <Sparkles
+          count={260}
+          scale={[170, 90, 360]}
+          position={[0, 0, -150]}
+          size={3}
+          speed={0.5}
+          opacity={0.7}
+          color="#8fd4ff"
+        />
+
         <CameraRig />
         <SceneManager />
         <PerfHUD />

--- a/components/Canvas3D.tsx
+++ b/components/Canvas3D.tsx
@@ -4,9 +4,17 @@ import { Stars, Sparkles } from "@react-three/drei";
 import { CameraRig } from "./CameraRig";
 import { SceneManager } from "./SceneManager";
 import { PerfHUD } from "./PerfHUD";
+import { useScrollStore } from "@/lib/scrollStore";
 
 // The single persistent Canvas for the entire site. Mounted once; scenes never remount it.
 export function Canvas3D() {
+  // Scale ambient decoration by GPU tier and honor reduced motion.
+  const lowTier = useScrollStore((s) => s.quality === "low");
+  const reducedMotion = useScrollStore((s) => s.reducedMotion);
+  const starCount = lowTier ? 1200 : 3500;
+  const sparkleCount = lowTier || reducedMotion ? 120 : 260;
+  const motion = reducedMotion ? 0 : 1;
+
   return (
     <div className="fixed inset-0">
       <Canvas
@@ -21,15 +29,15 @@ export function Canvas3D() {
         <directionalLight position={[10, 20, 10]} intensity={1.2} />
 
         {/* Ambient depth + motion so the flight never reads as an empty void. Distant
-            starfield for parallax + near light-motes that stream past for a speed cue.
-            Both animate on their own, independent of scroll. */}
-        <Stars radius={300} depth={120} count={3500} factor={4} saturation={0} fade speed={0.6} />
+            starfield for parallax (radius exceeds the spline's far end so it never empties)
+            + near light-motes that stream past for a speed cue. */}
+        <Stars radius={360} depth={120} count={starCount} factor={4} saturation={0} fade speed={0.6 * motion} />
         <Sparkles
-          count={260}
+          count={sparkleCount}
           scale={[170, 90, 360]}
           position={[0, 0, -150]}
           size={3}
-          speed={0.5}
+          speed={0.5 * motion}
           opacity={0.7}
           color="#8fd4ff"
         />

--- a/components/SceneManager.tsx
+++ b/components/SceneManager.tsx
@@ -24,7 +24,7 @@ export function SceneManager() {
             {Component ? (
               <Component />
             ) : (
-              <PlaceholderScene label={scene.label} position={[p.x, p.y, p.z]} />
+              <PlaceholderScene label={scene.label} position={[p.x, p.y, p.z]} index={i} />
             )}
           </SceneShell>
         );

--- a/components/ui/ScrollProxy.tsx
+++ b/components/ui/ScrollProxy.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useEffect } from "react";
 import { ReactLenis, useLenis } from "lenis/react";
 import { useScrollStore } from "@/lib/scrollStore";
 import { SCENE_COUNT } from "@/lib/spline";
@@ -13,8 +14,21 @@ function TWriter() {
 }
 
 export function ScrollProxy() {
+  const reducedMotion = useScrollStore((s) => s.reducedMotion);
+  const setReducedMotion = useScrollStore((s) => s.setReducedMotion);
+
+  // Honor the OS "reduce motion" setting: it drives the store flag that CameraRig and the
+  // ambient decorations read, and it makes Lenis scroll instant (no smoothing).
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const apply = () => setReducedMotion(mq.matches);
+    apply();
+    mq.addEventListener("change", apply);
+    return () => mq.removeEventListener("change", apply);
+  }, [setReducedMotion]);
+
   return (
-    <ReactLenis root options={{ lerp: 0.1, smoothWheel: true }}>
+    <ReactLenis root options={{ lerp: reducedMotion ? 1 : 0.1, smoothWheel: !reducedMotion }}>
       {/* Tall empty spacer provides the scroll range that maps to t ∈ [0,1]. */}
       <div style={{ height: `${SCENE_COUNT * 100}vh` }} aria-hidden />
       <TWriter />

--- a/lib/spline.ts
+++ b/lib/spline.ts
@@ -3,14 +3,14 @@ import { CatmullRomCurve3, Vector3 } from "three";
 /** Number of scene regions laid along the spline. */
 export const SCENE_COUNT = 11;
 
-// A sculpted 3D flight path: sweeping left/right turns plus elevation changes, so the
-// camera banks and re-frames continuously instead of flying straight down a tunnel. The
-// same curve drives both the camera (CameraRig) and scene placement (SceneManager), so
-// scenes always sit along the flight path and the camera flies through each region.
+// A bold, varied 3D flight path: steep dives and climbs plus sharp lateral sweeps, so the
+// camera pitches and banks dramatically instead of gliding straight. Higher-frequency
+// terms keep no two segments feeling the same. The same curve drives both the camera and
+// scene placement, so scenes always sit on the flight path.
 const points: Vector3[] = Array.from({ length: SCENE_COUNT + 2 }, (_, i) => {
-  const z = -i * 24;
-  const x = Math.sin(i * 0.8) * 18 + Math.cos(i * 1.7) * 6;
-  const y = Math.sin(i * 0.55 + 0.4) * 11;
+  const z = -i * 26;
+  const x = Math.sin(i * 0.9) * 22 + Math.sin(i * 2.1) * 7;
+  const y = Math.sin(i * 0.65 + 0.5) * 15 + Math.cos(i * 1.5) * 5;
   return new Vector3(x, y, z);
 });
 

--- a/scenes/PlaceholderScene.tsx
+++ b/scenes/PlaceholderScene.tsx
@@ -3,6 +3,7 @@ import { useMemo, useRef } from "react";
 import { useFrame } from "@react-three/fiber";
 import { Text } from "@react-three/drei";
 import { Color, type Mesh } from "three";
+import { SCENE_COUNT } from "@/lib/spline";
 
 // TODO(asset): replace with the real scene geometry / GLTF. Deliberately a labeled
 // wireframe cage + glowing core so it reads as an obvious placeholder, but each region
@@ -21,7 +22,7 @@ export function PlaceholderScene({
 
   // Hue sweeps across the journey so each region is visually distinct.
   const color = useMemo(
-    () => new Color().setHSL((index / 11) * 0.75 + 0.05, 0.7, 0.6),
+    () => new Color().setHSL((index / SCENE_COUNT) * 0.75 + 0.05, 0.7, 0.6),
     [index],
   );
 

--- a/scenes/PlaceholderScene.tsx
+++ b/scenes/PlaceholderScene.tsx
@@ -1,30 +1,56 @@
 "use client";
-import { useRef } from "react";
+import { useMemo, useRef } from "react";
 import { useFrame } from "@react-three/fiber";
 import { Text } from "@react-three/drei";
-import type { Mesh } from "three";
+import { Color, type Mesh } from "three";
 
 // TODO(asset): replace with the real scene geometry / GLTF. Deliberately a labeled
-// wireframe so it can never be mistaken for finished art.
+// wireframe cage + glowing core so it reads as an obvious placeholder, but each region
+// gets its own hue and idle life so the journey is varied instead of identical boxes.
 export function PlaceholderScene({
   label,
   position,
+  index,
 }: {
   label: string;
   position: [number, number, number];
+  index: number;
 }) {
-  const ref = useRef<Mesh>(null);
+  const cage = useRef<Mesh>(null);
+  const core = useRef<Mesh>(null);
+
+  // Hue sweeps across the journey so each region is visually distinct.
+  const color = useMemo(
+    () => new Color().setHSL((index / 11) * 0.75 + 0.05, 0.7, 0.6),
+    [index],
+  );
 
   // Idle motion, independent of scroll, so a scene still feels alive when paused.
-  useFrame((_, delta) => {
-    if (ref.current) ref.current.rotation.y += delta * 0.3;
+  useFrame((state, delta) => {
+    if (cage.current) cage.current.rotation.y += delta * 0.2;
+    if (core.current) {
+      core.current.rotation.x += delta * 0.5;
+      core.current.rotation.y -= delta * 0.35;
+      const s = 1 + Math.sin(state.clock.elapsedTime * 1.4 + index) * 0.15;
+      core.current.scale.setScalar(s);
+    }
   });
 
   return (
     <group position={position}>
-      <mesh ref={ref}>
+      <mesh ref={cage}>
         <boxGeometry args={[6, 6, 6]} />
-        <meshBasicMaterial wireframe color="#38bdf8" />
+        <meshBasicMaterial wireframe color={color} />
+      </mesh>
+      <mesh ref={core}>
+        <icosahedronGeometry args={[1.5, 0]} />
+        <meshStandardMaterial
+          color={color}
+          emissive={color}
+          emissiveIntensity={0.7}
+          roughness={0.35}
+          metalness={0.4}
+        />
       </mesh>
       <Text
         position={[0, 4.6, 0]}


### PR DESCRIPTION
Makes the scroll flight feel alive and dynamic (was a uniform glide through an empty void), and wires accessibility.

## Liveliness
- drei `Stars` (parallax backdrop, radius exceeds the spline end) + `Sparkles` (near motes) for depth and a speed cue.
- Placeholders: per-scene hue sweep + a glowing, pulsing icosahedron core spinning in the wireframe cage — each region is distinct and alive.

## Dynamic camera movement
- **Dwell/whip**: scroll→path remap so the camera lingers at each scene and accelerates between them (rhythmic slow-fast-slow). `u == t` at scene centers/boundaries, so mounting/placement stay aligned; `WHIP < 1` keeps `u` monotonic.
- **Bolder spline** (steeper dives/climbs, sharper turns), banking into turns, a corkscrew that peaks mid-transition, and a speed→FOV kick.

## Accessibility (prefers-reduced-motion)
- `matchMedia` → store; CameraRig damps bank and kills corkscrew/sway/FOV pulse; Canvas3D drops motes + drift; Lenis scroll goes instant. (The store flag was previously dead code.)
- Ambient decoration counts also gate on the GPU quality tier.

## Review gate
Passed the pre-PR gate: **security review clean**; **grumpy reviewer** verdict FIX-FIRST → all findings addressed (reduced-motion wiring, `SCENE_COUNT` hue, Stars radius, `updateProjectionMatrix` guard, `instanceof` narrowing, `WHIP<1` invariant doc, named consts, quality-gated decorations). `tsc` strict clean; verified in-browser (no console errors, healthy WebGL context).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
