### PR TITLE
OPEN SOURCE scene: 2x2 project cards (real CV content)

### DIFF
--- a/components/SceneManager.tsx
+++ b/components/SceneManager.tsx
@@ -10,6 +10,7 @@ import { DeskScene } from "@/scenes/02-desk/DeskScene";
 import { EnterMonitorScene } from "@/scenes/03-enter-monitor/EnterMonitorScene";
 import { AboutScene } from "@/scenes/04-about/AboutScene";
 import { SkillsScene } from "@/scenes/05-skills/SkillsScene";
+import { OpenSourceScene } from "@/scenes/06-open-source/OpenSourceScene";
 import { curve } from "@/lib/spline";
 
 // Real scene Components wired by registry id. Kept here — inside the Canvas-only, dynamically
@@ -21,6 +22,7 @@ const SCENE_COMPONENTS: Partial<Record<string, FC<SceneComponentProps>>> = {
   "03-enter-monitor": EnterMonitorScene,
   "04-about": AboutScene,
   "05-skills": SkillsScene,
+  "06-open-source": OpenSourceScene,
 };
 
 // Static per-scene placement on the spline, computed once (the curve never changes). Each

--- a/scenes/06-open-source/OpenSourceScene.tsx
+++ b/scenes/06-open-source/OpenSourceScene.tsx
@@ -1,0 +1,66 @@
+"use client";
+import { Text, Line } from "@react-three/drei";
+
+// OPEN SOURCE — the four projects as a 2x2 grid of wireframe cards (name · tech · blurb · repo). Its
+// scene centre sits at a hard ~25° camera bank, so the grid is anchored to the camera's measured
+// look-target pose at the dwell (ANCHOR) and counter-rolled (ROLL) — otherwise it flies past tilted
+// and half-off-frame. Measured off the spline+whip+bank at the scene centre. Content edits inline.
+const CYAN = "#8fd4ff";
+const DIM = "#a9c6da";
+const FAINT = "#6f97b5";
+const ANCHOR: [number, number, number] = [0, 1.98, -15.88]; // camera look-target, scene-local
+const ROLL = 0.4452; // camera roll at the dwell — counter-rotate to level the cards
+
+const CARD_W = 9.8;
+const CARD_H = 6.2;
+
+// closed rectangle outline in the XY plane
+const rect = (w: number, h: number): [number, number, number][] => {
+  const x = w / 2;
+  const y = h / 2;
+  return [
+    [-x, -y, 0],
+    [x, -y, 0],
+    [x, y, 0],
+    [-x, y, 0],
+    [-x, -y, 0],
+  ];
+};
+
+type Project = { name: string; tech: string; desc: string; repo: string; pos: [number, number] };
+const PROJECTS: readonly Project[] = [
+  { name: "AI Job Hunter", tech: "Tauri · React 19 · TypeScript", desc: "Local-first AI job-hunting desktop app. Multi-LLM, RAG job matching, streaming resume / cover-letter, ATS scoring, agentic Autopilot.", repo: "↗ /ai-job-hunter-app", pos: [-5.5, 3.6] },
+  { name: "AI Engineering Hub", tech: "React · TanStack · REST + WebSocket", desc: "Local-first ops platform unifying AI-coding-tool metrics. Real-time API, dimensional analytics, Stream Deck plugin.", repo: "↗ /ai-engineering-hub", pos: [5.5, 3.6] },
+  { name: "Claude Usage", tech: "Stream Deck · TypeScript · Node", desc: "Live Claude usage & limits. OAuth usage API, JSONL transcript parsing, dynamic SVG keys, OS keychain.", repo: "↗ /claude-usage-streamdeck-plugin", pos: [-5.5, -3.6] },
+  { name: "Token Savings", tech: "Stream Deck · TypeScript · Node", desc: "Tracks AI-coding token savings. Measured-vs-estimated accounting, multi-project aggregation, SVG dashboards.", repo: "↗ /tokensaver-streamdeck-plugin", pos: [5.5, -3.6] },
+];
+
+function Card({ name, tech, desc, repo, pos }: Project) {
+  return (
+    <group position={[pos[0], pos[1], 0]}>
+      <Line points={rect(CARD_W, CARD_H)} color={CYAN} lineWidth={1} transparent opacity={0.4} toneMapped={false} />
+      <Text position={[0, CARD_H / 2 - 0.95, 0]} fontSize={0.62} color={CYAN} anchorX="center" anchorY="middle" outlineWidth={0.02} outlineColor="#05060a">
+        {name}
+      </Text>
+      <Text position={[0, CARD_H / 2 - 1.7, 0]} fontSize={0.34} color={FAINT} anchorX="center" anchorY="middle" letterSpacing={0.03}>
+        {tech}
+      </Text>
+      <Text position={[0, 0.1, 0]} fontSize={0.38} color={DIM} maxWidth={CARD_W - 1.2} textAlign="center" anchorX="center" anchorY="middle" lineHeight={1.28}>
+        {desc}
+      </Text>
+      <Text position={[0, -CARD_H / 2 + 0.7, 0]} fontSize={0.36} color={FAINT} anchorX="center" anchorY="middle">
+        {repo}
+      </Text>
+    </group>
+  );
+}
+
+export function OpenSourceScene() {
+  return (
+    <group position={ANCHOR} rotation={[0, 0, ROLL]}>
+      {PROJECTS.map((p) => (
+        <Card key={p.name} {...p} />
+      ))}
+    </group>
+  );
+}

--- a/scenes/06-open-source/OpenSourceScene.tsx
+++ b/scenes/06-open-source/OpenSourceScene.tsx
@@ -8,6 +8,8 @@ import { Text, Line } from "@react-three/drei";
 const CYAN = "#8fd4ff";
 const DIM = "#a9c6da";
 const FAINT = "#6f97b5";
+// ANCHOR/ROLL are measured off the spline+whip+bank at the scene centre — re-measure if the spline,
+// scene WEIGHTS (registry), or CameraRig bank change, or the cards drift off-centre / re-tilt.
 const ANCHOR: [number, number, number] = [0, 1.98, -15.88]; // camera look-target, scene-local
 const ROLL = 0.4452; // camera roll at the dwell — counter-rotate to level the cards
 


### PR DESCRIPTION
Replaces the OPEN SOURCE placeholder with the third real content scene.

## What
The four projects as a **2×2 grid of wireframe cards** (name · tech · one-liner · repo):
- **AI Job Hunter** — Tauri · React 19 · TS → /ai-job-hunter-app
- **AI Engineering Hub** — React · TanStack · REST+WS → /ai-engineering-hub
- **Claude Usage** — Stream Deck · TS · Node → /claude-usage-streamdeck-plugin
- **Token Savings** — Stream Deck · TS · Node → /tokensaver-streamdeck-plugin

## Framing (the interesting bit)
This scene's centre sits at a **hard ~25° camera bank** (SKILLS' was 0.6°, which is why it framed clean with a simple z-offset). A naive layout flew past tilted and half off-frame. Fix: anchor the grid to the camera's **measured look-target pose** at the dwell (`ANCHOR = [0, 1.98, -15.88]`) and **counter-roll** it (`ROLL = 0.4452`) — same technique as the DESK monitor's `revealAnchor`. Result: level, centered, all four cards readable.

## Notes
- drei `<Text>` / `<Line>`; content inline (`PROJECTS`); no autonomous animation → reduced-motion safe.
- Wired into `SceneManager` by id (`06-open-source`).
- Anchor values are measured off the current spline+whip+bank; re-measure if pacing/spline/bank changes (per the scene-pacing memory).

## Verification
tsc + lint + `next build` green; browser-verified (~480fps, no console errors, cards level + framed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)