### PR TITLE
SPACE scene: cosmic breather (glowing star + orbital rings)

### DIFF
--- a/components/SceneManager.tsx
+++ b/components/SceneManager.tsx
@@ -14,6 +14,7 @@ import { OpenSourceScene } from "@/scenes/06-open-source/OpenSourceScene";
 import { TimelineScene } from "@/scenes/07-timeline/TimelineScene";
 import { StreamingScene } from "@/scenes/08-streaming/StreamingScene";
 import { ArchitectureScene } from "@/scenes/09-architecture/ArchitectureScene";
+import { SpaceScene } from "@/scenes/10-space/SpaceScene";
 import { curve } from "@/lib/spline";
 
 // Real scene Components wired by registry id. Kept here — inside the Canvas-only, dynamically
@@ -29,6 +30,7 @@ const SCENE_COMPONENTS: Partial<Record<string, FC<SceneComponentProps>>> = {
   "07-timeline": TimelineScene,
   "08-streaming": StreamingScene,
   "09-architecture": ArchitectureScene,
+  "10-space": SpaceScene,
 };
 
 // Static per-scene placement on the spline, computed once (the curve never changes). Each

--- a/scenes/10-space/SpaceScene.tsx
+++ b/scenes/10-space/SpaceScene.tsx
@@ -1,0 +1,56 @@
+"use client";
+import { useRef } from "react";
+import { useFrame } from "@react-three/fiber";
+import { AdditiveBlending, Group, Mesh } from "three";
+import { useScrollStore } from "@/lib/scrollStore";
+
+// SPACE — a quiet atmospheric breather between the ARCHITECTURE diagram and the TERMINAL closer: a
+// glowing star with slow, tilted orbital rings. Radially symmetric, so no leveling needed — just the
+// look-target anchor. All idle motion (spin + core pulse) is gated on reduced motion.
+const CYAN = "#8fd4ff";
+const PALE = "#bfe6ff";
+const ANCHOR: [number, number, number] = [0, 1.93, -15.88]; // look-target at the dwell (measured)
+
+export function SpaceScene() {
+  const rings = useRef<Group>(null);
+  const core = useRef<Mesh>(null);
+
+  useFrame((state, delta) => {
+    if (useScrollStore.getState().reducedMotion) return;
+    if (rings.current) {
+      rings.current.rotation.y += delta * 0.09;
+      rings.current.rotation.x += delta * 0.035;
+    }
+    if (core.current) core.current.scale.setScalar(1 + Math.sin(state.clock.elapsedTime * 0.8) * 0.12);
+  });
+
+  return (
+    <group position={ANCHOR}>
+      {/* glowing star core + soft halo (additive → blooms rather than occludes) */}
+      <mesh ref={core}>
+        <sphereGeometry args={[1.4, 32, 32]} />
+        <meshBasicMaterial color={PALE} toneMapped={false} />
+      </mesh>
+      <mesh scale={2.6}>
+        <sphereGeometry args={[1.4, 24, 24]} />
+        <meshBasicMaterial color={CYAN} transparent opacity={0.08} blending={AdditiveBlending} depthWrite={false} toneMapped={false} />
+      </mesh>
+
+      {/* slow, tilted orbital rings */}
+      <group ref={rings}>
+        <mesh rotation={[Math.PI / 2.2, 0, 0]}>
+          <torusGeometry args={[5, 0.03, 10, 96]} />
+          <meshBasicMaterial color={CYAN} transparent opacity={0.35} toneMapped={false} />
+        </mesh>
+        <mesh rotation={[Math.PI / 2.6, 0.6, 0.3]}>
+          <torusGeometry args={[6.6, 0.025, 10, 96]} />
+          <meshBasicMaterial color={CYAN} transparent opacity={0.24} toneMapped={false} />
+        </mesh>
+        <mesh rotation={[Math.PI / 1.8, -0.5, 0.2]}>
+          <torusGeometry args={[8.2, 0.02, 10, 96]} />
+          <meshBasicMaterial color={PALE} transparent opacity={0.16} toneMapped={false} />
+        </mesh>
+      </group>
+    </group>
+  );
+}

--- a/scenes/10-space/SpaceScene.tsx
+++ b/scenes/10-space/SpaceScene.tsx
@@ -5,11 +5,14 @@ import { AdditiveBlending, Group, Mesh } from "three";
 import { useScrollStore } from "@/lib/scrollStore";
 
 // SPACE — a quiet atmospheric breather between the ARCHITECTURE diagram and the TERMINAL closer: a
-// glowing star with slow, tilted orbital rings. Radially symmetric, so no leveling needed — just the
-// look-target anchor. All idle motion (spin + core pulse) is gated on reduced motion.
+// glowing star with slow, tilted orbital rings. The composition has no expected upright (the rings
+// tumble freely), so no leveling is needed — just the look-target anchor. All idle motion (spin +
+// core pulse) is gated on reduced motion.
 const CYAN = "#8fd4ff";
 const PALE = "#bfe6ff";
-const ANCHOR: [number, number, number] = [0, 1.93, -15.88]; // look-target at the dwell (measured)
+// Look-target at the dwell, measured off spline+whip; re-measure if the spline, scene WEIGHTS
+// (registry), or CameraRig bank change.
+const ANCHOR: [number, number, number] = [0, 1.93, -15.88];
 
 export function SpaceScene() {
   const rings = useRef<Group>(null);


### PR DESCRIPTION
Seventh real scene — the atmospheric breather.

## What
A quiet beat between the ARCHITECTURE diagram and the TERMINAL closer: a glowing **star core** + soft additive **halo**, wrapped by three slow, tilted **orbital rings**. Deliberately *not* the placeholder wireframe-cage look, so it reads as a cosmic pause.

## Notes
- Radially symmetric → no leveling needed; positioned at the measured look-target anchor.
- Idle spin + core pulse gated on `reducedMotion`; no per-frame allocation (scalar rotation/`setScalar`).
- All JSX geometry/material (sphere, torus) → auto-disposed via SceneShell. Wired into `SceneManager` by id (`10-space`).

## Verification
tsc + lint + `next build` green; browser-verified (~415fps, no console errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)