### PR TITLE
Phase 1 · Scene 03 ENTER MONITOR — the GPU-particle dive into the screen

### DIFF
--- a/components/SceneManager.tsx
+++ b/components/SceneManager.tsx
@@ -7,6 +7,7 @@ import { SceneShell } from "@/scenes/_SceneShell";
 import { PlaceholderScene } from "@/scenes/PlaceholderScene";
 import { OutsideScene } from "@/scenes/01-outside/OutsideScene";
 import { DeskScene } from "@/scenes/02-desk/DeskScene";
+import { EnterMonitorScene } from "@/scenes/03-enter-monitor/EnterMonitorScene";
 import { curve } from "@/lib/spline";
 
 // Real scene Components wired by registry id. Kept here — inside the Canvas-only, dynamically
@@ -15,6 +16,7 @@ import { curve } from "@/lib/spline";
 const SCENE_COMPONENTS: Partial<Record<string, FC<SceneComponentProps>>> = {
   "01-outside": OutsideScene,
   "02-desk": DeskScene,
+  "03-enter-monitor": EnterMonitorScene,
 };
 
 // Static per-scene placement on the spline, computed once (the curve never changes). Each

--- a/lib/rng.ts
+++ b/lib/rng.ts
@@ -1,0 +1,12 @@
+// Seeded PRNG (mulberry32). Scene instance / particle layouts are built from a fixed seed so
+// each scene is identical every time it mounts — no reshuffle when it leaves and re-enters the
+// ±1 mount window (Math.random would jitter the layout on every remount). Shared across scenes.
+export function mulberry32(seed: number): () => number {
+  let s = seed >>> 0;
+  return () => {
+    s = (s + 0x6d2b79f5) | 0;
+    let t = Math.imul(s ^ (s >>> 15), 1 | s);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}

--- a/lib/useUniformClock.ts
+++ b/lib/useUniformClock.ts
@@ -5,11 +5,11 @@ import type { ShaderMaterial } from "three";
 import { useScrollStore } from "@/lib/scrollStore";
 
 // Drives a shader material's `uTime` uniform from a per-material accumulator that advances only
-// while reduced motion is off. Every OUTSIDE shader uses this hook, so they all share the same
-// clock value (identical delta + gate each frame) and freeze together into a calm static frame
-// for prefers-reduced-motion. Ref access happens in-frame only — never reads a ref during render
-// nor mutates a memoized value, so it satisfies the react-hooks rules (unlike a shared uTime
-// object threaded through props).
+// while reduced motion is off — so every scene shader that uses this hook shares the same clock
+// value (identical delta + gate each frame) and freezes together into a calm static frame for
+// prefers-reduced-motion. Ref access happens in-frame only — never reads a ref during render nor
+// mutates a memoized value, so it satisfies the react-hooks rules (unlike a shared uTime object
+// threaded through props). Shared by the OUTSIDE and ENTER-MONITOR scenes.
 export function useUniformClock(matRef: RefObject<ShaderMaterial | null>) {
   const t = useRef(0);
   useFrame((_, delta) => {

--- a/scenes/01-outside/CityInstances.tsx
+++ b/scenes/01-outside/CityInstances.tsx
@@ -12,9 +12,10 @@ import {
   UniformsUtils,
   Vector3,
 } from "three";
-import { COLOR, COUNT, LAYOUT, mulberry32, pick } from "./config";
+import { COLOR, COUNT, LAYOUT, pick } from "./config";
 import { TOWER_VERT, TOWER_FRAG } from "./shaders";
-import { useUniformClock } from "./useSceneClock";
+import { mulberry32 } from "@/lib/rng";
+import { useUniformClock } from "@/lib/useUniformClock";
 import type { QualityTier } from "@/lib/scrollStore";
 
 // The whole megacity is 3 InstancedMeshes (towers · rooftop aerials · cyan signage) — one draw

--- a/scenes/01-outside/Environment.tsx
+++ b/scenes/01-outside/Environment.tsx
@@ -12,7 +12,7 @@ import {
   STREET_FRAG,
   STREET_VERT,
 } from "./shaders";
-import { useUniformClock } from "./useSceneClock";
+import { useUniformClock } from "@/lib/useUniformClock";
 
 // Horizon-glow backdrop dome — renders behind the shared drei Stars; no fog (it IS the sky).
 // TODO(asset): swap the gradient+fbm material for an equirect night-smog HDR onto the same dome.

--- a/scenes/01-outside/HeroTower.tsx
+++ b/scenes/01-outside/HeroTower.tsx
@@ -4,7 +4,7 @@ import { Color, ShaderMaterial, UniformsLib, UniformsUtils } from "three";
 import { COLOR, LAYOUT } from "./config";
 import { TOWER_VERT, TOWER_FRAG } from "./shaders";
 import { GlowQuad } from "./Environment";
-import { useUniformClock } from "./useSceneClock";
+import { useUniformClock } from "@/lib/useUniformClock";
 
 // The developer's building — a near-black monolith the descending camera aims down, carrying
 // the ONE warm window (the desk) that is the sole warm mark and the bloom handoff into DESK.

--- a/scenes/01-outside/Rain.tsx
+++ b/scenes/01-outside/Rain.tsx
@@ -1,9 +1,10 @@
 "use client";
 import { useMemo, useRef } from "react";
 import { AdditiveBlending, Color, ShaderMaterial } from "three";
-import { COLOR, COUNT, MOTION, mulberry32, pick } from "./config";
+import { COLOR, COUNT, MOTION, pick } from "./config";
 import { RAIN_VERT, RAIN_FRAG } from "./shaders";
-import { useUniformClock } from "./useSceneClock";
+import { mulberry32 } from "@/lib/rng";
+import { useUniformClock } from "@/lib/useUniformClock";
 import type { QualityTier } from "@/lib/scrollStore";
 
 // The rain box hugs the flight corridor; points wrap-fall in the vertex shader (mod over

--- a/scenes/01-outside/config.ts
+++ b/scenes/01-outside/config.ts
@@ -48,19 +48,6 @@ export const LAYOUT = {
   sky: { radius: 340 },
 } as const;
 
-/** Seeded PRNG (mulberry32). Instance layouts are built from a fixed seed so the city is
- *  identical every time the scene mounts — no reshuffle when it leaves/re-enters the ±1
- *  mount window (Math.random would jitter the skyline on every remount). */
-export function mulberry32(seed: number): () => number {
-  let s = seed >>> 0;
-  return () => {
-    s = (s + 0x6d2b79f5) | 0;
-    let t = Math.imul(s ^ (s >>> 15), 1 | s);
-    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
-}
-
 /** Motion in units/sec (or rad/sec) — every value is applied `* delta` via the shared
  *  uTime clock, which only advances when reduced motion is off. */
 export const MOTION = {

--- a/scenes/03-enter-monitor/EnterMonitorScene.tsx
+++ b/scenes/03-enter-monitor/EnterMonitorScene.tsx
@@ -1,0 +1,110 @@
+"use client";
+import { useMemo, useRef } from "react";
+import { AdditiveBlending, Color, ShaderMaterial } from "three";
+import { useScrollStore } from "@/lib/scrollStore";
+import { useUniformClock } from "@/lib/useUniformClock";
+import { mulberry32 } from "@/lib/rng";
+import { COLOR, CORE, PARTICLES, pickCount } from "./config";
+
+// A swirling tube of GPU particles streams past the diving camera toward a glowing core — the
+// plunge INTO the monitor. One Points draw call + one additive core. useUniformClock advances
+// uTime (only while reduced motion is off), so the whole flow freezes into a calm static field
+// for prefers-reduced-motion. All motion is in-shader off uTime.
+const VERT = /* glsl */ `
+uniform float uTime; uniform float uSize; uniform float uMaxSize; uniform float uLen; uniform float uSwirl; uniform float uStream;
+attribute float aSeed;
+varying float vSeed;
+void main(){
+  vSeed = aSeed;
+  vec3 p = position;
+  // stream toward +z and wrap over the tube length, so particles rush past the -z-diving camera
+  p.z = mod(p.z + uTime * uStream, uLen) - uLen * 0.5;
+  // swirl around the z axis, faster near the axis (a vortex)
+  float r = length(p.xy);
+  float a = uTime * uSwirl / (r * 0.08 + 1.0) + aSeed * 6.2831853;
+  float c = cos(a), s = sin(a);
+  p.xy = mat2(c, -s, s, c) * p.xy;
+  vec4 mv = modelViewMatrix * vec4(p, 1.0);
+  gl_PointSize = clamp(uSize * (200.0 / -mv.z), 1.0, uMaxSize);
+  gl_Position = projectionMatrix * mv;
+}
+`;
+const FRAG = /* glsl */ `
+uniform vec3 uColorA; uniform vec3 uColorB;
+varying float vSeed;
+void main(){
+  vec2 c = gl_PointCoord - 0.5;
+  float d = length(c);
+  if (d > 0.5) discard;
+  float alpha = smoothstep(0.5, 0.0, d);
+  vec3 col = mix(uColorA, uColorB, vSeed);
+  gl_FragColor = vec4(col, alpha * alpha);
+  #include <colorspace_fragment>
+}
+`;
+
+export function EnterMonitorScene() {
+  const matRef = useRef<ShaderMaterial>(null);
+  useUniformClock(matRef);
+  const quality = useScrollStore((s) => s.quality);
+  const count = pickCount(quality);
+
+  const { positions, seeds } = useMemo(() => {
+    const rnd = mulberry32(2024);
+    const positions = new Float32Array(count * 3);
+    const seeds = new Float32Array(count);
+    const TWO_PI = Math.PI * 2;
+    for (let i = 0; i < count; i++) {
+      const ang = rnd() * TWO_PI;
+      const rad = Math.sqrt(rnd()) * PARTICLES.radius; // uniform over the disc
+      positions[i * 3] = Math.cos(ang) * rad;
+      positions[i * 3 + 1] = Math.sin(ang) * rad;
+      positions[i * 3 + 2] = rnd() * PARTICLES.length;
+      seeds[i] = rnd();
+    }
+    return { positions, seeds };
+  }, [count]);
+
+  const uniforms = useMemo(
+    () => ({
+      uTime: { value: 0 },
+      uSize: { value: PARTICLES.size },
+      uMaxSize: { value: PARTICLES.maxPointPx },
+      uLen: { value: PARTICLES.length },
+      uSwirl: { value: PARTICLES.swirl },
+      uStream: { value: PARTICLES.stream },
+      uColorA: { value: new Color(COLOR.particleA) },
+      uColorB: { value: new Color(COLOR.particleB) },
+    }),
+    [],
+  );
+
+  return (
+    <>
+      <points frustumCulled={false}>
+        <bufferGeometry>
+          <bufferAttribute attach="attributes-position" args={[positions, 3]} />
+          <bufferAttribute attach="attributes-aSeed" args={[seeds, 1]} />
+        </bufferGeometry>
+        {/* TODO(asset): a soft particle sprite texture could replace the procedural round point. */}
+        <shaderMaterial
+          ref={matRef}
+          vertexShader={VERT}
+          fragmentShader={FRAG}
+          uniforms={uniforms}
+          transparent
+          depthWrite={false}
+          blending={AdditiveBlending}
+          toneMapped={false}
+        />
+      </points>
+
+      {/* The glowing core the camera passes through — additive so it flares (bloom) rather than
+          occludes, bridging the dive into the ABOUT scene. */}
+      <mesh>
+        <sphereGeometry args={[CORE.radius, CORE.segments, CORE.segments]} />
+        <meshBasicMaterial color={COLOR.core} transparent opacity={CORE.opacity} blending={AdditiveBlending} depthWrite={false} toneMapped={false} />
+      </mesh>
+    </>
+  );
+}

--- a/scenes/03-enter-monitor/config.ts
+++ b/scenes/03-enter-monitor/config.ts
@@ -1,0 +1,29 @@
+// Tunables for the ENTER MONITOR scene — the dive INTO the screen. A swirling tube of GPU
+// particles streams past the diving camera toward a glowing core, in the code editor's cool
+// cyan/white so it reads as plunging into the monitor. The tube half-length (length/2 = 30)
+// stays inside the ~34u spacing to the neighbouring DESK / ABOUT scenes co-mounted by the ±1
+// budget, so it doesn't overreach their centers.
+
+import type { QualityTier } from "@/lib/scrollStore";
+
+export const COLOR = {
+  particleA: "#7ec8ff", // cyan (screen continuity)
+  particleB: "#eaf6ff", // bright white-cyan
+  core: "#bfe9ff", // the glowing core the camera passes through
+} as const;
+
+export const PARTICLES = {
+  count: { high: 16000, low: 6000 },
+  radius: 30, // tube radius
+  length: 60, // tube length along local z (shader wraps particles over this; half-length 30 < 34u gap)
+  size: 2.6,
+  maxPointPx: 14, // near-camera point-size cap — keeps additive overdraw in budget
+  swirl: 0.5, // rad/sec angular drift (faster near the axis)
+  stream: 26, // units/sec toward +z, so particles rush past the -z-diving camera
+} as const;
+
+/** The glowing core the camera passes through (additive, so it flares rather than occludes). */
+export const CORE = { radius: 3, segments: 24, opacity: 0.85 } as const;
+
+export const pickCount = (tier: QualityTier) =>
+  tier === "low" ? PARTICLES.count.low : PARTICLES.count.high;


### PR DESCRIPTION
## What

Replaces the `03-enter-monitor` placeholder with the **plunge INTO the monitor**: a swirling tube of ~16k GPU particles streams past the diving camera toward a glowing additive core, in the code editor's cool cyan/white so it reads as entering the screen. This is the fast transition that hands off from DESK into ABOUT.

## How

- One `THREE.Points` system (inline swirl + z-stream vertex shader, soft round additive fragment) + one additive core sphere = **2 draw calls**.
- All motion is in-shader off a single `uTime`, advanced by the shared reduced-motion-gated clock → freezes to a calm static field for `prefers-reduced-motion`.
- Positions/seeds built once in `useMemo`; **zero per-frame allocation**.

## Shared-module extraction (touches 01-outside)

Both OUTSIDE and ENTER-MONITOR now use these, so I lifted them out of `scenes/01-outside/` into `lib/` (drift-proof, per grumpy #1/#3):
- **`lib/useUniformClock.ts`** (was `scenes/01-outside/useSceneClock.ts`) — the per-material reduced-motion clock; rewired across the 4 OUTSIDE consumers.
- **`lib/rng.ts`** — the `mulberry32` seeded PRNG (was duplicated in each scene config).

## Review-gate fixes

- **perf P1 (additive fill-rate) + grumpy #2 (false footprint comment):** the tube half-length (55u) actually *overreached* the ~34u neighbor-scene gap. Shortened the tube (`length 110→60`, half-length 30 now stays inside the gap), trimmed the count (`22k→16k`), and capped near-camera point size (`22→14px`, threaded as `uMaxSize`). **Much less overdraw AND less cross-scene bleed**; the comment is now accurate.
- **grumpy #5:** core sphere radius/segments/opacity → a `CORE` config block.

## Review gate

- **grumpy-reviewer**: SHIP-WITH-NITS, no P0/P1 — verified shader math (`mod` wrap, `mat2` swirl, div-by-zero guards, no NaN), disposal, and reduced-motion all clean; DRY + comment nits fixed.
- **security-reviewer**: clean (authored GLSL literals, seeded PRNG, no untrusted input).
- **perf-profiler**: clean — 2 draw calls, zero per-frame alloc, VRAM trivial; fill-rate trimmed per P1. (The dead quality-tier P0 is the tracked global issue; the low-tier count is ready.)

## Verification

`tsc` ✓ · `lint` ✓ · `next build` ✓ · browser smoke: particle dive renders at **~480 FPS**, no console errors, and OUTSIDE is unaffected by the shared-module move (regression-checked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)