### PR TITLE
Infra: on-demand Claude PR reviewer + graph MCP registration

### DIFF
--- a/.claude/agents/issue-builder.md
+++ b/.claude/agents/issue-builder.md
@@ -2,7 +2,7 @@
 name: issue-builder
 description: Builds or modifies a scene ("issue"), camera/shot list, or engine module of the PANEL JUMP comic portfolio per its SPEC.md section. MUST BE USED for any scene, set, shot, registry, camera-system, or engine-module implementation work. Not for GLSL (shader-engineer) or gates (gate-auditor).
 model: fable
-tools: Read, Write, Edit, Glob, Grep, Bash
+tools: Read, Write, Edit, Glob, Grep, Bash, mcp__codegraph__*, mcp__graphify__*
 skills: panel-jump-conventions
 ---
 
@@ -17,7 +17,7 @@ Hard rules (verified 2026-07-02 against current docs):
 - A numeric useFrame priority disables R3F auto-render; only PostPipeline owns priority 1. Animation useFrames stay at default 0 (r3f.docs.pmnd.rs/api/hooks).
 - Read scroll state in the loop via useScrollStore.getState() — never a hook selector for per-frame values (r3f.docs.pmnd.rs/advanced/pitfalls).
 - MeshToonMaterial gradientMap: NearestFilter min+mag, NoColorSpace — use lib/toon.ts toonRamp() (threejs.org/docs MeshToonMaterial, r185).
-- InstancedMesh colors: setColorAt() then instanceColor.needsUpdate = true (three r185 source).
+- InstancedMesh colors: setColorAt() then instanceColor.needsUpdate = true; matrices: setMatrixAt() then instanceMatrix.needsUpdate = true. instanceColor is null until the first setColorAt, and unset instances render WHITE - set every instance (three r185 source, verified 2026-07-02).
 - Everything scroll-driven is a pure function of t (scrub-safe); authored-time motion goes through the beat engine (lib/beats.ts) only.
 - Non-ASCII characters in source files are banned (Turbopack rope bug, DECISIONS.md 2026-07-02).
 - Comfort rule S2.16: zero channel separation, ghosting, or blur on readable content, anywhere.

--- a/.claude/agents/perf-profiler.md
+++ b/.claude/agents/perf-profiler.md
@@ -2,7 +2,7 @@
 name: perf-profiler
 description: Profiles PANEL JUMP frame rate and owns the S0.6 degradation ladder. MUST BE USED when a trace or FPS number is below target, or when a gate needs before/after perf evidence. Applies ladder rungs in order and stops at the first passing rung.
 model: opus
-tools: Read, Write, Edit, Glob, Grep, Bash, mcp__chrome-devtools__*
+tools: Read, Write, Edit, Glob, Grep, Bash, mcp__chrome-devtools__*, mcp__codegraph__*
 ---
 
 You measure first, then apply the S0.6 perf ladder IN ORDER, one rung at a

--- a/.claude/agents/shader-engineer.md
+++ b/.claude/agents/shader-engineer.md
@@ -2,7 +2,7 @@
 name: shader-engineer
 description: Writes and fixes all GLSL for PANEL JUMP - postprocessing Effects, print recipes, transition shaders, onBeforeCompile patches, comfort-rule compliance. MUST BE USED for any shader, post pass, or transition-effect work. Not for scene layout (issue-builder).
 model: fable
-tools: Read, Write, Edit, Glob, Grep, Bash
+tools: Read, Write, Edit, Glob, Grep, Bash, mcp__codegraph__*
 skills: panel-jump-conventions
 ---
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,20 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__codegraph__*",
+      "mcp__graphify__*"
+    ]
+  },
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "codegraph prompt-hook"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,72 @@
+name: Claude Review (on demand)
+
+# ----------------------------------------------------------------------
+# AI review, ON-DEMAND ONLY (mirrors ai-job-hunter-assistant-app lane A1).
+# Runs ONLY when the repository owner comments "@claude review" on a PR.
+# Nothing automatic - not on open, not on push.
+#
+# Auth: a CLAUDE_CODE_OAUTH_TOKEN secret generated locally with
+#   `claude setup-token` (subscription quota, no per-token API bill).
+#   Until that secret is added, this workflow is inert.
+#   Do NOT also add ANTHROPIC_API_KEY - if both exist, the API key wins
+#   and usage is billed per-token instead of drawing on the subscription.
+#
+# Security (public repo): the `if:` gate restricts triggering to the repo
+# owner with an exact phrase, so strangers cannot drain quota or
+# prompt-inject. Permissions are least-privilege (no contents write).
+# ----------------------------------------------------------------------
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+# cancel-in-progress MUST stay false: while a review runs, claude[bot] posts
+# a "working..." comment, which is itself an issue_comment event that starts
+# a second run in this same group. With cancel-in-progress: true that second
+# run cancels the real review mid-flight. false lets the real review finish;
+# the bot-comment run just queues and is then skipped by the gate.
+concurrency:
+  group: claude-review-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  claude-review:
+    name: Claude Review
+    if: >
+      ((github.event_name == 'issue_comment' && github.event.issue.pull_request != null) ||
+      github.event_name == 'pull_request_review_comment') &&
+      contains(github.event.comment.body, '@claude review') &&
+      github.event.comment.user.login == github.repository_owner
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout Repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude review
+        uses: anthropics/claude-code-action@6c0083bb7289c31716797a039b6367b3079cc46e # v1.0.162
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # NO `prompt` on purpose: a prompt forces automation mode, where the
+          # inline-comment tools are DENIED. The "@claude review" mention runs
+          # the action in TAG mode, which grants the comment tools.
+          # `--append-system-prompt` injects PANEL JUMP review standards
+          # WITHOUT flipping to automation mode.
+          claude_args: |
+            --model claude-opus-4-8
+            --append-system-prompt "Review this pull request for PANEL JUMP (a comic-book scroll-driven portfolio). SPEC.md S0/S2/S5/S5b are law; review ONLY the changed files against the locked contract: scroll-driven state is a pure function of the timeline t (useScrollStore.getState() in useFrame, never hook selectors for per-frame values); authored-time motion goes through lib/beats.ts only, with any flash gated by requestFlash(); S2.16 comfort rule - zero channel separation, ghosting, or blur on readable content; TransitionEffect is the post pass's single allowed CONVOLUTION effect; live render targets are budgeted at 3; source files are pure ASCII (Turbopack rope bug); lettering meant to stay readable lives in the post-exempt layer (DOM overlay or Hud renderPriority 2plus). Severity: only HIGH or CRITICAL are blocking (S2.16 comfort violations, flash-budget bypasses, scrub non-determinism, non-ASCII source, RT-budget or perf-ladder regressions, broken engine contracts); everything else is advisory. Post findings as inline comments on the changed lines. Be advisory only; do not approve or block the PR."

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,16 @@
+{
+  "mcpServers": {
+    "graphify": {
+      "command": "graphify-mcp",
+      "args": ["graphify-out/graph.json"]
+    },
+    "codegraph": {
+      "type": "stdio",
+      "command": "codegraph",
+      "args": [
+        "serve",
+        "--mcp"
+      ]
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Route (delegate, don't do):
 - FPS below target -> perf-profiler (owns the S0.6 ladder)
 - any API uncertainty -> docs-researcher BEFORE coding against it
 - copy / content.ts / Print Edition -> content-scribe
-- where is X / who calls X / what breaks if X changes -> `codegraph query|explore|node` (CLI - no MCP server registered; see DECISIONS 2026-07-02), never grep sweeps
-- how does the engine fit together / orient a new session -> `graphify query` / graphify-out/wiki
+- where is X / who calls X / what breaks if X changes -> codegraph MCP (mcp__codegraph__*; CLI `codegraph query|explore|node` as fallback), never grep sweeps
+- how does the engine fit together / orient a new session -> graphify MCP (mcp__graphify__*; CLI `graphify query` / graphify-out/wiki as fallback)
 
-Rules: bounded agent reports (<=20 lines); never ask the user (S0.7 only); log rulings with /decision; commit per phase; source files stay pure ASCII (Turbopack rope bug); refresh graphs after each phase commit (post-commit hook does it - verify it fired).
+Rules: bounded agent reports (<=20 lines); never ask the user (S0.7 only); log rulings with /decision; phase branch + PR per phase (never commit to main directly; after opening the PR, comment "@claude review" on it); source files stay pure ASCII (Turbopack rope bug); refresh graphs after each phase commit (post-commit hook does it - verify it fired).


### PR DESCRIPTION
Bootstrap PR - the "@claude review" workflow must live on the default branch before it can be triggered on any PR, so this lands ahead of the Phase 1 PR.

- `.github/workflows/claude-review.yml`: owner-gated on-demand review (comment "@claude review"), TAG mode, hardened runner, pinned action SHAs, PANEL JUMP review contract injected via `--append-system-prompt`. Uses the `CLAUDE_CODE_OAUTH_TOKEN` secret (already set).
- `.mcp.json`: codegraph + graphify project MCP servers (pending one-time approval in Claude Code).
- `.claude/settings.json` + agent allowlists: S0.11 graph-MCP access wiring (user-authorized 2026-07-02).
- `CLAUDE.md`: phase branch + PR + "@claude review" replaces direct commit-per-phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)