### PR TITLE
ABOUT scene: identity constellation (real CV content)

### DIFF
--- a/components/SceneManager.tsx
+++ b/components/SceneManager.tsx
@@ -8,6 +8,7 @@ import { PlaceholderScene } from "@/scenes/PlaceholderScene";
 import { OutsideScene } from "@/scenes/01-outside/OutsideScene";
 import { DeskScene } from "@/scenes/02-desk/DeskScene";
 import { EnterMonitorScene } from "@/scenes/03-enter-monitor/EnterMonitorScene";
+import { AboutScene } from "@/scenes/04-about/AboutScene";
 import { curve } from "@/lib/spline";
 
 // Real scene Components wired by registry id. Kept here — inside the Canvas-only, dynamically
@@ -17,6 +18,7 @@ const SCENE_COMPONENTS: Partial<Record<string, FC<SceneComponentProps>>> = {
   "01-outside": OutsideScene,
   "02-desk": DeskScene,
   "03-enter-monitor": EnterMonitorScene,
+  "04-about": AboutScene,
 };
 
 // Static per-scene placement on the spline, computed once (the curve never changes). Each

--- a/scenes/04-about/AboutScene.tsx
+++ b/scenes/04-about/AboutScene.tsx
@@ -1,0 +1,66 @@
+"use client";
+import { Text, Line } from "@react-three/drei";
+
+// ABOUT — an identity constellation the camera flies through after the monitor dive: a glowing hub
+// (name + role) wired to satellite nodes (the stack this site is built on), in the screen's cyan so
+// it reads as still being "inside the machine". Everything's a labeled node so it's easy to edit.
+const CYAN = "#8fd4ff";
+
+const NAME = "SAEED KOLIVAND";
+const ROLE = "Senior Frontend Developer";
+const SUB = "AI & Agentic Systems  ·  Köln, DE";
+const HUB: [number, number, number] = [0, 1.5, 0];
+
+// [label, position, labelDy] — the facets that define the work, spread in the XY plane (slight z
+// for depth). labelDy places the label above (+) or below (−) the node, off the wire.
+const NODES: ReadonlyArray<readonly [string, [number, number, number], number]> = [
+  ["AI & Agentic", [-10.5, 1.5, 1.5], 0.95],
+  ["Multi-LLM", [-9, -4.5, -1.5], -1.1],
+  ["6+ Years", [-3.5, -8, 1.5], -1.1],
+  ["React · Next", [5, -7, -1.5], -1.1],
+  ["TypeScript", [10.5, -1, 1.5], 0.95],
+];
+
+function Node({ position, label, labelDy }: { position: [number, number, number]; label: string; labelDy: number }) {
+  return (
+    <group position={position}>
+      <mesh>
+        <icosahedronGeometry args={[0.35, 0]} />
+        <meshBasicMaterial color={CYAN} toneMapped={false} />
+      </mesh>
+      <Text position={[0, labelDy, 0]} fontSize={0.62} color="#cfe8ff" anchorX="center" anchorY="middle" outlineWidth={0.02} outlineColor="#05060a">
+        {label}
+      </Text>
+    </group>
+  );
+}
+
+export function AboutScene() {
+  return (
+    <group>
+      {/* wires from the hub to each satellite */}
+      {NODES.map(([, p], i) => (
+        <Line key={`w${i}`} points={[HUB, p]} color={CYAN} lineWidth={1} transparent opacity={0.45} toneMapped={false} />
+      ))}
+
+      {/* hub core + name + role */}
+      <mesh position={HUB}>
+        <icosahedronGeometry args={[0.6, 1]} />
+        <meshBasicMaterial color={CYAN} toneMapped={false} />
+      </mesh>
+      <Text position={[0, 4.9, 0]} fontSize={1.9} color="#eaf6ff" anchorX="center" anchorY="middle" outlineWidth={0.04} outlineColor="#05060a">
+        {NAME}
+      </Text>
+      <Text position={[0, 3.5, 0]} fontSize={0.78} color={CYAN} anchorX="center" anchorY="middle" letterSpacing={0.12}>
+        {ROLE}
+      </Text>
+      <Text position={[0, 2.7, 0]} fontSize={0.5} color="#9fb4c8" anchorX="center" anchorY="middle" letterSpacing={0.06}>
+        {SUB}
+      </Text>
+
+      {NODES.map(([label, p, dy], i) => (
+        <Node key={`n${i}`} position={p} label={label} labelDy={dy} />
+      ))}
+    </group>
+  );
+}


### PR DESCRIPTION
Replaces the ABOUT wireframe placeholder with the first real content scene.

## What
A glowing **identity constellation** the camera flies through after the monitor dive:
- Hub: **SAEED KOLIVAND** · Senior Frontend Developer · *AI & Agentic Systems · Köln, DE*
- Facet nodes wired to the hub: **AI & Agentic · Multi-LLM · 6+ Years · React · Next · TypeScript**
- Screen-cyan palette so it reads as still being "inside the machine"; approached from far thanks to the ABOUT pacing weight.

## Notes
- drei `<Text>` / `<Line>` (same `<Text>` the placeholder used).
- Content is inline consts (`NAME` / `ROLE` / `SUB` / `NODES`) for trivial edits; per-node `labelDy` places labels above/below off the wires.
- No autonomous animation → reduced-motion safe by default.
- Wired into `SceneManager` by id (`04-about`).

## Verification
tsc + lint + `next build` green; browser-verified (~480fps, no console errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)