### PR TITLE
SKILLS scene: three skill-cluster columns (real CV content)

### DIFF
--- a/components/SceneManager.tsx
+++ b/components/SceneManager.tsx
@@ -9,6 +9,7 @@ import { OutsideScene } from "@/scenes/01-outside/OutsideScene";
 import { DeskScene } from "@/scenes/02-desk/DeskScene";
 import { EnterMonitorScene } from "@/scenes/03-enter-monitor/EnterMonitorScene";
 import { AboutScene } from "@/scenes/04-about/AboutScene";
+import { SkillsScene } from "@/scenes/05-skills/SkillsScene";
 import { curve } from "@/lib/spline";
 
 // Real scene Components wired by registry id. Kept here — inside the Canvas-only, dynamically
@@ -19,6 +20,7 @@ const SCENE_COMPONENTS: Partial<Record<string, FC<SceneComponentProps>>> = {
   "02-desk": DeskScene,
   "03-enter-monitor": EnterMonitorScene,
   "04-about": AboutScene,
+  "05-skills": SkillsScene,
 };
 
 // Static per-scene placement on the spline, computed once (the curve never changes). Each

--- a/scenes/05-skills/SkillsScene.tsx
+++ b/scenes/05-skills/SkillsScene.tsx
@@ -1,0 +1,54 @@
+"use client";
+import { Text, Line } from "@react-three/drei";
+
+// SKILLS — the three skill clusters from the CV as heading + plumb-list columns the camera flies
+// between. Deliberately a different motif from ABOUT's radial hub (co-mounted neighbor) so the two
+// read as distinct beats. Same screen-cyan. Edit skills inline.
+const CYAN = "#8fd4ff";
+const DIM = "#a9c6da";
+
+const TOP = 5; // heading y
+const LINE = 1.4; // line spacing
+const SKILL0 = 3.1; // first skill y
+
+// SKILLS' scroll region is narrow, so the whole cluster is pushed AHEAD to the camera's look-target
+// (z ≈ -LOOK_AHEAD) — that lands it framed dead-centre during the scene's dwell instead of flying
+// past at the origin. Kept compact in x so all three columns read together.
+const AHEAD = -15; // ≈ CameraRig LOOK_AHEAD, so the dwell looks straight at it
+
+// [title, x, skills] — three columns, tight enough to all sit in frame at the dwell.
+const CLUSTERS: ReadonlyArray<readonly [string, number, readonly string[]]> = [
+  ["AI & AGENTIC", -10.5, ["LLM Integration", "RAG · Vector Search", "Agentic Workflows", "Prompt Engineering", "Streaming Gen", "AI Coding Agents"]],
+  ["FRONTEND", 0, ["React 19", "TypeScript", "Next.js", "TanStack Query", "Zustand · Redux-Saga", "Tailwind · MUI"]],
+  ["ARCHITECTURE", 10.5, ["Monorepos · Turbo", "Node · SQLite", "REST · WebSocket", "Tauri Desktop", "Vitest · Jest", "CI/CD · GH Actions"]],
+];
+
+function Cluster({ title, x, skills }: { title: string; x: number; skills: readonly string[] }) {
+  const bottom = SKILL0 - (skills.length - 1) * LINE - 0.9;
+  return (
+    <group position={[x, 0, 0]}>
+      {/* accent plumb line down the column */}
+      <Line points={[[0, TOP - 1, 0], [0, bottom, 0]]} color={CYAN} lineWidth={1} transparent opacity={0.35} toneMapped={false} />
+      <Text position={[0, TOP, 0]} fontSize={1.05} color={CYAN} anchorX="center" anchorY="middle" outlineWidth={0.03} outlineColor="#05060a">
+        {title}
+      </Text>
+      {skills.map((s, i) => (
+        <Text key={s} position={[0, SKILL0 - i * LINE, 0]} fontSize={0.6} color={DIM} anchorX="center" anchorY="middle" outlineWidth={0.015} outlineColor="#05060a">
+          {s}
+        </Text>
+      ))}
+    </group>
+  );
+}
+
+export function SkillsScene() {
+  return (
+    // Dropped in Y so the columns sit centred in frame (the camera looks below the scene origin
+    // here) rather than crowding the top edge.
+    <group position={[0, -5, AHEAD]}>
+      {CLUSTERS.map(([title, x, skills]) => (
+        <Cluster key={title} title={title} x={x} skills={skills} />
+      ))}
+    </group>
+  );
+}

--- a/scenes/05-skills/SkillsScene.tsx
+++ b/scenes/05-skills/SkillsScene.tsx
@@ -24,16 +24,16 @@ const CLUSTERS: ReadonlyArray<readonly [string, number, readonly string[]]> = [
 ];
 
 function Cluster({ title, x, skills }: { title: string; x: number; skills: readonly string[] }) {
-  const bottom = SKILL0 - (skills.length - 1) * LINE - 0.9;
+  const bottom = SKILL0 - (skills.length - 1) * LINE - 0.9; // last skill y, plus foot padding
   return (
     <group position={[x, 0, 0]}>
-      {/* accent plumb line down the column */}
+      {/* accent plumb line, from just under the heading down past the last skill */}
       <Line points={[[0, TOP - 1, 0], [0, bottom, 0]]} color={CYAN} lineWidth={1} transparent opacity={0.35} toneMapped={false} />
       <Text position={[0, TOP, 0]} fontSize={1.05} color={CYAN} anchorX="center" anchorY="middle" outlineWidth={0.03} outlineColor="#05060a">
         {title}
       </Text>
       {skills.map((s, i) => (
-        <Text key={s} position={[0, SKILL0 - i * LINE, 0]} fontSize={0.6} color={DIM} anchorX="center" anchorY="middle" outlineWidth={0.015} outlineColor="#05060a">
+        <Text key={i} position={[0, SKILL0 - i * LINE, 0]} fontSize={0.6} color={DIM} anchorX="center" anchorY="middle" outlineWidth={0.015} outlineColor="#05060a">
           {s}
         </Text>
       ))}


### PR DESCRIPTION
Replaces the SKILLS wireframe placeholder with the second real content scene.

## What
Three skill clusters from the CV as **heading + plumb-list columns**:
- **AI & AGENTIC** — LLM Integration · RAG · Vector Search · Agentic Workflows · Prompt Engineering · Streaming Gen · AI Coding Agents
- **FRONTEND** — React 19 · TypeScript · Next.js · TanStack Query · Zustand · Redux-Saga · Tailwind · MUI
- **ARCHITECTURE** — Monorepos · Node · SQLite · REST · WebSocket · Tauri · Vitest/Jest · CI/CD

Deliberately a different motif from ABOUT's radial hub (its co-mounted neighbour) so the two read as distinct beats. Same screen-cyan.

## Framing
SKILLS' scroll region is narrow (weight 1), so its approach happens mostly during ABOUT's active window. Placing content at the origin meant the camera had already flown past it by the time SKILLS was active. Fix: push the whole cluster **ahead to the camera's look-target** (`z ≈ -LOOK_AHEAD`) and drop it in Y — lands it framed dead-centre during the dwell. Columns kept compact in x so all three fit.

## Notes
- drei `<Text>` / `<Line>`; content inline (`CLUSTERS`); no autonomous animation → reduced-motion safe.
- Wired into `SceneManager` by id (`05-skills`).

## Verification
tsc + lint + `next build` green; browser-verified (~480fps, no console errors, all three columns framed and readable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Skills scene with three 3D skill clusters and styled text elements.
  * The app now shows the Skills scene when the corresponding scene entry is selected, instead of a placeholder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->