### PR TITLE
STREAMING scene + shared useLevelRoll hook

### DIFF
--- a/components/SceneManager.tsx
+++ b/components/SceneManager.tsx
@@ -12,6 +12,7 @@ import { AboutScene } from "@/scenes/04-about/AboutScene";
 import { SkillsScene } from "@/scenes/05-skills/SkillsScene";
 import { OpenSourceScene } from "@/scenes/06-open-source/OpenSourceScene";
 import { TimelineScene } from "@/scenes/07-timeline/TimelineScene";
+import { StreamingScene } from "@/scenes/08-streaming/StreamingScene";
 import { curve } from "@/lib/spline";
 
 // Real scene Components wired by registry id. Kept here — inside the Canvas-only, dynamically
@@ -25,6 +26,7 @@ const SCENE_COMPONENTS: Partial<Record<string, FC<SceneComponentProps>>> = {
   "05-skills": SkillsScene,
   "06-open-source": OpenSourceScene,
   "07-timeline": TimelineScene,
+  "08-streaming": StreamingScene,
 };
 
 // Static per-scene placement on the spline, computed once (the curve never changes). Each

--- a/lib/useLevelRoll.ts
+++ b/lib/useLevelRoll.ts
@@ -1,0 +1,33 @@
+"use client";
+import { useRef } from "react";
+import { useFrame } from "@react-three/fiber";
+import { Group, Vector3 } from "three";
+
+const WORLD_UP = new Vector3(0, 1, 0);
+
+// Returns a group ref that, each frame, cancels the camera's roll about its view axis so the group's
+// content stays level in view. For content scenes sitting on hard/fast-banking spline sections where
+// a static counter-roll only levels one instant. It reads the ACTUAL camera roll, so it self-corrects
+// for whatever bank remains — including under reduced motion, where CameraRig only DAMPS the bank to
+// 25% (it does not disable it). Do NOT gate this on reducedMotion. No per-frame allocation.
+export function useLevelRoll() {
+  const ref = useRef<Group>(null);
+  const fwd = useRef(new Vector3()).current;
+  const right = useRef(new Vector3()).current;
+  const levelRight = useRef(new Vector3()).current;
+  const cross = useRef(new Vector3()).current;
+
+  useFrame((state) => {
+    if (!ref.current) return;
+    const cam = state.camera;
+    cam.getWorldDirection(fwd);
+    levelRight.crossVectors(fwd, WORLD_UP); // where "right" points with zero roll
+    if (levelRight.lengthSq() < 1e-8) return; // fwd ∥ up — can't happen on this spline, but avoid NaN
+    levelRight.normalize();
+    right.set(1, 0, 0).applyQuaternion(cam.quaternion); // camera's actual right
+    const sin = cross.crossVectors(levelRight, right).dot(fwd);
+    ref.current.rotation.z = -Math.atan2(sin, levelRight.dot(right));
+  });
+
+  return ref;
+}

--- a/scenes/07-timeline/TimelineScene.tsx
+++ b/scenes/07-timeline/TimelineScene.tsx
@@ -1,25 +1,18 @@
 "use client";
-import { useRef } from "react";
-import { useFrame } from "@react-three/fiber";
 import { Text, Line } from "@react-three/drei";
-import { Group, Vector3 } from "three";
+import { useLevelRoll } from "@/lib/useLevelRoll";
 
 // TIMELINE — the career as a horizontal spine of dated milestones (oldest → newest, labels
-// alternating above/below), with education + languages beneath. Content edits inline.
-//
-// This spline section banks HARD and FAST (±34° across the region), so a static counter-roll only
-// levels one instant. Instead we read the camera's *current* roll each frame and cancel it, keeping
-// the spine horizontal throughout the fly-through. It reads the ACTUAL camera roll, so it self-
-// corrects for whatever bank remains — including under reduced motion, where CameraRig damps the
-// bank to 25% (not off, see CameraRig bankLimit). Do NOT gate this on reducedMotion.
+// alternating above/below), with education + languages beneath. This spline section banks HARD and
+// FAST (±34° across the region), so the group is levelled per-frame by useLevelRoll — a static
+// counter-roll would only level one instant. Content edits inline.
 const CYAN = "#8fd4ff";
 const DIM = "#a9c6da";
 const FAINT = "#6f97b5";
 
-// Look-target pose at the dwell (measured off spline+whip); re-measure if the spline or scene
-// WEIGHTS (registry) change. Roll is handled dynamically below, not here.
+// Look-target position at the dwell (measured off spline+whip); re-measure if the spline or scene
+// WEIGHTS (registry) change. Roll is handled dynamically by useLevelRoll, not here.
 const ANCHOR: [number, number, number] = [0, 7.71, -14.02];
-const WORLD_UP = new Vector3(0, 1, 0);
 
 const SPINE = 15; // half-length of the horizontal spine line
 
@@ -54,25 +47,7 @@ function Milestone({ company, role, dates, x, above }: Job) {
 }
 
 export function TimelineScene() {
-  const root = useRef<Group>(null);
-  const fwd = useRef(new Vector3()).current;
-  const right = useRef(new Vector3()).current;
-  const levelRight = useRef(new Vector3()).current;
-  const cross = useRef(new Vector3()).current;
-
-  // Cancel the camera's roll about its view axis so the spine stays level (no per-frame allocation).
-  useFrame((state) => {
-    if (!root.current) return;
-    const cam = state.camera;
-    cam.getWorldDirection(fwd);
-    levelRight.crossVectors(fwd, WORLD_UP); // where "right" points with zero roll
-    if (levelRight.lengthSq() < 1e-8) return; // fwd ∥ up — can't happen on this spline, but avoid NaN
-    levelRight.normalize();
-    right.set(1, 0, 0).applyQuaternion(cam.quaternion); // camera's actual right
-    const sin = cross.crossVectors(levelRight, right).dot(fwd);
-    root.current.rotation.z = -Math.atan2(sin, levelRight.dot(right));
-  });
-
+  const root = useLevelRoll();
   return (
     <group ref={root} position={ANCHOR}>
       <Text position={[0, 4.6, 0]} fontSize={1} color={CYAN} anchorX="center" anchorY="middle" outlineWidth={0.03} outlineColor="#05060a" letterSpacing={0.15}>

--- a/scenes/08-streaming/StreamingScene.tsx
+++ b/scenes/08-streaming/StreamingScene.tsx
@@ -1,0 +1,64 @@
+"use client";
+import { useRef } from "react";
+import { useFrame } from "@react-three/fiber";
+import { Text } from "@react-three/drei";
+import type { Mesh } from "three";
+import { useScrollStore } from "@/lib/scrollStore";
+import { useLevelRoll } from "@/lib/useLevelRoll";
+
+// STREAMING — an LLM "generating" a profile of Saeed: a prompt, then the response streams in token by
+// token with a cursor, looping. Reinforces the streaming-generation skill. Sits on a hard-banking
+// spline section, so the group is levelled per-frame (useLevelRoll). Content edits inline.
+const CYAN = "#8fd4ff";
+const DIM = "#cfe4f2";
+const FAINT = "#6f97b5";
+
+const ANCHOR: [number, number, number] = [0, 4.02, -15.49]; // camera look-target at the dwell (measured)
+const LEFT = -11; // left margin for the terminal-style block
+const RATE = 11; // tokens revealed per second
+const HOLD = 24; // tokens-worth of pause at full before looping (~1.8s at RATE)
+
+const PROMPT = "▸ describe: Saeed Kolivand";
+const RESPONSE =
+  "Senior Frontend Engineer building AI-native, local-first software — multi-LLM integration, RAG semantic search, agentic automation, and streaming generation. Clean front-end architecture, premium UI, 6+ years of React · Next · TypeScript.";
+const WORDS = RESPONSE.split(" ");
+
+type TextMesh = Mesh & { text: string; sync: () => void };
+
+export function StreamingScene() {
+  const root = useLevelRoll();
+  const body = useRef<TextMesh>(null);
+  const acc = useRef(0);
+  const shown = useRef(-1);
+
+  // Reveal the response token by token off a clock, imperatively (no React re-render / no allocation).
+  useFrame((_, delta) => {
+    if (!body.current) return;
+    let count: number;
+    if (useScrollStore.getState().reducedMotion) {
+      count = WORDS.length; // no animation: show the whole response
+    } else {
+      acc.current += delta * RATE;
+      if (acc.current > 1e7) acc.current = 0; // keep the float bounded
+      count = Math.min(WORDS.length, Math.floor(acc.current % (WORDS.length + HOLD)));
+    }
+    if (count === shown.current) return;
+    shown.current = count;
+    body.current.text = WORDS.slice(0, count).join(" ") + (count < WORDS.length ? " ▋" : "");
+    body.current.sync();
+  });
+
+  return (
+    <group ref={root} position={ANCHOR}>
+      <Text position={[LEFT, 3.4, 0]} fontSize={0.62} color={CYAN} anchorX="left" anchorY="middle" outlineWidth={0.02} outlineColor="#05060a">
+        {PROMPT}
+      </Text>
+      <Text ref={body} position={[LEFT, 2.2, 0]} fontSize={0.72} color={DIM} anchorX="left" anchorY="top" maxWidth={22} textAlign="left" lineHeight={1.35}>
+        {""}
+      </Text>
+      <Text position={[LEFT, -4, 0]} fontSize={0.36} color={FAINT} anchorX="left" anchorY="middle" letterSpacing={0.05}>
+        streaming generation · token by token
+      </Text>
+    </group>
+  );
+}

--- a/scenes/08-streaming/StreamingScene.tsx
+++ b/scenes/08-streaming/StreamingScene.tsx
@@ -16,7 +16,7 @@ const FAINT = "#6f97b5";
 const ANCHOR: [number, number, number] = [0, 4.02, -15.49]; // camera look-target at the dwell (measured)
 const LEFT = -11; // left margin for the terminal-style block
 const RATE = 11; // tokens revealed per second
-const HOLD = 24; // tokens-worth of pause at full before looping (~1.8s at RATE)
+const HOLD = 24; // tokens-worth of pause at full before looping (~2.2s at RATE)
 
 const PROMPT = "▸ describe: Saeed Kolivand";
 const RESPONSE =
@@ -31,7 +31,8 @@ export function StreamingScene() {
   const acc = useRef(0);
   const shown = useRef(-1);
 
-  // Reveal the response token by token off a clock, imperatively (no React re-render / no allocation).
+  // Reveal the response token by token off a clock, imperatively (no React re-render; allocates a
+  // string only when a token is added, never on the hot path).
   useFrame((_, delta) => {
     if (!body.current) return;
     let count: number;
@@ -53,6 +54,8 @@ export function StreamingScene() {
       <Text position={[LEFT, 3.4, 0]} fontSize={0.62} color={CYAN} anchorX="left" anchorY="middle" outlineWidth={0.02} outlineColor="#05060a">
         {PROMPT}
       </Text>
+      {/* children MUST stay constant "" — we own .text imperatively above; a changing child would
+          make R3F diff `text` and clobber the stream every re-render. */}
       <Text ref={body} position={[LEFT, 2.2, 0]} fontSize={0.72} color={DIM} anchorX="left" anchorY="top" maxWidth={22} textAlign="left" lineHeight={1.35}>
         {""}
       </Text>


### PR DESCRIPTION
Fifth real scene, plus a small refactor.

## STREAMING
An LLM "generating" a profile of Saeed: a prompt (`▸ describe: Saeed Kolivand`), then the response streams in **token by token** with a cursor, looping. Reinforces the streaming-generation skill.
- Imperative troika text update in `useFrame` (set `.text` + `.sync()` only when the token count changes) — no React re-render, no per-frame allocation.
- Reduced motion → shows the full response, no animation.
- Streaming loop confirmed via a temporary console trace (count cycles 0→N→reset).

## Refactor: `lib/useLevelRoll`
TIMELINE added an inline per-frame roll-canceller for hard-banking spline sections. STREAMING sits on another one (+34° at center, swinging), so — now that there are 2 uses — I extracted that logic into `useLevelRoll()`: reads the camera's actual roll each frame and levels the group. Self-corrects under reduced motion (where CameraRig only damps the bank to 25%, not off). `TimelineScene` refactored onto the hook (behavior unchanged, verified still level).

## Notes
- drei `<Text>` / `<Line>`; content inline; wired into `SceneManager` by id (`08-streaming`).
- Anchor position measured at the dwell; roll handled by the hook.

## Verification
tsc + lint + `next build` green; browser-verified (~470fps, level, no console errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)