### PR TITLE
Phase 1 foundation: position + orient scenes on the spline

### DIFF
--- a/components/SceneManager.tsx
+++ b/components/SceneManager.tsx
@@ -1,9 +1,35 @@
 "use client";
+import { Quaternion, Vector3 } from "three";
 import { useScrollStore } from "@/lib/scrollStore";
 import { scenes } from "@/scenes/registry";
 import { SceneShell } from "@/scenes/_SceneShell";
 import { PlaceholderScene } from "@/scenes/PlaceholderScene";
 import { curve } from "@/lib/spline";
+
+// Static per-scene placement on the spline, computed once (the curve never changes). Each
+// scene sits at its region's center point, yaw-oriented so its local -Z faces the flight
+// direction — real scenes are then authored in a level local frame (camera flies in along
+// -Z, +Y is world up). Yaw-only (tangent flattened to XZ) keeps scenes upright: a desk must
+// not tilt with the path's pitch. This runs once at module load, never per frame.
+const FORWARD = new Vector3(0, 0, -1);
+const sceneItems = scenes.map((scene, index) => {
+  const centerT = (scene.range[0] + scene.range[1]) / 2;
+  const p = curve.getPointAt(centerT);
+  const tan = curve.getTangentAt(centerT);
+  const flat = new Vector3(tan.x, 0, tan.z);
+  // ponytail: spline z strictly decreases so |flat| is never ~0; fall back to identity if a
+  // future curve ever makes the tangent purely vertical.
+  const q =
+    flat.lengthSq() < 1e-8
+      ? new Quaternion()
+      : new Quaternion().setFromUnitVectors(FORWARD, flat.normalize());
+  return {
+    scene,
+    index,
+    position: [p.x, p.y, p.z] as [number, number, number],
+    quaternion: [q.x, q.y, q.z, q.w] as [number, number, number, number],
+  };
+});
 
 export function SceneManager() {
   // Subscribe to activeIndex only — it changes on boundary crossings, not every frame.
@@ -11,20 +37,18 @@ export function SceneManager() {
 
   return (
     <>
-      {scenes.map((scene, i) => {
+      {sceneItems.map(({ scene, index, position, quaternion }) => {
         // Only current ± 1 scene is ever mounted — the biggest performance lever.
-        if (Math.abs(i - active) > 1) return null;
+        if (Math.abs(index - active) > 1) return null;
 
-        const centerT = (scene.range[0] + scene.range[1]) / 2;
-        const p = curve.getPointAt(centerT);
         const Component = scene.Component;
 
         return (
-          <SceneShell key={scene.id}>
+          <SceneShell key={scene.id} position={position} quaternion={quaternion}>
             {Component ? (
-              <Component />
+              <Component index={index} />
             ) : (
-              <PlaceholderScene label={scene.label} position={[p.x, p.y, p.z]} index={i} />
+              <PlaceholderScene label={scene.label} index={index} />
             )}
           </SceneShell>
         );

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,10 @@ import nextTs from "eslint-config-next/typescript";
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
+  // eslint-config-next 16 bundles eslint-plugin-react 7.37, whose React-version
+  // auto-detection calls context.getFilename() — removed in ESLint 10, so "detect" crashes
+  // every React file. Pinning the version skips detection (the broken path) entirely.
+  { settings: { react: { version: "19.2" } } },
   // Override default ignores of eslint-config-next.
   globalIgnores([
     // Default ignores of eslint-config-next:

--- a/scenes/PlaceholderScene.tsx
+++ b/scenes/PlaceholderScene.tsx
@@ -4,17 +4,16 @@ import { useFrame } from "@react-three/fiber";
 import { Text } from "@react-three/drei";
 import { Color, type Mesh } from "three";
 import { SCENE_COUNT } from "@/lib/spline";
+import { useScrollStore } from "@/lib/scrollStore";
 
 // TODO(asset): replace with the real scene geometry / GLTF. Deliberately a labeled
 // wireframe cage + glowing core so it reads as an obvious placeholder, but each region
 // gets its own hue and idle life so the journey is varied instead of identical boxes.
 export function PlaceholderScene({
   label,
-  position,
   index,
 }: {
   label: string;
-  position: [number, number, number];
   index: number;
 }) {
   const cage = useRef<Mesh>(null);
@@ -28,6 +27,8 @@ export function PlaceholderScene({
 
   // Idle motion, independent of scroll, so a scene still feels alive when paused.
   useFrame((state, delta) => {
+    // Honor prefers-reduced-motion: no autonomous idle spin/pulse when the user opts out.
+    if (useScrollStore.getState().reducedMotion) return;
     if (cage.current) cage.current.rotation.y += delta * 0.2;
     if (core.current) {
       core.current.rotation.x += delta * 0.5;
@@ -38,7 +39,7 @@ export function PlaceholderScene({
   });
 
   return (
-    <group position={position}>
+    <>
       <mesh ref={cage}>
         <boxGeometry args={[6, 6, 6]} />
         <meshBasicMaterial wireframe color={color} />
@@ -64,6 +65,6 @@ export function PlaceholderScene({
       >
         {label}
       </Text>
-    </group>
+    </>
   );
 }

--- a/scenes/_SceneShell.tsx
+++ b/scenes/_SceneShell.tsx
@@ -1,12 +1,26 @@
 "use client";
 import type { ReactNode } from "react";
 
-// Shared wrapper for every scene. When this group unmounts, react-three-fiber
-// automatically disposes the geometries/materials of the JSX meshes inside it, so a
-// distant scene frees its GPU memory for free — the core of the "only current ±1 live"
-// budget lever.
+// Shared wrapper for every scene. Positions + orients the scene's local frame on the spline
+// (transform computed once in SceneManager) so real scenes are authored in local space: the
+// camera flies in along local -Z, +Y is world up, origin is the scene's spline center.
+// When this group unmounts, react-three-fiber automatically disposes the geometries/materials
+// of the JSX meshes inside it, so a distant scene frees its GPU memory for free — the core of
+// the "only current ±1 live" budget lever.
 // ponytail: no manual dispose loop here until a scene owns resources R3F can't track
 // (imperative textures / render targets) — dispose those in a useEffect cleanup.
-export function SceneShell({ children }: { children: ReactNode }) {
-  return <group>{children}</group>;
+export function SceneShell({
+  position,
+  quaternion,
+  children,
+}: {
+  position: [number, number, number];
+  quaternion: [number, number, number, number];
+  children: ReactNode;
+}) {
+  return (
+    <group position={position} quaternion={quaternion}>
+      {children}
+    </group>
+  );
 }

--- a/scenes/registry.ts
+++ b/scenes/registry.ts
@@ -1,5 +1,11 @@
 import type { FC } from "react";
 
+/** Props every real scene Component receives from the SceneManager. */
+export interface SceneComponentProps {
+  /** Registry index of this scene (0-based). */
+  index: number;
+}
+
 /** The contract every scene implements (spec §3). */
 export interface SceneDef {
   id: string;
@@ -8,8 +14,13 @@ export interface SceneDef {
   range: [number, number];
   /** Extra t-margin to mount early. */
   preload?: number;
-  /** Real scene component; when absent, a labeled placeholder is rendered (Phase 0). */
-  Component?: FC;
+  /** Real scene component; when absent, a labeled placeholder is rendered (Phase 0).
+   *  Authored in a local frame placed on the spline by SceneShell: camera flies in along
+   *  local -Z, +Y is world up, origin is the scene's spline center. Note the camera passes
+   *  THROUGH the origin (a fly-through, not a framed tableau) entering from the +Z side, so
+   *  arrange content around the approach rather than piling it at the origin; and its view
+   *  can pitch up to ~±24° relative to this level frame, since orientation is yaw-only. */
+  Component?: FC<SceneComponentProps>;
 }
 
 // TODO(asset): each scene gets a real Component in later phases. Phase 0 renders every


### PR DESCRIPTION
## What & why

Phase 1 enabling refactor. Real scenes need to sit on the flight path and face the incoming camera — until now only the wireframe placeholder was positioned, and a real `<Component/>` would render at the world origin. This makes **`SceneShell` own each scene's placement**, so every real scene (starting with `01-outside`) is authored in one clean local frame.

## Changes

- **`SceneManager`** precomputes, once at module load (never per-frame), each scene's world **position** (`curve.getPointAt(centerT)`) + a **yaw-only quaternion** (`setFromUnitVectors((0,0,-1), flattenedTangent)`) so scenes face the horizontal flight direction while staying **upright** — a desk must not tilt with the path's pitch.
- **`SceneShell`** applies `position` + `quaternion` to its group. Authoring frame: **camera flies in along local −Z, +Y world up, origin = spline center**. It's a *fly-through* (camera passes through the origin), not a framed tableau, and the view can pitch up to ~±24° relative to the level frame.
- **`registry`**: `Component` is now `FC<SceneComponentProps>` (receives `index`); the authoring contract lives on the type doc.
- **`PlaceholderScene`** renders at local origin, drops its now-redundant identity `<group>`, and **gates its idle spin/pulse on `reducedMotion`** (a11y invariant that was previously ungated).
- **`eslint.config.mjs`**: fixes `npm run lint`, which was crashing **repo-wide** — `eslint-config-next@16` bundles `eslint-plugin-react@7.37`, whose React-version auto-detection calls `context.getFilename()` (removed in ESLint 10). Pinning `react.version` skips the broken detection path **without disabling any rule**.

## Invariants held

One persistent Canvas · mount budget ±1 unchanged · `u==t` alignment untouched (placement uses `centerT`) · no per-frame allocations (all `new` at module load) · reducedMotion respected · derives from `SCENE_COUNT`/registry, no hardcoded 11.

## Review gate

- **grumpy-reviewer**: SHIP-WITH-NITS, no P0/P1. Numerically verified the orientation is upright (dot=1.0) with −Z→tangent error ~1e-16 at all 11 centers; confirmed not-per-frame. The 3 actionable nits (reduced-motion gating, fly-through doc, redundant group) are applied.
- **security-reviewer**: clean — client-only, no untrusted input surface.
- **qa-verifier**: `tsc` 0 errors, `lint` clean, `next build` succeeds.
- **Browser smoke**: scenes place + orient correctly (level), mount budget holds across scroll transitions, **480 FPS**, no console errors (one upstream `THREE.Clock` deprecation warning only).

## Deferred (pre-existing, out of scope)

`registry` derives `range` from `NAMES.length` while `scrollStore` derives `activeIndex` from `SCENE_COUNT`; both are 11 today. Noted for when scenes get uneven ranges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scenes now follow the path more accurately, with consistent placement and upright orientation as the experience moves forward.
  * Scene rendering now focuses on the active scene and nearby neighbors, helping keep the experience smoother.

* **Bug Fixes**
  * Placeholder scenes now respect reduced-motion settings and stop their idle animation when motion is disabled.
  * Scene loading now handles both real scenes and placeholders more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->