### PR TITLE
Phase 1 · Scene 01 OUTSIDE — "The One Warm Window" (hero scene)

### DIFF
--- a/components/Canvas3D.tsx
+++ b/components/Canvas3D.tsx
@@ -1,6 +1,9 @@
 "use client";
+import { useMemo } from "react";
 import { Canvas } from "@react-three/fiber";
 import { Stars, Sparkles } from "@react-three/drei";
+import { EffectComposer, Bloom, Vignette, ChromaticAberration } from "@react-three/postprocessing";
+import { Vector2 } from "three";
 import { CameraRig } from "./CameraRig";
 import { SceneManager } from "./SceneManager";
 import { PerfHUD } from "./PerfHUD";
@@ -14,13 +17,17 @@ export function Canvas3D() {
   const starCount = lowTier ? 1200 : 3500;
   const sparkleCount = lowTier || reducedMotion ? 120 : 260;
   const motion = reducedMotion ? 0 : 1;
+  // Wet-lens chromatic split; memoized so the Vector2 isn't reallocated each render.
+  const caOffset = useMemo(() => new Vector2(0.0006, 0.0006), []);
 
   return (
     <div className="fixed inset-0">
       <Canvas
         frameloop="always"
-        dpr={[1, 2]}
-        gl={{ antialias: true, powerPreference: "high-performance" }}
+        // The EffectComposer owns the render target + AA (its `multisampling`), so context MSAA
+        // never reaches the composited image — disable it and don't pay for an unused MSAA buffer.
+        dpr={lowTier ? [1, 1.5] : [1, 2]}
+        gl={{ antialias: false, powerPreference: "high-performance" }}
         camera={{ fov: 62, near: 0.1, far: 1000, position: [0, 0, 5] }}
       >
         <color attach="background" args={["#05060a"]} />
@@ -45,6 +52,15 @@ export function Canvas3D() {
         <CameraRig />
         <SceneManager />
         <PerfHUD />
+
+        {/* Selective bloom is the scene's whole look — only emissives above threshold (the one
+            warm window, cyan accents) flare; the matte city + rain stay crisp. Global pass, so
+            it also gently lifts the placeholder scenes' emissive cores. Cheaper on low tier. */}
+        <EffectComposer multisampling={lowTier ? 0 : 4}>
+          <Bloom luminanceThreshold={0.6} intensity={lowTier ? 0.45 : 0.7} radius={0.6} mipmapBlur />
+          <Vignette offset={0.28} darkness={0.7} />
+          <ChromaticAberration offset={caOffset} />
+        </EffectComposer>
       </Canvas>
     </div>
   );

--- a/components/SceneManager.tsx
+++ b/components/SceneManager.tsx
@@ -1,10 +1,19 @@
 "use client";
+import type { FC } from "react";
 import { Quaternion, Vector3 } from "three";
 import { useScrollStore } from "@/lib/scrollStore";
-import { scenes } from "@/scenes/registry";
+import { scenes, type SceneComponentProps } from "@/scenes/registry";
 import { SceneShell } from "@/scenes/_SceneShell";
 import { PlaceholderScene } from "@/scenes/PlaceholderScene";
+import { OutsideScene } from "@/scenes/01-outside/OutsideScene";
 import { curve } from "@/lib/spline";
+
+// Real scene Components wired by registry id. Kept here — inside the Canvas-only, dynamically
+// imported (ssr:false) subtree — so the 3D bundle stays lazy and never leaks into label-only
+// consumers of the registry (e.g. UIOverlay). Regions with no entry render a placeholder.
+const SCENE_COMPONENTS: Partial<Record<string, FC<SceneComponentProps>>> = {
+  "01-outside": OutsideScene,
+};
 
 // Static per-scene placement on the spline, computed once (the curve never changes). Each
 // scene sits at its region's center point, yaw-oriented so its local -Z faces the flight
@@ -41,7 +50,7 @@ export function SceneManager() {
         // Only current ± 1 scene is ever mounted — the biggest performance lever.
         if (Math.abs(index - active) > 1) return null;
 
-        const Component = scene.Component;
+        const Component = SCENE_COMPONENTS[scene.id];
 
         return (
           <SceneShell key={scene.id} position={position} quaternion={quaternion}>

--- a/scenes/01-outside/CityInstances.tsx
+++ b/scenes/01-outside/CityInstances.tsx
@@ -1,0 +1,176 @@
+"use client";
+import { useLayoutEffect, useMemo, useRef } from "react";
+import {
+  Color,
+  DoubleSide,
+  InstancedBufferAttribute,
+  InstancedMesh,
+  Matrix4,
+  Quaternion,
+  ShaderMaterial,
+  UniformsLib,
+  UniformsUtils,
+  Vector3,
+} from "three";
+import { COLOR, COUNT, LAYOUT, mulberry32, pick } from "./config";
+import { TOWER_VERT, TOWER_FRAG } from "./shaders";
+import { useUniformClock } from "./useSceneClock";
+import type { QualityTier } from "@/lib/scrollStore";
+
+// The whole megacity is 3 InstancedMeshes (towers · rooftop aerials · cyan signage) — one draw
+// call each, thousands of lit windows baked into the tower fragment shader. Layouts are built
+// once from a fixed seed (see mulberry32) so the skyline never reshuffles on remount.
+
+function Towers({ count }: { count: number }) {
+  const ref = useRef<InstancedMesh>(null);
+  const matRef = useRef<ShaderMaterial>(null);
+  useUniformClock(matRef);
+
+  const { matrixArray, seeds, lits } = useMemo(() => {
+    const rnd = mulberry32(1337);
+    const m = new Matrix4();
+    const pos = new Vector3();
+    const quat = new Quaternion();
+    const scl = new Vector3();
+    const up = new Vector3(0, 1, 0);
+    const { minX, maxX, zFront, zBack } = LAYOUT.corridor;
+    const matrixArray = new Float32Array(count * 16);
+    const seeds = new Float32Array(count);
+    const lits = new Float32Array(count);
+    for (let i = 0; i < count; i++) {
+      const side = rnd() < 0.5 ? -1 : 1;
+      const x = side * (minX + rnd() * (maxX - minX));
+      const z = zFront + rnd() * (zBack - zFront);
+      const h = 18 + rnd() * 72;
+      pos.set(x, LAYOUT.street.y + h / 2, z);
+      quat.setFromAxisAngle(up, (rnd() - 0.5) * 0.4);
+      scl.set(6 + rnd() * 10, h, 6 + rnd() * 10);
+      m.compose(pos, quat, scl);
+      m.toArray(matrixArray, i * 16);
+      seeds[i] = rnd() * 100;
+      lits[i] = rnd() < 0.85 ? 1 : 0; // a few towers go fully dark
+    }
+    return { matrixArray, seeds, lits };
+  }, [count]);
+
+  useLayoutEffect(() => {
+    const mesh = ref.current;
+    if (!mesh) return;
+    mesh.instanceMatrix.array.set(matrixArray);
+    mesh.instanceMatrix.needsUpdate = true;
+    mesh.geometry.setAttribute("aSeed", new InstancedBufferAttribute(seeds, 1));
+    mesh.geometry.setAttribute("aLit", new InstancedBufferAttribute(lits, 1));
+  }, [matrixArray, seeds, lits]);
+
+  const uniforms = useMemo(
+    () => ({
+      ...UniformsUtils.clone(UniformsLib.fog),
+      uTime: { value: 0 },
+      uBody: { value: new Color(COLOR.towerBody) },
+      uEdge: { value: new Color(COLOR.edge) },
+      uWindowDim: { value: new Color(COLOR.windowDim) },
+      uCyan: { value: new Color(COLOR.cyan) },
+      uThreshold: { value: 0.62 },
+    }),
+    [],
+  );
+
+  return (
+    <instancedMesh ref={ref} args={[undefined, undefined, count]} frustumCulled={false}>
+      <boxGeometry args={[1, 1, 1]} />
+      <shaderMaterial ref={matRef} vertexShader={TOWER_VERT} fragmentShader={TOWER_FRAG} uniforms={uniforms} fog />
+    </instancedMesh>
+  );
+}
+
+function Aerials({ count }: { count: number }) {
+  const ref = useRef<InstancedMesh>(null);
+  const matrixArray = useMemo(() => {
+    const rnd = mulberry32(90210);
+    const m = new Matrix4();
+    const pos = new Vector3();
+    const quat = new Quaternion();
+    const scl = new Vector3();
+    const arr = new Float32Array(count * 16);
+    const { minX, maxX, zFront, zBack } = LAYOUT.corridor;
+    for (let i = 0; i < count; i++) {
+      const side = rnd() < 0.5 ? -1 : 1;
+      const x = side * (minX + rnd() * (maxX - minX));
+      const z = zFront + rnd() * (zBack - zFront);
+      const top = LAYOUT.street.y + 18 + rnd() * 72;
+      pos.set(x, top + 3, z);
+      scl.set(0.3, 3 + rnd() * 5, 0.3);
+      m.compose(pos, quat, scl);
+      m.toArray(arr, i * 16);
+    }
+    return arr;
+  }, [count]);
+
+  useLayoutEffect(() => {
+    const mesh = ref.current;
+    if (!mesh) return;
+    mesh.instanceMatrix.array.set(matrixArray);
+    mesh.instanceMatrix.needsUpdate = true;
+  }, [matrixArray]);
+
+  if (count === 0) return null;
+  return (
+    <instancedMesh ref={ref} args={[undefined, undefined, count]} frustumCulled={false}>
+      <boxGeometry args={[1, 1, 1]} />
+      <meshBasicMaterial color={COLOR.towerBody} fog />
+    </instancedMesh>
+  );
+}
+
+function Signage({ count }: { count: number }) {
+  const ref = useRef<InstancedMesh>(null);
+  const matrixArray = useMemo(() => {
+    const rnd = mulberry32(4242);
+    const m = new Matrix4();
+    const pos = new Vector3();
+    const quat = new Quaternion();
+    const scl = new Vector3();
+    const up = new Vector3(0, 1, 0);
+    const arr = new Float32Array(count * 16);
+    const { minX, zFront, zBack } = LAYOUT.corridor;
+    for (let i = 0; i < count; i++) {
+      const side = rnd() < 0.5 ? -1 : 1;
+      pos.set(
+        side * (minX * 0.92),
+        LAYOUT.street.y + 8 + rnd() * 34,
+        zFront * 0.6 + rnd() * (zBack * 0.55 - zFront * 0.6),
+      );
+      // face the corridor centre: +Z plane normal -> ∓X
+      quat.setFromAxisAngle(up, side > 0 ? -Math.PI / 2 : Math.PI / 2);
+      scl.set(0.6 + rnd() * 1.4, 0.5 + rnd() * 1.2, 1);
+      m.compose(pos, quat, scl);
+      m.toArray(arr, i * 16);
+    }
+    return arr;
+  }, [count]);
+
+  useLayoutEffect(() => {
+    const mesh = ref.current;
+    if (!mesh) return;
+    mesh.instanceMatrix.array.set(matrixArray);
+    mesh.instanceMatrix.needsUpdate = true;
+  }, [matrixArray]);
+
+  return (
+    // TODO(asset): swap for a neon-sign SDF/MSDF atlas sampled per-instance; procedural cyan for now.
+    <instancedMesh ref={ref} args={[undefined, undefined, count]} frustumCulled={false}>
+      <planeGeometry args={[1, 1]} />
+      <meshBasicMaterial color={COLOR.cyan} toneMapped={false} fog side={DoubleSide} />
+    </instancedMesh>
+  );
+}
+
+export function CityInstances({ quality }: { quality: QualityTier }) {
+  return (
+    <>
+      <Towers count={pick(quality, COUNT.towers)} />
+      <Aerials count={pick(quality, COUNT.aerials)} />
+      <Signage count={pick(quality, COUNT.signage)} />
+    </>
+  );
+}

--- a/scenes/01-outside/Environment.tsx
+++ b/scenes/01-outside/Environment.tsx
@@ -1,0 +1,129 @@
+"use client";
+import { useMemo, useRef } from "react";
+import { AdditiveBlending, BackSide, Color, DoubleSide, ShaderMaterial, UniformsLib, UniformsUtils } from "three";
+import { COLOR, LAYOUT, MOTION } from "./config";
+import {
+  GLASS_FRAG,
+  GLASS_VERT,
+  GLOW_FRAG,
+  GLOW_VERT,
+  SKY_FRAG,
+  SKY_VERT,
+  STREET_FRAG,
+  STREET_VERT,
+} from "./shaders";
+import { useUniformClock } from "./useSceneClock";
+
+// Horizon-glow backdrop dome — renders behind the shared drei Stars; no fog (it IS the sky).
+// TODO(asset): swap the gradient+fbm material for an equirect night-smog HDR onto the same dome.
+export function SkyDome() {
+  const matRef = useRef<ShaderMaterial>(null);
+  useUniformClock(matRef);
+  const uniforms = useMemo(
+    () => ({
+      uTime: { value: 0 },
+      uDrift: { value: MOTION.smogDrift },
+      uZenith: { value: new Color(COLOR.skyZenith) },
+      uHorizon: { value: new Color(COLOR.skyHorizon) },
+    }),
+    [],
+  );
+  return (
+    <mesh renderOrder={-1}>
+      <sphereGeometry args={[LAYOUT.sky.radius, 32, 16]} />
+      <shaderMaterial ref={matRef} vertexShader={SKY_VERT} fragmentShader={SKY_FRAG} uniforms={uniforms} side={BackSide} depthWrite={false} />
+    </mesh>
+  );
+}
+
+// Wet asphalt below the corridor — analytic accent reflections + fresnel sheen, no render pass.
+// TODO(asset): real wet-asphalt normal + roughness maps drop onto this same plane.
+export function WetStreet() {
+  const matRef = useRef<ShaderMaterial>(null);
+  useUniformClock(matRef);
+  const uniforms = useMemo(
+    () => ({
+      ...UniformsUtils.clone(UniformsLib.fog),
+      uTime: { value: 0 },
+      uAsphalt: { value: new Color(COLOR.asphalt) },
+      uCyan: { value: new Color(COLOR.cyan) },
+      uWarm: { value: new Color(COLOR.warm) },
+      uRipple: { value: MOTION.ripple },
+    }),
+    [],
+  );
+  return (
+    <mesh position={[0, LAYOUT.street.y, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+      <planeGeometry args={[LAYOUT.street.size, LAYOUT.street.size]} />
+      <shaderMaterial ref={matRef} vertexShader={STREET_VERT} fragmentShader={STREET_FRAG} uniforms={uniforms} fog />
+    </mesh>
+  );
+}
+
+// The rain-on-glass threshold pane the camera flies THROUGH at scene centre — the outside/
+// inside beat. Fake refraction via procedural rivulets, no screen-space transmission pass.
+// TODO(asset): rain-on-glass normal/roughness photo texture can replace the droplet shader.
+export function GlassPane() {
+  const matRef = useRef<ShaderMaterial>(null);
+  useUniformClock(matRef);
+  const uniforms = useMemo(
+    () => ({
+      uTime: { value: 0 },
+      uRivulet: { value: MOTION.rivulet },
+      uWarm: { value: new Color(COLOR.warm) },
+      uCool: { value: new Color(COLOR.cyan) },
+    }),
+    [],
+  );
+  const [w, h] = LAYOUT.glass.size;
+  const tilt = (LAYOUT.glass.tiltDeg * Math.PI) / 180;
+  return (
+    <mesh position={[0, -6, LAYOUT.glass.z]} rotation={[tilt, 0, 0]}>
+      <planeGeometry args={[w, h]} />
+      <shaderMaterial
+        ref={matRef}
+        vertexShader={GLASS_VERT}
+        fragmentShader={GLASS_FRAG}
+        uniforms={uniforms}
+        transparent
+        depthWrite={false}
+        toneMapped={false}
+        side={DoubleSide}
+      />
+    </mesh>
+  );
+}
+
+// Soft radial additive glow — the window's bloom carrier and the fake-volumetric haze pockets.
+// Static (no clock): it only grows because the scroll-driven camera approaches it.
+export function GlowQuad({
+  color,
+  size,
+  position,
+  opacity = 0.5,
+}: {
+  color: string;
+  size: number;
+  position: [number, number, number];
+  opacity?: number;
+}) {
+  const uniforms = useMemo(
+    () => ({ uColor: { value: new Color(color) }, uOpacity: { value: opacity } }),
+    [color, opacity],
+  );
+  return (
+    <mesh position={position}>
+      <planeGeometry args={[size, size]} />
+      <shaderMaterial
+        vertexShader={GLOW_VERT}
+        fragmentShader={GLOW_FRAG}
+        uniforms={uniforms}
+        transparent
+        depthWrite={false}
+        blending={AdditiveBlending}
+        toneMapped={false}
+        side={DoubleSide}
+      />
+    </mesh>
+  );
+}

--- a/scenes/01-outside/HeroTower.tsx
+++ b/scenes/01-outside/HeroTower.tsx
@@ -1,0 +1,58 @@
+"use client";
+import { useMemo, useRef } from "react";
+import { Color, ShaderMaterial, UniformsLib, UniformsUtils } from "three";
+import { COLOR, LAYOUT } from "./config";
+import { TOWER_VERT, TOWER_FRAG } from "./shaders";
+import { GlowQuad } from "./Environment";
+import { useUniformClock } from "./useSceneClock";
+
+// The developer's building — a near-black monolith the descending camera aims down, carrying
+// the ONE warm window (the desk) that is the sole warm mark and the bloom handoff into DESK.
+export function HeroTower() {
+  const matRef = useRef<ShaderMaterial>(null);
+  useUniformClock(matRef);
+
+  // Reuses the tower shader via its non-instanced (USE_INSTANCING off) branch; aSeed/aLit are
+  // uniforms here. High threshold => almost every window dark, for a lonely late-night facade.
+  const uniforms = useMemo(
+    () => ({
+      ...UniformsUtils.clone(UniformsLib.fog),
+      uTime: { value: 0 },
+      uBody: { value: new Color(COLOR.towerBody) },
+      uEdge: { value: new Color(COLOR.edge) },
+      uWindowDim: { value: new Color(COLOR.windowDim) },
+      uCyan: { value: new Color(COLOR.cyan) },
+      uThreshold: { value: 0.97 },
+      aSeed: { value: 3.0 },
+      aLit: { value: 1.0 },
+    }),
+    [],
+  );
+
+  const [hx, hy, hz] = LAYOUT.hero.pos;
+  const [sx, sy, sz] = LAYOUT.hero.size;
+  const [wx, wy] = LAYOUT.warmWindow.size;
+  const yaw = (LAYOUT.hero.yawDeg * Math.PI) / 180;
+  const faceZ = sz / 2 + 0.05;
+  const winY = sy * 0.16;
+
+  return (
+    <group position={[hx, hy, hz]} rotation={[0, yaw, 0]}>
+      {/* TODO(asset): swap this box for a hero-building GLTF; the warm-window inset + glow stay. */}
+      <mesh scale={[sx, sy, sz]}>
+        <boxGeometry args={[1, 1, 1]} />
+        <shaderMaterial ref={matRef} vertexShader={TOWER_VERT} fragmentShader={TOWER_FRAG} uniforms={uniforms} fog />
+      </mesh>
+
+      {/* THE one warm window — the developer's desk. Bright enough to cross the bloom threshold. */}
+      {/* TODO(asset): can later show a lit-interior card/texture in this same inset slot. */}
+      <mesh position={[2.4, winY, faceZ]}>
+        <planeGeometry args={[wx, wy]} />
+        <meshBasicMaterial color={COLOR.warm} toneMapped={false} />
+      </mesh>
+
+      {/* Warm glow carrier + haze pocket so the window survives fog and blooms on approach. */}
+      <GlowQuad color={COLOR.warm} size={LAYOUT.warmWindow.glow} position={[2.4, winY, faceZ + 0.1]} opacity={0.55} />
+    </group>
+  );
+}

--- a/scenes/01-outside/OutsideScene.tsx
+++ b/scenes/01-outside/OutsideScene.tsx
@@ -1,0 +1,31 @@
+"use client";
+import { useScrollStore } from "@/lib/scrollStore";
+import { COLOR } from "./config";
+import { CityInstances } from "./CityInstances";
+import { Rain } from "./Rain";
+import { HeroTower } from "./HeroTower";
+import { SkyDome, WetStreet, GlassPane, GlowQuad } from "./Environment";
+
+// OUTSIDE — "The One Warm Window": a cold, desaturated cyan rain-city that dissolves into the
+// shared #05060a fog, with exactly one warm amber window (the desk) as the sole warm mark.
+//
+// Each animated shader self-clocks via useUniformClock — a per-material accumulator that only
+// advances while reduced motion is off, so every animation (rain, smog, rivulets, ripples,
+// flicker) freezes together into a calm static postcard for prefers-reduced-motion, with zero
+// vestibular trigger (the camera flight itself is scroll-driven, never autonomous). Everything
+// is instanced/pointed: ~13 scene draw calls. Camera flies +Z entry -> origin -> -Z exit.
+export function OutsideScene() {
+  const quality = useScrollStore((s) => s.quality);
+  return (
+    <>
+      <SkyDome />
+      <CityInstances quality={quality} />
+      <Rain quality={quality} />
+      <GlassPane />
+      <WetStreet />
+      <HeroTower />
+      {/* Cold haze pocket in the canyon (the warm pocket rides the hero window). */}
+      <GlowQuad color={COLOR.cyan} size={40} position={[14, -12, 20]} opacity={0.12} />
+    </>
+  );
+}

--- a/scenes/01-outside/Rain.tsx
+++ b/scenes/01-outside/Rain.tsx
@@ -1,0 +1,83 @@
+"use client";
+import { useMemo, useRef } from "react";
+import { AdditiveBlending, Color, ShaderMaterial } from "three";
+import { COLOR, COUNT, MOTION, mulberry32, pick } from "./config";
+import { RAIN_VERT, RAIN_FRAG } from "./shaders";
+import { useUniformClock } from "./useSceneClock";
+import type { QualityTier } from "@/lib/scrollStore";
+
+// The rain box hugs the flight corridor; points wrap-fall in the vertex shader (mod over
+// spanY) so the volume stays full as the camera flies through — no world-locked pop.
+const BOX = { halfX: 70, halfZ: 90, spanY: 100 };
+
+function RainLayer({
+  count,
+  fall,
+  size,
+  opacity,
+  seed,
+}: {
+  count: number;
+  fall: number;
+  size: number;
+  opacity: number;
+  seed: number;
+}) {
+  const matRef = useRef<ShaderMaterial>(null);
+  useUniformClock(matRef);
+
+  const { positions, seeds } = useMemo(() => {
+    const rnd = mulberry32(seed);
+    const positions = new Float32Array(count * 3);
+    const seeds = new Float32Array(count);
+    for (let i = 0; i < count; i++) {
+      positions[i * 3] = (rnd() * 2 - 1) * BOX.halfX;
+      positions[i * 3 + 1] = rnd() * BOX.spanY;
+      positions[i * 3 + 2] = (rnd() * 2 - 1) * BOX.halfZ;
+      seeds[i] = rnd();
+    }
+    return { positions, seeds };
+  }, [count, seed]);
+
+  const uniforms = useMemo(
+    () => ({
+      uTime: { value: 0 },
+      uFall: { value: fall },
+      uWind: { value: MOTION.windShear },
+      uSpanY: { value: BOX.spanY },
+      uSize: { value: size },
+      uColor: { value: new Color(COLOR.rain) },
+      uOpacity: { value: opacity },
+    }),
+    [fall, size, opacity],
+  );
+
+  return (
+    <points frustumCulled={false}>
+      <bufferGeometry>
+        <bufferAttribute attach="attributes-position" args={[positions, 3]} />
+        <bufferAttribute attach="attributes-aSeed" args={[seeds, 1]} />
+      </bufferGeometry>
+      {/* TODO(asset): rain-streak sprite texture could replace the procedural point smear. */}
+      <shaderMaterial
+        ref={matRef}
+        vertexShader={RAIN_VERT}
+        fragmentShader={RAIN_FRAG}
+        uniforms={uniforms}
+        transparent
+        depthWrite={false}
+        blending={AdditiveBlending}
+        toneMapped={false}
+      />
+    </points>
+  );
+}
+
+export function Rain({ quality }: { quality: QualityTier }) {
+  return (
+    <>
+      <RainLayer count={pick(quality, COUNT.rainNear)} fall={MOTION.rainNearFall} size={3} opacity={0.5} seed={7} />
+      <RainLayer count={pick(quality, COUNT.rainFar)} fall={MOTION.rainFarFall} size={2} opacity={0.3} seed={13} />
+    </>
+  );
+}

--- a/scenes/01-outside/config.ts
+++ b/scenes/01-outside/config.ts
@@ -1,0 +1,71 @@
+// The main tunables for the OUTSIDE hero scene — "The One Warm Window", a restrained noir
+// descent: palette, instance counts, layout, and motion speeds. (Some purely-procedural art
+// constants — window-grid density, per-tower size ranges — still live inline in shaders.ts /
+// CityInstances.tsx.) Art direction: a cold desaturated cyan rain-city dissolving into the
+// shared #05060a fog, with exactly ONE warm amber window (the developer's desk) as the sole
+// warm mark.
+
+import type { QualityTier } from "@/lib/scrollStore";
+
+/** Palette (exact hexes from the art direction). THREE.Color reads these as sRGB and
+ *  converts to linear for the shaders — the whole scene works in linear space. */
+export const COLOR = {
+  skyZenith: "#070b14",
+  skyHorizon: "#14243d",
+  towerBody: "#0a1018",
+  edge: "#1b2c44",
+  windowDim: "#2a3d55",
+  cyan: "#8fd4ff",
+  cyanCore: "#bfe9ff",
+  rain: "#6f8598",
+  asphalt: "#060a10",
+  warm: "#ffcf8a",
+} as const;
+
+/** Per-instance counts by quality tier — low tier thins the fill-heavy systems. */
+export const COUNT = {
+  towers: { high: 260, low: 90 },
+  aerials: { high: 80, low: 0 },
+  signage: { high: 60, low: 24 },
+  rainNear: { high: 5000, low: 1500 },
+  rainFar: { high: 2000, low: 500 },
+} as const;
+
+export const pick = (tier: QualityTier, c: { high: number; low: number }) =>
+  tier === "low" ? c.low : c.high;
+
+/** Local-frame placement (camera flies +Z entry -> origin -> -Z exit, +Y world up). */
+export const LAYOUT = {
+  corridor: { minX: 22, maxX: 60, zFront: 90, zBack: -260, spanY: 46 },
+  // Hero z pulled inside the camera's actual local-Z reach (~-32 at scene-0 exit) so the warm
+  // window is genuinely approached and grows into the DESK bloom-handoff, not viewed from afar.
+  hero: { pos: [-8, -24, -40] as const, size: [16, 46, 16] as const, yawDeg: 15 },
+  warmWindow: { size: [1.6, 2.2] as const, glow: 22 },
+  glass: { size: [46, 28] as const, tiltDeg: 8, z: 6 },
+  street: { y: -40, size: 900 },
+  sky: { radius: 340 },
+} as const;
+
+/** Seeded PRNG (mulberry32). Instance layouts are built from a fixed seed so the city is
+ *  identical every time the scene mounts — no reshuffle when it leaves/re-enters the ±1
+ *  mount window (Math.random would jitter the skyline on every remount). */
+export function mulberry32(seed: number): () => number {
+  let s = seed >>> 0;
+  return () => {
+    s = (s + 0x6d2b79f5) | 0;
+    let t = Math.imul(s ^ (s >>> 15), 1 | s);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Motion in units/sec (or rad/sec) — every value is applied `* delta` via the shared
+ *  uTime clock, which only advances when reduced motion is off. */
+export const MOTION = {
+  rainNearFall: 28,
+  rainFarFall: 14,
+  windShear: 4,
+  smogDrift: 0.05,
+  rivulet: 1.0,
+  ripple: 0.6,
+} as const;

--- a/scenes/01-outside/shaders.ts
+++ b/scenes/01-outside/shaders.ts
@@ -1,0 +1,197 @@
+// GLSL for the OUTSIDE scene. Kept as string constants so the .tsx files stay readable and
+// the shaders are diffable in one place. Every fragment that writes final scene colour ends
+// with the same chunk trio three's own materials use — <tonemapping_fragment> /
+// <colorspace_fragment> / <fog_fragment> — so these ShaderMaterials behave identically to
+// built-ins under the @react-three/postprocessing composer (they render linear into its
+// buffer; the composer owns the final sRGB encode). Light overlays (rain + glow are additive,
+// glass is alpha-blended) skip tonemapping+fog and only encode colour.
+
+// Small self-contained hash/value-noise/fbm prelude, injected where needed.
+const NOISE = /* glsl */ `
+float h21(vec2 p){ vec3 p3 = fract(vec3(p.xyx)*0.1031); p3 += dot(p3, p3.yzx+33.33); return fract((p3.x+p3.y)*p3.z); }
+float n2(vec2 p){ vec2 i=floor(p), f=fract(p); f=f*f*(3.0-2.0*f);
+  float a=h21(i), b=h21(i+vec2(1.0,0.0)), c=h21(i+vec2(0.0,1.0)), d=h21(i+vec2(1.0,1.0));
+  return mix(mix(a,b,f.x), mix(c,d,f.x), f.y); }
+float fbm(vec2 p){ float s=0.0, a=0.5; for(int i=0;i<2;i++){ s+=a*n2(p); p*=2.0; a*=0.5; } return s; }
+`;
+
+// ---- Sky dome: vertical gradient + slow low-horizon smog drift (backdrop, no fog) ----
+export const SKY_VERT = /* glsl */ `
+varying vec3 vDir;
+void main(){ vDir = position; gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0); }
+`;
+export const SKY_FRAG = /* glsl */ `
+#include <common>
+#include <tonemapping_pars_fragment>
+uniform float uTime; uniform float uDrift; uniform vec3 uZenith; uniform vec3 uHorizon;
+varying vec3 vDir;
+${NOISE}
+void main(){
+  vec3 d = normalize(vDir);
+  float h = clamp(d.y*0.5 + 0.5, 0.0, 1.0);
+  vec3 col = mix(uHorizon, uZenith, smoothstep(0.05, 0.55, h));
+  float lowMask = 1.0 - smoothstep(0.0, 0.4, h);
+  // +1e-6 keeps atan defined at the exact zenith/nadir pole vertices (d.x==d.z==0).
+  float smog = fbm(vec2(atan(d.z, d.x + 1e-6)*2.0, h*3.0) + uTime*uDrift);
+  col += uHorizon * smog * lowMask * 0.4;
+  gl_FragColor = vec4(col, 1.0);
+  #include <tonemapping_fragment>
+  #include <colorspace_fragment>
+}
+`;
+
+// ---- City / hero towers: instanced, in-shader window grid + fresnel edge, fogged ----
+// USE_INSTANCING is defined by three only for InstancedMesh, so this one shader serves both
+// the instanced city AND the single non-instanced hero tower (which has no instanceMatrix).
+export const TOWER_VERT = /* glsl */ `
+#include <common>
+#include <fog_pars_vertex>
+#ifdef USE_INSTANCING
+  attribute float aSeed;
+  attribute float aLit;
+#else
+  uniform float aSeed;
+  uniform float aLit;
+#endif
+varying vec2 vUv; varying vec3 vViewNormal; varying float vSeed; varying float vLit;
+void main(){
+  vUv = uv; vSeed = aSeed; vLit = aLit;
+  #ifdef USE_INSTANCING
+    mat4 local = instanceMatrix;
+  #else
+    mat4 local = mat4(1.0);
+  #endif
+  vec4 mvPosition = modelViewMatrix * local * vec4(position, 1.0);
+  vViewNormal = normalize((modelViewMatrix * local * vec4(normal, 0.0)).xyz);
+  gl_Position = projectionMatrix * mvPosition;
+  #include <fog_vertex>
+}
+`;
+export const TOWER_FRAG = /* glsl */ `
+#include <common>
+#include <tonemapping_pars_fragment>
+#include <fog_pars_fragment>
+uniform vec3 uBody; uniform vec3 uEdge; uniform vec3 uWindowDim; uniform vec3 uCyan;
+uniform float uTime; uniform float uThreshold;
+varying vec2 vUv; varying vec3 vViewNormal; varying float vSeed; varying float vLit;
+float h21(vec2 p){ vec3 p3 = fract(vec3(p.xyx)*0.1031); p3 += dot(p3, p3.yzx+33.33); return fract((p3.x+p3.y)*p3.z); }
+void main(){
+  vec2 grid = vec2(5.0, 14.0);
+  vec2 cell = floor(vUv*grid);
+  vec2 f = fract(vUv*grid);
+  float win = step(0.16,f.x)*step(f.x,0.84)*step(0.14,f.y)*step(f.y,0.86);
+  float lit = step(uThreshold, h21(cell + vSeed*17.3)) * vLit;
+  float flick = 1.0 - 0.35*step(0.98, h21(cell + floor(uTime*1.7)));
+  vec3 winCol = mix(uWindowDim, uCyan, step(0.90, h21(cell + vSeed*3.1))) * flick;
+  float fres = pow(1.0 - abs(vViewNormal.z), 2.5);
+  vec3 body = mix(uBody, uEdge, fres*0.8);
+  vec3 col = mix(body, winCol, win*lit);
+  gl_FragColor = vec4(col, 1.0);
+  #include <tonemapping_fragment>
+  #include <colorspace_fragment>
+  #include <fog_fragment>
+}
+`;
+
+// ---- Rain: GPU points stretched into slanted streaks, wrap-falling via uTime ----
+export const RAIN_VERT = /* glsl */ `
+uniform float uTime; uniform float uFall; uniform float uWind; uniform float uSpanY; uniform float uSize;
+attribute float aSeed;
+varying float vFade;
+void main(){
+  vec3 p = position;
+  float fall = mod(p.y - uTime*uFall + aSeed*uSpanY, uSpanY);
+  p.y = fall - uSpanY*0.5;
+  p.x += (uSpanY*0.5 - fall) * uWind * 0.015;
+  vFade = 0.6 + 0.4*aSeed;
+  vec4 mv = modelViewMatrix * vec4(p, 1.0);
+  gl_PointSize = clamp(uSize * (260.0 / -mv.z), 1.0, 28.0);
+  gl_Position = projectionMatrix * mv;
+}
+`;
+export const RAIN_FRAG = /* glsl */ `
+uniform vec3 uColor; uniform float uOpacity;
+varying float vFade;
+void main(){
+  vec2 c = gl_PointCoord - 0.5;
+  float x = abs(c.x + c.y*0.12);
+  float streak = smoothstep(0.5, 0.0, x*8.0);
+  float yg = smoothstep(0.5, 0.05, abs(c.y));
+  float a = streak*yg*uOpacity*vFade;
+  if (a < 0.01) discard;
+  gl_FragColor = vec4(uColor, a);
+  #include <colorspace_fragment>
+}
+`;
+
+// ---- Rain-on-glass threshold pane: procedural rivulets + beads (transparent overlay) ----
+export const GLASS_VERT = /* glsl */ `
+varying vec2 vUv;
+void main(){ vUv = uv; gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0); }
+`;
+export const GLASS_FRAG = /* glsl */ `
+uniform float uTime; uniform float uRivulet; uniform vec3 uWarm; uniform vec3 uCool;
+varying vec2 vUv;
+${NOISE}
+void main(){
+  vec2 uv = vUv;
+  float trail = fbm(vec2(uv.x*26.0, uv.y*7.0 - uTime*uRivulet));
+  float rivulet = smoothstep(0.62, 0.95, trail);
+  float beads = smoothstep(0.75, 1.0, h21(floor(uv*vec2(34.0, 54.0))));
+  float wet = max(rivulet, beads*0.6);
+  vec3 col = uCool*wet*0.5 + uWarm*pow(wet, 3.0)*0.9;
+  float alpha = clamp(wet*0.55, 0.0, 0.8);
+  gl_FragColor = vec4(col, alpha);
+  #include <colorspace_fragment>
+}
+`;
+
+// ---- Radial additive glow: window glow sprite + haze pockets (fake volumetric) ----
+export const GLOW_VERT = /* glsl */ `
+varying vec2 vUv;
+void main(){ vUv = uv; gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0); }
+`;
+export const GLOW_FRAG = /* glsl */ `
+uniform vec3 uColor; uniform float uOpacity;
+varying vec2 vUv;
+void main(){
+  float d = length(vUv - 0.5) * 2.0;
+  float a = smoothstep(1.0, 0.0, d);
+  a *= a;
+  gl_FragColor = vec4(uColor, a*uOpacity);
+  #include <colorspace_fragment>
+}
+`;
+
+// ---- Wet street: analytic accent reflections + fresnel sheen + ripples, fogged ----
+export const STREET_VERT = /* glsl */ `
+#include <fog_pars_vertex>
+varying vec2 vUv;
+void main(){
+  vUv = uv;
+  vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
+  gl_Position = projectionMatrix * mvPosition;
+  #include <fog_vertex>
+}
+`;
+export const STREET_FRAG = /* glsl */ `
+#include <common>
+#include <tonemapping_pars_fragment>
+#include <fog_pars_fragment>
+uniform float uTime; uniform vec3 uAsphalt; uniform vec3 uCyan; uniform vec3 uWarm; uniform float uRipple;
+varying vec2 vUv;
+void main(){
+  vec3 col = uAsphalt;
+  float up = smoothstep(0.0, 1.0, vUv.y);
+  float ripple = sin(length(vUv - 0.5)*60.0 - uTime*uRipple*10.0)*0.5 + 0.5;
+  float cyanSmear = smoothstep(0.5, 0.0, abs(vUv.x - 0.35)) * up * (0.5 + 0.5*ripple);
+  float warmSmear = smoothstep(0.5, 0.0, abs(vUv.x - 0.62)) * up;
+  col += uCyan * cyanSmear * 0.25;
+  col += uWarm * warmSmear * 0.12;
+  col += uCyan * pow(vUv.y, 4.0) * 0.06;
+  gl_FragColor = vec4(col, 1.0);
+  #include <tonemapping_fragment>
+  #include <colorspace_fragment>
+  #include <fog_fragment>
+}
+`;

--- a/scenes/01-outside/useSceneClock.ts
+++ b/scenes/01-outside/useSceneClock.ts
@@ -1,0 +1,22 @@
+"use client";
+import { useRef, type RefObject } from "react";
+import { useFrame } from "@react-three/fiber";
+import type { ShaderMaterial } from "three";
+import { useScrollStore } from "@/lib/scrollStore";
+
+// Drives a shader material's `uTime` uniform from a per-material accumulator that advances only
+// while reduced motion is off. Every OUTSIDE shader uses this hook, so they all share the same
+// clock value (identical delta + gate each frame) and freeze together into a calm static frame
+// for prefers-reduced-motion. Ref access happens in-frame only — never reads a ref during render
+// nor mutates a memoized value, so it satisfies the react-hooks rules (unlike a shared uTime
+// object threaded through props).
+export function useUniformClock(matRef: RefObject<ShaderMaterial | null>) {
+  const t = useRef(0);
+  useFrame((_, delta) => {
+    if (!useScrollStore.getState().reducedMotion) t.current += Math.min(delta, 0.05);
+    const m = matRef.current;
+    if (!m) return;
+    const u = m.uniforms.uTime;
+    if (u) u.value = t.current;
+  });
+}

--- a/scenes/registry.ts
+++ b/scenes/registry.ts
@@ -1,12 +1,19 @@
-import type { FC } from "react";
-
-/** Props every real scene Component receives from the SceneManager. */
+/** Props every real scene Component (wired by id in SceneManager's SCENE_COMPONENTS map)
+ *  receives. Real scenes are authored in a local frame placed on the spline by SceneShell:
+ *  the camera flies in along local -Z, +Y is world up, origin is the scene's spline center.
+ *  The camera passes THROUGH the origin (a fly-through, not a framed tableau) entering from
+ *  the +Z side, so arrange content around the approach rather than piling it at the origin;
+ *  and its view can pitch up to ~±24° relative to this level frame, since orientation is
+ *  yaw-only. */
 export interface SceneComponentProps {
   /** Registry index of this scene (0-based). */
   index: number;
 }
 
-/** The contract every scene implements (spec §3). */
+/** The contract every scene region implements (spec §3). This is a pure data module (labels
+ *  + ranges) so label-only consumers like UIOverlay never pull in the 3D bundle. Real scene
+ *  Components are wired by `id` in SceneManager; a region with no mapped Component renders a
+ *  labeled placeholder. */
 export interface SceneDef {
   id: string;
   label: string;
@@ -14,13 +21,6 @@ export interface SceneDef {
   range: [number, number];
   /** Extra t-margin to mount early. */
   preload?: number;
-  /** Real scene component; when absent, a labeled placeholder is rendered (Phase 0).
-   *  Authored in a local frame placed on the spline by SceneShell: camera flies in along
-   *  local -Z, +Y is world up, origin is the scene's spline center. Note the camera passes
-   *  THROUGH the origin (a fly-through, not a framed tableau) entering from the +Z side, so
-   *  arrange content around the approach rather than piling it at the origin; and its view
-   *  can pitch up to ~±24° relative to this level frame, since orientation is yaw-only. */
-  Component?: FC<SceneComponentProps>;
 }
 
 // TODO(asset): each scene gets a real Component in later phases. Phase 0 renders every


### PR DESCRIPTION
## What

Replaces the `01-outside` wireframe placeholder with the portfolio's **hero scene**: a cold, desaturated **cyan noir rain-city** the camera flies through, dissolving into the shared `#05060a` fog, with exactly **one warm amber window** (the developer's desk) as the sole warm mark — the focal point that blooms into the DESK handoff.

Art direction was chosen from a **3-concept judge panel** → *"The One Warm Window — a restrained noir descent"* (narrative from the noir concept, monochrome discipline from the minimal concept, the rain-on-glass threshold from the melancholy concept). You approved it before build.

## How (all procedural + GPU-instanced, ~13 scene draw calls)

| Element | Technique |
|---|---|
| **SkyDome** | gradient + fbm smog `ShaderMaterial`, BackSide, behind the shared drei Stars |
| **City** | ~260 towers as **one** `InstancedMesh` — window grid baked into the fragment shader (thousands of lit windows, 1 draw call) + fresnel edges + fog; aerials + cyan signage 1 InstancedMesh each. Seeded layout (`mulberry32`) so the skyline never reshuffles on remount |
| **Rain** | near + far `THREE.Points`, streaks stretched + wrap-fallen in the vertex shader, additive |
| **GlassPane** | the rain-on-glass threshold the camera flies through at origin — procedural rivulets, fake refraction (no extra render pass) |
| **WetStreet** | analytic accent reflections + fresnel sheen + ripples (no `MeshReflector`/SSR) |
| **HeroTower** | near-black monolith (tower shader via `#ifdef USE_INSTANCING` for the non-instanced case) + warm-window inset + additive glow carrier |
| **Postprocessing** | global `EffectComposer`: Bloom (only the warm window + cyan accents cross threshold) + Vignette + subtle ChromaticAberration; `antialias:false` (composer owns AA); `dpr` tier-scaled |

## Engine hygiene (reviewer-verified)

- The **only** `useFrame` is `useUniformClock` — advances a per-material clock by `delta`, **freezes on `reducedMotion`** (so every shader animation stops together), **zero per-frame allocation**.
- All instance matrices/attributes/positions built once in `useMemo`; every geometry/material is JSX so R3F auto-disposes on unmount via `SceneShell`.
- **Bundle hygiene:** real scene Components are now mapped by `id` in `SceneManager` (`registry.ts` is pure data again), so the 3D bundle stays in the lazy `ssr:false` Canvas chunk and never leaks into the eager `UIOverlay`.
- Every real-asset swap point is a `// TODO(asset)` (sky HDR, hero GLTF, rain/asphalt/neon textures) — swapping needs no architectural change.

## Review gate

- **grumpy-reviewer**: SHIP-WITH-NITS, no P0/P1 (numerically verified allocations/disposal/delta-motion/reduced-motion/fog+tonemapping chunk wiring/registry refactor all clean). Fixed: hero **framing** (window is now actually approached — pulled from z −70 into the camera's ~−32 local-Z reach), dead `MOTION.smogDrift`/`rivulet` wired as uniforms, shader comment, sky-pole `atan` guard, `side={2}`→`DoubleSide`.
- **security-reviewer**: clean (procedural client-only WebGL, no untrusted data into shaders, no new deps).
- **perf-profiler**: ~12 draw calls, zero per-frame alloc, negligible VRAM. Applied the tier-independent wins (antialias off, rain point-size ceiling trim, reactive dpr).

## ⚠️ Deferred (tracked)

**GPU quality tiering is unwired** (pre-existing since Phase 0): store `quality` is hardcoded `"high"`, `setQuality` is never called, `detect-gpu` is unused — so every low-tier path (instance counts, dpr, bloom multisampling, star/sparkle counts) is **dead code today**. perf-profiler flagged this P0. It's a cross-cutting infra change (self-host `detect-gpu` benchmarks to avoid its default unpkg.com CDN fetch, and/or add `<PerformanceMonitor>` live recovery) that benefits **all** scenes, so I split it into its own follow-up rather than bolt a silent CDN fetch onto this scene PR. **The low-tier code here is already written and ready** for that wiring.

## Verification

`npx tsc --noEmit` ✓ · `npm run lint` ✓ · `npm run build` ✓ · browser smoke: renders the art direction at **~480 FPS**, warm window reads + blooms, mount budget holds through the transition, **no console errors** (one upstream `THREE.Clock` deprecation warning only).

Real photographic sky / GLTF models are deliberately left as procedural stand-ins per the project's placeholder convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “outside” scene with a rainy city, animated sky, street reflections, glass effects, tower lighting, and atmospheric glow.
  * Improved scene rendering with richer visual effects such as bloom, vignette, and chromatic color separation.
  * Scene quality now scales more smoothly across devices for better visual consistency and performance.
* **Bug Fixes**
  * Reduced motion settings now keep scene animation behavior more stable and comfortable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->