### PR TITLE
Phase 1: vertical slice - Cover + Noir + Desk + Neon fully real

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -108,3 +108,105 @@ pinned 5.9.3, an external edit bumped it - kept, builds clean),
   title-drop beat is authored.
 - Cover is a generic placeholder room; Phase 1 builds the real cover +
   attract mode.
+
+## 2026-07-02 - Phase 1
+
+- Phase 1 rulings batch: (1) CodeGraph DOES ship an MCP server (codegraph
+  install, v1.2.0) - registered via project .mcp.json (codegraph serve --mcp)
+  + .claude/settings.json permission/hook, 2026-07-02; pending user approval,
+  live next session; CLI via Bash remains the in-session path. Graphify
+  re-checked: no MCP server subcommand exists - CLI/skill ruling stands.
+  Adding mcp__codegraph__* to issue-builder/shader-engineer/perf-profiler
+  allowlists was DENIED by the permission classifier (self-modification) -
+  queued for user-approved edit. (2) TransitionEffect is now the pass's
+  single CONVOLUTION effect (whip directional smear, 8 dithered taps along
+  uWhipDir; crash-through mode 4); taps are pre-print, re-graded via
+  uSmearMono. (3) Color window = world-space rect via per-pixel depth
+  reconstruction (shaders/colorWindow.ts channel), zero RTs; mask-texture
+  option rejected to protect the RT budget of 3. (4) Crash-through chromatic
+  punch dropped - S2.16 bans channel separation; zoom punch is single-layer
+  resample. Missing cover snapshot falls back to flat cover-paper fragments
+  (same pattern as dot-zoom). (5) Timeline numbers moved to leaf
+  issues/timeline.ts (registry re-exports) so per-issue shots.ts import
+  ranges without an import cycle; plumbing touched SceneManager/ShotDirector/
+  fx/globals.css as required glue. (6) Neon recipe grain 0.06->0.03, paperTex
+  0.1->0.05: 10Hz grain flicker on max-contrast black edged toward strobe
+  (S2.16 tune). Reasoning: each is the simplest option that passes its gate
+  check under the locked S2/S5/S2.16 rules, logged per S0.1.
+- CORRECTION to (1), user-caught: Graphify DOES ship an MCP server - it is a
+  separate binary `graphify-mcp` (python -m graphify.serve, stdio/http), not
+  a `graphify` subcommand, which is why the --help sweep missed it. Registered
+  in .mcp.json pointed at graphify-out/graph.json (mirrors the working
+  ai-job-hunter-assistant-app config); pending user approval alongside
+  codegraph, live next session. CLI remains the in-session path. S0.11 agent
+  allowlist additions (mcp__graphify__* -> issue-builder) still queued behind
+  the same classifier denial as codegraph's.
+- User authorization 2026-07-02: the classifier-blocked edits were explicitly
+  approved and applied - mcp__codegraph__* added to issue-builder/
+  shader-engineer/perf-profiler tools, mcp__graphify__* to issue-builder,
+  both wildcards to .claude/settings.json permissions.allow. S0.11 agent
+  access is now fully wired (live once the user approves both .mcp.json
+  servers).
+- Workflow change (user directive, overrides S0.9 "commit per phase" to
+  main): every phase now lands as a phase branch + PR, reviewed on demand by
+  .github/workflows/claude-review.yml (clone of ai-job-hunter lane A1:
+  owner-only "@claude review" comment trigger, TAG mode, opus, PANEL JUMP
+  contract baked into --append-system-prompt). Inert until the
+  CLAUDE_CODE_OAUTH_TOKEN secret is set (claude setup-token). CLAUDE.md rules
+  line updated accordingly.
+- Wave 3 scene rulings (issue-builders, 2026-07-02): Cover is ONE compiled
+  shot (drift-then-crash ease) instead of hold+crash - compileSegments
+  hardcodes intra-issue gutters to whip, and whip smear over static readable
+  cover lettering breaks S2.16; cover lettering deliberately INSIDE the post
+  pipeline (spec-intended print look). Noir: shot-4 target racks cat->window
+  ease-in-cubic so the p~0.8 leap crosses frame (pose data only); rain dashes
+  + window glow are unlit meshBasicMaterial (flat ink, toon reserved for lit
+  surfaces); three 0.003 intra whip gutters carved from RANGES[1], S0.8
+  shares apply to the remaining span. Desk: THUMP/PADD words filtered from
+  the cat onomatopoeia pool instead of new content.ts entries (content-scribe
+  owns that file); RT PanelWall mounts/unmounts at whip cutPoints +/- margin
+  so render-target warm-up is never on-screen; low quality tier drops
+  keyboard RT (3->2 live RTs). Neon: beats.ts imports NEON_CASCADE_T from
+  issues/03-neon/shots.ts (single source of truth for the cascade trigger,
+  no cycle); cascade quantized to 10 radial rings as the "block-by-block on
+  2s" reading (scroll-space steps, not clock time). Package renamed
+  panel-jump -> saeed-kolivand-portfolio (user directive: match repo name);
+  lockfile regenerated, no dependency versions changed (S0.2 intact).
+
+### Phase 1 gate result (Chrome DevTools MCP, formal - no self-reported items)
+- Attempt 1: 10 PASS / 1 DEGRADED / 1 FAIL. Root cause of both failures:
+  noir dark-paper tonal wash (halftone/hatch mapped darkness->ink assuming
+  light paper; near-black subjects bleached to pale ink #F5F1E8).
+- Fix loop attempt 1 of 5 (3 parallel agents) + re-audit: ALL 12 CHECKS PASS,
+  no regressions. Highlights: slice 0-0.31 seamless both directions at
+  steady 60 FPS (worst frame 16.9ms); dot-zoom scrub-deterministic; title
+  drop authored ~1.1s velocity-independent with verified hysteresis re-arm;
+  3 live RTs at 59-60 FPS (single 33ms first-mount hitch, absent on repeat);
+  flash budget 2 gated impacts; onomatopoeia pool 0 frames >20ms over 5s of
+  CLACK oscillation; console clean. Phase 0 self-reported items (FPS trace,
+  beat timing) formally re-traced and closed: both PASS.
+- Fix rulings: (1) PrintEffect derives dark-paper polarity from uPaper
+  luminance in-shader (no recipe field; cross-fades smoothly; screentone/
+  press/pop/spread/terminal inherit correct polarity for free). (2) Noir
+  leap k-window 0.72-1.0 with flatter arc + shot-4 from-target moved to the
+  crouch spot (second latent cause: crouch dropped out of frame at p .75-.8);
+  "leaps at p~0.8" still canonically true. (3) Desk cat restaged at monitor
+  with full character pass; S6 asset prompt NOT queued (procedural reads as
+  deliberate). (4) Noir window figure = backlit dev silhouette; S6 upgrade
+  prompt queued at assets/prompts/noir-window-figure.md -> target
+  public/images/noir-window-figure.png (user generates at leisure).
+- User-directed post-gate, pre-commit (screenshot-verified): cover masthead
+  PANEL JUMP -> SAEED KOLIVAND (hero-titled cover; codename stays internal);
+  cover cat rebuilt as connected flat-print silhouette matching the Desk cat
+  identity; burst restyled as 16-wedge sunburst; masthead auto-splits
+  kicker/main clear of the price box. Root bugs found in the process:
+  (a) attract breathe sine drove layer z negative, sinking art behind the
+  opaque paper board half of every cycle; (b) .pj-breathe CSS never applied
+  under Turbopack - breathe now rAF-driven, dead CSS rule deleted;
+  (c) per-layer breathe phases could invert layer z-order, slicing the cat
+  across the burst plane - single shared breathe phase with monotone
+  amplitudes, z-order invariant for all t; shadow joined the cat group; tail
+  pivot + leg roots moved inside body silhouettes (fix rounds: 2 of 3 S0.8
+  framing iterations used).
+- Queued to Phase 2 in PLAN.md: scroll pacing pass (user: too fast per
+  wheel), deep-jump mount blank (~1s into neon), shared CatModel extraction.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -210,3 +210,16 @@ pinned 5.9.3, an external edit bumped it - kept, builds clean),
   framing iterations used).
 - Queued to Phase 2 in PLAN.md: scroll pacing pass (user: too fast per
   wheel), deep-jump mount blank (~1s into neon), shared CatModel extraction.
+- PR #22 Claude review (advisory-only, no blocking findings; all engine
+  invariants verified). Notes adopted as standing rulings: (1) S5b.2
+  "no adjacent equal intensity" - noir(2)/desk(2) adjacency is CORRECT: the
+  title-drop beat (intensity 5) is the authored separating peak between
+  them; future gates must treat gutter beats as intensity rows, not flag
+  this pair. (2) flashBudget counts requestFlash() calls, not individual
+  inversions - a granted beat may emit 2 inverts (~0.16s apart); fine at
+  current cadence, re-audit if beats ever cluster within 1s. (3) Crash-
+  through briefly shows the incoming issue pre-print (inputBuffer sample);
+  cosmetic, settle resolves - candidate polish in Phase 2 transition
+  library. (4) Neon diegetic drei-Text signs are environmental art, not
+  "readable lettering" under S2.16 - whip smear may touch them; avoid
+  centering a sign in frame at a whip gutter when authoring future shots.

--- a/PLAN.md
+++ b/PLAN.md
@@ -21,17 +21,36 @@ Session protocol (S0.9): one phase per session. Kickoff every session with
 - [x] Gate: see DECISIONS.md 2026-07-02 (2 self-reported items -> re-trace
       with DevTools MCP at Phase 1 gate)
 
-## Phase 1 - Vertical slice: Cover + Issues 1-3 fully real -- NEXT
-Cover + attract mode + crash-through; Noir (rain, color window, cat leap);
-title-drop beat; Desk (cat lands, RT 3-panel composite, keycap CLACKs);
-dot-zoom via cat dot-bat; Neon city (dive, power-on cascade).
-Also: lettering layer exempt from post (S2.16 known deviation), first real
-shots.md files (S0.8), onomatopoeia pool, DevTools-MCP traces for the gate.
+## Phase 1 - Vertical slice: Cover + Issues 1-3 fully real -- DONE (2026-07-02)
+- [x] Cover: printed cover (masthead SAEED KOLIVAND, price gag, barcode),
+      attract mode, parallax break, crash-through-cover transition
+- [x] Noir: hatched B&W + dark-paper polarity fix, instanced rain, CMYK
+      color window (zero-RT depth-reconstruction mask), 4 S0.8 shots,
+      cat leap motivated cut
+- [x] Title-drop beat (authored speed, re-arm verified) + whip smear
+- [x] Desk: cat landing continuity, RT 3-panel composite (3->2 ladder),
+      keycap CLACKs, dot-bat motivated dot-zoom
+- [x] Neon: code city, krackle, power-on cascade (10-ring, scrub-safe) + beat
+- [x] Lettering layer post-exempt (DOM + Hud pool), onomatopoeia pool (GC-clean)
+- [x] Gate: all 12 checks PASS via DevTools MCP (1 fix loop);
+      Phase 0 self-reported items re-traced closed; see DECISIONS 2026-07-02
+- [x] Asset prompt queued: assets/prompts/noir-window-figure.md
+- Ships as PR (new workflow): branch phase-1-vertical-slice
 
 ## Phase 2 - Framework hardening
 Full transition library (page-flip, tear, panel-wipe, match-cut, stamp),
 recipe API extraction, balloon/word pooling, snapshot pool generalization,
 jaw-drop trigger helper. Gate: new issue = component + registry entry + recipe.
+Also: scroll pacing pass (user 2026-07-02: one wheel scroll moves scenes too
+fast) - grow the 1200vh ScrollProxy spacer and/or tune Lenis duration/
+wheelMultiplier; pure t-space means zero scene re-authoring; user judges feel.
+Also: SceneManager mount latency on discrete deep jumps (gate 2026-07-02:
+~1s cream blank jumping straight into neon; continuous scrub unaffected by
+active+/-1 premounts) - premount on large t deltas or cheap loading treatment.
+Also: extract shared CatModel component (user 2026-07-02: no more
+shapes-taped-together cats) from the approved cover/desk cats - organic
+primitives, palette + pose + material-mode params - before Issues 4-11 reuse
+the mascot.
 
 ## Phase 3 - Issues 4-11, one commit each (styled placeholders -> real)
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 import Experience from "@/components/Experience";
+import Lettering from "@/components/Lettering";
 import ScrollProxy from "@/components/ScrollProxy";
 import { content } from "@/lib/content";
 
@@ -11,6 +12,7 @@ export default function Home() {
       </h1>
       <p className="sr-only">{content.tagline}</p>
       <Experience />
+      <Lettering />
       <ScrollProxy />
     </main>
   );

--- a/assets/prompts/noir-window-figure.md
+++ b/assets/prompts/noir-window-figure.md
@@ -1,0 +1,47 @@
+# noir-window-figure
+
+Upgrade for the Issue 1 (NOIR) lit-window interior. Procedural silhouette
+ships regardless; this asset replaces it at the user's leisure.
+
+Target path: public/images/noir-window-figure.png
+Format: PNG with transparent background (alpha), 1024x1280 (4:5 -- matches
+the 1.6 x 2.0 world-unit window pane).
+
+## Prompt
+
+A single comic-book panel seen straight-on: the warm interior of one
+apartment window at night, viewed from outside through the glass. A person
+sits at a desk with their back to the viewer, rendered as a clean solid
+ink-black silhouette (#050507): round head wearing over-ear headphones,
+soft rounded shoulders, seated at a thin black desk line. On the desk, a
+glowing computer monitor in flat teal (#39D0D8) faces the figure so the
+head silhouette overlaps the screen; to the left a small desk lamp casts a
+flat circular glow in pink (#FF4FA3); a small black coffee mug sits on the
+desk. The entire background of the pane is one flat field of warm amber
+(#FFB347). No other colors anywhere: only #FFB347, #FF4FA3, #39D0D8,
+silhouette black #050507, and deep ink #0E0E10. Flat cel shading, bold
+uniform ink outlines, halftone dot shading only inside the amber field,
+crisp vector-like shapes, comic panel art.
+
+## Avoid
+
+- gradients, soft light falloff, glow bloom, photorealism
+- soft shadows, ambient occlusion, 3D rendering look
+- chromatic aberration, offset-print ghosting, doubled edges
+- facial features, skin tones, any color outside the five hexes above
+- any franchise character, logo, or artist-style reference
+
+## Palette source
+
+lib/recipes.ts issue 1: paper #0E0E10, ink #F5F1E8 (ink is NOT used in
+this asset; the figure is silhouette black). Window accents AMBER #FFB347,
+PINK #FF4FA3, TEAL #39D0D8 are locked to the inside of the colorWindow
+rect (S0.4 row 1).
+
+## Placement notes for the swap-in session
+
+Replaces the silhouette primitive group inside TheWindow (issues/01-noir/
+Noir.tsx) as a single textured plane 1.6 x 2.0 at the pane position,
+meshBasicMaterial with alpha; keep the mullion bars and the amber point
+light. Verify in situ: does it sit in recipe 1's mono world with the CMYK
+rect the only color? Does the halftone pass fight it?

--- a/components/Experience.tsx
+++ b/components/Experience.tsx
@@ -4,6 +4,7 @@ import { Canvas } from "@react-three/fiber";
 import ShotDirector from "./ShotDirector";
 import SceneManager from "./SceneManager";
 import PostPipeline from "./PostPipeline";
+import Onomatopoeia from "./Onomatopoeia";
 import PerfHUD from "./PerfHUD";
 import { useScrollStore } from "@/lib/scrollStore";
 
@@ -24,6 +25,8 @@ export default function Experience() {
         <ShotDirector />
         <SceneManager />
         <PostPipeline />
+        {/* post-exempt comic words, drawn after the composer (S2.16) */}
+        <Onomatopoeia />
       </Canvas>
       <PerfHUD />
     </div>

--- a/components/Lettering.tsx
+++ b/components/Lettering.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useScrollStore } from "@/lib/scrollStore";
+import { fx } from "@/lib/fx";
+import { lettering } from "@/lib/content";
+import { RANGES } from "@/issues/timeline";
+import { NOIR_SHOTS } from "@/issues/01-noir/shots";
+import { clamp01 } from "@/lib/shots";
+
+/**
+ * S2.16 lettering layer -- a DOM overlay ABOVE the canvas, unconditionally
+ * exempt from post: attract prompt (cover only), title-drop card (fx.title,
+ * beat-driven), noir captions (per shot range in Issue 1). Everything is a
+ * pure function of t + fx channels, read per rAF via getState() -- no hook
+ * selectors, no React state per frame. Crisp single-layer type only: solid
+ * fills, zero-blur shadows (comfort rule).
+ */
+
+const COVER_END = RANGES[0]![1];
+const NOIR_RANGE = RANGES[1]!;
+const CAPTIONS = lettering.noirCaptions;
+
+/** One caption window per noir shot when counts allow, else an even split of the issue range. */
+const CAPTION_WINDOWS: [number, number][] =
+  NOIR_SHOTS.length >= CAPTIONS.length
+    ? CAPTIONS.map((_, i) => [NOIR_SHOTS[i]!.range[0], NOIR_SHOTS[i]!.range[1]])
+    : CAPTIONS.map((_, i) => {
+        const w = (NOIR_RANGE[1] - NOIR_RANGE[0]) / CAPTIONS.length;
+        return [NOIR_RANGE[0] + i * w, NOIR_RANGE[0] + (i + 1) * w];
+      });
+
+/** fade in over the first 18% of a window, out over the last 18% -- pure f(t) */
+function windowOpacity(t: number, a: number, b: number): number {
+  const p = (t - a) / (b - a);
+  if (p <= 0 || p >= 1) return 0;
+  return Math.min(1, p / 0.18, (1 - p) / 0.18);
+}
+
+const INK = "#14110E";
+const PAPER = "#F2EAD9";
+const RED = "#E2574C";
+
+/** alternate caption boxes across the frame, comic-page style */
+const CAPTION_SPOTS = [
+  { top: "10vh", left: "7vw" },
+  { top: "12vh", right: "7vw" },
+  { bottom: "14vh", left: "10vw" },
+] as const;
+
+export default function Lettering() {
+  const promptRef = useRef<HTMLDivElement>(null);
+  const cardRef = useRef<HTMLDivElement>(null);
+  const capRefs = useRef<(HTMLDivElement | null)[]>([]);
+
+  useEffect(() => {
+    let raf = 0;
+    const loop = (now: number) => {
+      raf = requestAnimationFrame(loop);
+      const { t, reducedMotion } = useScrollStore.getState();
+
+      const prompt = promptRef.current;
+      if (prompt) {
+        const o = clamp01(1 - t / COVER_END);
+        prompt.style.opacity = o.toFixed(3);
+        prompt.style.visibility = o > 0.001 ? "visible" : "hidden";
+        // centering + 2.4s breathe live HERE, not in a CSS class: the
+        // .pj-breathe rule in globals.css never reached the element under
+        // Turbopack, which left the prompt un-centered (barcode collision)
+        const s = reducedMotion ? 1 : 1 + 0.05 * Math.sin(now * 0.00262);
+        prompt.style.transform = "translateX(-50%) scale(" + s.toFixed(4) + ")";
+      }
+
+      const card = cardRef.current;
+      if (card) {
+        const v = fx.title;
+        card.style.opacity = clamp01(v * 1.5).toFixed(3);
+        // slam: oversized at v=0, settles at 1 (back.out overshoot dips it slightly under)
+        card.style.transform = `scale(${Math.max(2.6 - 1.6 * v, 0.05).toFixed(4)})`;
+        card.style.visibility = v > 0.001 ? "visible" : "hidden";
+      }
+
+      for (let i = 0; i < CAPTION_WINDOWS.length; i++) {
+        const el = capRefs.current[i];
+        if (!el) continue;
+        const win = CAPTION_WINDOWS[i]!;
+        const o = windowOpacity(t, win[0], win[1]);
+        el.style.opacity = o.toFixed(3);
+        el.style.visibility = o > 0.001 ? "visible" : "hidden";
+      }
+    };
+    raf = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
+  return (
+    <div className="pointer-events-none fixed inset-0 z-20 select-none" aria-hidden>
+      {/* attract prompt -- cover segment only, breathing (rAF-driven,
+          reduced-motion aware). Bottom-center in the ink-void band BELOW the
+          cover art (attract camera leaves ~8vh of void), clear of barcode. */}
+      <div ref={promptRef} className="absolute bottom-[2.2vh] left-1/2" style={{ opacity: 0 }}>
+        <div
+          style={{
+            fontFamily: "var(--font-bangers)",
+            fontSize: "clamp(16px, 3.2vh, 30px)",
+            letterSpacing: "0.08em",
+            color: PAPER,
+            textShadow: `2px 2px 0 ${RED}`,
+            whiteSpace: "nowrap",
+          }}
+        >
+          {lettering.cover.attractPrompt}
+        </div>
+      </div>
+
+      {/* title-drop card -- slammed in by the title-drop beat via fx.title */}
+      <div className="absolute inset-0 flex items-center justify-center">
+        <div ref={cardRef} style={{ opacity: 0, visibility: "hidden", textAlign: "center" }}>
+          <div
+            style={{
+              fontFamily: "var(--font-bangers)",
+              fontSize: "clamp(52px, 11vw, 160px)",
+              lineHeight: 1,
+              letterSpacing: "0.02em",
+              color: PAPER,
+              WebkitTextStroke: `3px ${INK}`,
+              textShadow: `8px 8px 0 ${INK}`,
+            }}
+          >
+            {lettering.titleDrop.name}
+          </div>
+          <div
+            style={{
+              fontFamily: "var(--font-caveat)",
+              fontSize: "clamp(20px, 2.8vw, 38px)",
+              marginTop: "1.2vh",
+              color: PAPER,
+              textShadow: `2px 2px 0 ${INK}, -2px 2px 0 ${INK}, 2px -2px 0 ${INK}, -2px -2px 0 ${INK}`,
+            }}
+          >
+            {lettering.titleDrop.sub}
+          </div>
+        </div>
+      </div>
+
+      {/* noir captions -- one per shot window in Issue 1 */}
+      {CAPTIONS.map((caption, i) => (
+        <div
+          key={caption}
+          ref={(el) => {
+            capRefs.current[i] = el;
+          }}
+          className="absolute"
+          style={{
+            ...CAPTION_SPOTS[i % CAPTION_SPOTS.length],
+            opacity: 0,
+            visibility: "hidden",
+            maxWidth: "min(46ch, 60vw)",
+            padding: "0.5em 0.9em",
+            background: PAPER,
+            border: `3px solid ${INK}`,
+            boxShadow: `5px 5px 0 ${INK}`,
+            fontFamily: "var(--font-caveat)",
+            fontSize: "clamp(17px, 2.2vw, 28px)",
+            lineHeight: 1.25,
+            color: INK,
+          }}
+        >
+          {caption}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/Onomatopoeia.tsx
+++ b/components/Onomatopoeia.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { Suspense, useRef } from "react";
+import { useFrame, useThree } from "@react-three/fiber";
+import { Hud, OrthographicCamera, Text } from "@react-three/drei";
+import { Vector3, type Camera, type Mesh } from "three";
+import { wordPool, WORD_POOL_SIZE, WORD_LIFE } from "@/lib/onomatopoeia";
+import { stepTime } from "@/lib/steppedClock";
+import { clamp01 } from "@/lib/shots";
+
+/**
+ * Renders the lib/onomatopoeia pool as Bangers lettering in a screen-space
+ * Hud scene. renderPriority 2 draws AFTER the composer (priority 1), so the
+ * words stay post-exempt and pixel-crisp (S2.16). Pop-in/pop-out scale +
+ * rotation envelopes sample stepped time (S2.8); the per-frame loop only
+ * mutates pooled objects -- zero allocation.
+ */
+
+type TroikaText = Mesh & { text: string; color: string; sync: () => void };
+
+const ndc = new Vector3(); // shared projection scratch
+
+function WordSprites({ mainCamera }: { mainCamera: Camera }) {
+  const size = useThree((s) => s.size); // Hud portal inherits root size
+  const refs = useRef<(TroikaText | null)[]>([]);
+  const gens = useRef<number[]>(new Array<number>(WORD_POOL_SIZE).fill(-1));
+
+  useFrame(() => {
+    const now = performance.now();
+    const halfW = size.width * 0.5;
+    const halfH = size.height * 0.5;
+    for (let i = 0; i < WORD_POOL_SIZE; i++) {
+      const mesh = refs.current[i];
+      if (!mesh) continue;
+      const slot = wordPool[i]!;
+      if (!slot.active) {
+        mesh.visible = false;
+        continue;
+      }
+      const age = (now - slot.start) / 1000;
+      if (age >= WORD_LIFE) {
+        slot.active = false;
+        mesh.visible = false;
+        continue;
+      }
+      if (gens.current[i] !== slot.gen) {
+        gens.current[i] = slot.gen;
+        mesh.text = slot.word;
+        mesh.color = slot.color;
+        mesh.sync();
+      }
+      ndc.copy(slot.pos).project(mainCamera);
+      if (ndc.z > 1 || ndc.z < -1) {
+        mesh.visible = false; // behind the camera / out of depth range
+        continue;
+      }
+      const sAge = stepTime(age, 12);
+      const inP = clamp01(sAge / 0.14);
+      const outP = clamp01((WORD_LIFE - sAge) / 0.18);
+      const scale = inP * (1 + 0.4 * Math.sin(inP * Math.PI)) * outP;
+      if (scale <= 0.001) {
+        mesh.visible = false;
+        continue;
+      }
+      mesh.visible = true;
+      mesh.position.set(ndc.x * halfW, ndc.y * halfH, 0);
+      mesh.scale.setScalar(scale);
+      mesh.rotation.z = (slot.seed - 0.5) * 0.5 + 0.05 * Math.sin(sAge * 18);
+    }
+  });
+
+  return (
+    <Suspense fallback={null}>
+      {wordPool.map((_, i) => (
+        <Text
+          key={i}
+          ref={(el: unknown) => {
+            refs.current[i] = el as TroikaText | null;
+          }}
+          font="/fonts/Bangers-Regular.ttf"
+          fontSize={44}
+          anchorX="center"
+          anchorY="middle"
+          outlineWidth={5}
+          outlineColor="#14110E"
+          color="#FFFFFF"
+          visible={false}
+        >
+          {" "}
+        </Text>
+      ))}
+    </Suspense>
+  );
+}
+
+export default function Onomatopoeia() {
+  const camera = useThree((s) => s.camera); // main scene camera (outside the Hud portal)
+  return (
+    <Hud renderPriority={2}>
+      <OrthographicCamera makeDefault position={[0, 0, 100]} />
+      <WordSprites mainCamera={camera} />
+    </Hud>
+  );
+}

--- a/components/PostPipeline.tsx
+++ b/components/PostPipeline.tsx
@@ -3,10 +3,11 @@
 import { useEffect, useMemo, useRef } from "react";
 import { useFrame, useThree } from "@react-three/fiber";
 import { EffectComposer, EffectPass, NormalPass, RenderPass } from "postprocessing";
-import { Color, HalfFloatType, type Texture } from "three";
+import { Color, HalfFloatType, Matrix4, Vector3, type Texture } from "three";
 import { PrintEffect } from "@/shaders/PrintEffect";
 import { TransitionEffect } from "@/shaders/TransitionEffect";
-import { evaluateTimeline, lerp } from "@/lib/shots";
+import { colorWindow } from "@/shaders/colorWindow";
+import { evaluateTimeline, lerp, poseAt, type Pose, type Vec3 } from "@/lib/shots";
 import { ISSUES, SEGMENTS } from "@/issues/registry";
 import { useScrollStore } from "@/lib/scrollStore";
 import { fx } from "@/lib/fx";
@@ -22,6 +23,40 @@ import { stepNoise } from "@/lib/steppedClock";
  * verified 2026-07 (R3F v9 docs): a numeric useFrame priority disables
  * R3F's automatic render; the composer owns the frame at priority 1.
  */
+
+const sub3 = (a: Vec3, b: Vec3): Vec3 => [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+const dot3 = (a: Vec3, b: Vec3) => a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+const cross3 = (a: Vec3, b: Vec3): Vec3 => [
+  a[1] * b[2] - a[2] * b[1],
+  a[2] * b[0] - a[0] * b[2],
+  a[0] * b[1] - a[1] * b[0],
+];
+const norm3 = (a: Vec3): Vec3 => {
+  const l = Math.hypot(a[0], a[1], a[2]);
+  return l < 1e-6 ? [1, 0, 0] : [a[0] / l, a[1] / l, a[2] / l];
+};
+const wrapPi = (a: number) => Math.atan2(Math.sin(a), Math.cos(a));
+
+/**
+ * Screen-space whip axis for the directional smear: yaw/pitch delta between
+ * the outgoing and incoming poses; falls back to the position delta
+ * projected onto the camera basis for purely translational whips.
+ */
+function whipAxis(a: Pose, b: Pose): [number, number] {
+  const fa = norm3(sub3(a.target, a.position));
+  const fb = norm3(sub3(b.target, b.position));
+  let x = wrapPi(Math.atan2(fb[0], -fb[2]) - Math.atan2(fa[0], -fa[2]));
+  let y = Math.asin(Math.max(-1, Math.min(1, fb[1]))) - Math.asin(Math.max(-1, Math.min(1, fa[1])));
+  if (Math.hypot(x, y) < 1e-3) {
+    const dp = sub3(b.position, a.position);
+    const right = norm3(cross3(fa, [0, 1, 0]));
+    x = dot3(dp, right);
+    y = dot3(dp, cross3(right, fa));
+  }
+  const l = Math.hypot(x, y);
+  return l < 1e-4 ? [1, 0] : [x / l, y / l];
+}
+
 export default function PostPipeline() {
   const gl = useThree((s) => s.gl);
   const scene = useThree((s) => s.scene);
@@ -81,6 +116,8 @@ export default function PostPipeline() {
     c.paperTex = lerp(c.paperTex, recipe.paperTex, k);
     c.vignette = lerp(c.vignette, recipe.vignette, k);
     c.boil = lerp(c.boil, recipe.boil, k);
+    c.hatch = lerp(c.hatch, recipe.hatch, k);
+    c.hatchScale = lerp(c.hatchScale, recipe.hatchScale, k);
     paper.current.lerp(target.current.paper.set(recipe.paper), k);
     edgeColor.current.lerp(target.current.edgeColor.set(recipe.edgeColor), k);
 
@@ -94,6 +131,22 @@ export default function PostPipeline() {
     print.u<number>("uPaperTex").value = c.paperTex;
     print.u<number>("uVignette").value = c.vignette;
     print.u<number>("uImpact").value = fx.impact;
+    print.u<number>("uHatch").value = c.hatch;
+    print.u<number>("uHatchScale").value = c.hatchScale;
+
+    // color window (noir): world-space rect positioned by the issue via
+    // shaders/colorWindow.ts; mask reconstructs world pos from depth
+    print.u<number>("uWindow").value = colorWindow.enabled;
+    if (colorWindow.enabled > 0) {
+      print.u<Vector3>("uWinCenter").value.fromArray(colorWindow.center);
+      print.u<Vector3>("uWinU").value.fromArray(colorWindow.halfU);
+      print.u<Vector3>("uWinV").value.fromArray(colorWindow.halfV);
+      print.u<number>("uWinDepth").value = colorWindow.depth;
+      camera.updateMatrixWorld();
+      print
+        .u<Matrix4>("uInvViewProjection")
+        .value.multiplyMatrices(camera.matrixWorld, camera.projectionMatrixInverse);
+    }
 
     // S2.9 line boil: quantized jitter, amplitude grows with scroll speed
     const el = state.clock.elapsedTime;
@@ -106,13 +159,21 @@ export default function PostPipeline() {
     // transition layer
     const tr = sample.transition;
     transition.u<number>("uVelocity").value = velocity;
+    transition.u<number>("uSmearMono").value = c.mono;
     if (tr) {
       transition.setMode(tr.mode);
       transition.u<number>("uP").value = tr.p;
       transition
         .u<Color>("uFallback")
         .value.set(ISSUES[tr.fromIssue]!.recipe.paper);
-      if (tr.mode === "dot-zoom") {
+      if (tr.mode === "whip" && sample.segment.type === "gutter") {
+        const g = sample.segment;
+        const [wx, wy] = whipAxis(poseAt(g.fromShot, 1), poseAt(g.toShot, 0));
+        const wd = transition.u<{ x: number; y: number }>("uWhipDir").value;
+        wd.x = wx;
+        wd.y = wy;
+      }
+      if (tr.mode === "dot-zoom" || tr.mode === "crash-through") {
         const snap = snapshots.get(tr.fromIssue);
         transition.u<Texture | null>("uSnapshot").value = snap;
         transition.u<number>("uHasSnapshot").value = snap ? 1 : 0;
@@ -124,10 +185,14 @@ export default function PostPipeline() {
     composer.render(delta);
 
     // S2.11 -- refresh the outgoing issue's snapshot in the tail of a shot
-    // that exits through a snapshot-driven transition (dot-zoom for now)
+    // that exits through a snapshot-driven transition
     if (sample.segment.type === "shot" && sample.shotP > 0.85) {
       const next = SEGMENTS[SEGMENTS.indexOf(sample.segment) + 1];
-      if (next?.type === "gutter" && next.interIssue && next.mode === "dot-zoom") {
+      if (
+        next?.type === "gutter" &&
+        next.interIssue &&
+        (next.mode === "dot-zoom" || next.mode === "crash-through")
+      ) {
         snapshots.capture(gl, sample.segment.shot.issue);
       }
     }

--- a/components/SceneManager.tsx
+++ b/components/SceneManager.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import PlaceholderIssue from "@/issues/PlaceholderIssue";
 import { ISSUES } from "@/issues/registry";
 import { useScrollStore } from "@/lib/scrollStore";
 
@@ -15,9 +14,11 @@ export default function SceneManager() {
   );
   return (
     <>
-      {mounted.map((i) => (
-        <PlaceholderIssue key={ISSUES[i]!.id} index={i} />
-      ))}
+      {mounted.map((i) => {
+        const issue = ISSUES[i]!;
+        const IssueScene = issue.component;
+        return <IssueScene key={issue.id} index={i} />;
+      })}
     </>
   );
 }

--- a/components/ShotDirector.tsx
+++ b/components/ShotDirector.tsx
@@ -6,7 +6,7 @@ import { Color, Vector3, type PerspectiveCamera } from "three";
 import { evaluateTimeline, type TimelineSample } from "@/lib/shots";
 import { SEGMENTS, ISSUES } from "@/issues/registry";
 import { useScrollStore } from "@/lib/scrollStore";
-import { BeatRunner, makeDemoBeats } from "@/lib/beats";
+import { BeatRunner, makeBeats } from "@/lib/beats";
 
 /**
  * S2.3 -- evaluates the shot list from t and drives the camera: pose lerp
@@ -20,7 +20,7 @@ export default function ShotDirector({
 }) {
   const camera = useThree((s) => s.camera);
   const scene = useThree((s) => s.scene);
-  const beats = useMemo(() => new BeatRunner(makeDemoBeats()), []);
+  const beats = useMemo(() => new BeatRunner(makeBeats()), []);
 
   const pos = useRef(new Vector3());
   const tgt = useRef(new Vector3());

--- a/issues/00-cover/Cover.tsx
+++ b/issues/00-cover/Cover.tsx
@@ -1,0 +1,479 @@
+"use client";
+
+import { Suspense, useMemo, useRef } from "react";
+import { useFrame } from "@react-three/fiber";
+import { Text } from "@react-three/drei";
+import type { Group, Mesh } from "three";
+import IssueShell from "../_IssueShell";
+import { ISSUES } from "../registry";
+import { RANGES } from "../timeline";
+import { toonRamp } from "@/lib/toon";
+import { stepTime } from "@/lib/steppedClock";
+import { useScrollStore } from "@/lib/scrollStore";
+import { lettering } from "@/lib/content";
+import { clamp01, easeOutCubic } from "@/lib/shots";
+
+/**
+ * Issue #0 -- the COVER (S7 Phase 1). The loading screen IS Issue #1's
+ * printed comic cover: at t=0 four art layers sit almost coplanar so the
+ * whole thing reads as a flat print; as t moves 0->0.030 the layers
+ * separate in z (pure f(t)) while the camera crash-dollies in, feeding the
+ * crash-through tear in the 0.030-0.040 gutter. Attract mode (before
+ * scroll) breathes the layers and flicks the cat tail on 12fps stepTime;
+ * the DOM attract prompt lives in components/Lettering.tsx -- not here.
+ *
+ * All copy comes from lettering.cover (lib/content.ts). In-scene cover
+ * type is drei Text INSIDE the post pipeline deliberately: the print
+ * treatment IS the cover look (crisp solid fills only, S2.16).
+ */
+
+// S0.4 Cover palette row
+const PAPER = "#F2EAD9";
+const INK = "#201D18";
+const RED = "#E2574C";
+const TEAL = "#2BB3A3";
+
+const BANGERS = "/fonts/Bangers-Regular.ttf";
+const COVER_END = RANGES[0]![1];
+
+// Masthead splits into a small kicker line + a big main line so long names
+// ("SAEED KOLIVAND", 14 chars) never clip or collide with the price box.
+// Sizes derive from string length -- content.ts can change without relayout.
+const MAST_WORDS = lettering.cover.masthead.split(" ");
+const MAST_KICKER = MAST_WORDS.length > 1 ? MAST_WORDS[0]! : "";
+const MAST_MAIN =
+  MAST_WORDS.length > 1 ? MAST_WORDS.slice(1).join(" ") : lettering.cover.masthead;
+const MAST_MAIN_SIZE = Math.min(1.18, 9.4 / Math.max(MAST_MAIN.length, 1));
+const MAST_KICKER_SIZE = Math.min(0.56, 4.2 / Math.max(MAST_KICKER.length, 1));
+
+// z at full separation (wu) + tiny coplanar base so t=0 never z-fights
+const LAYER = {
+  art: { base: 0.015, depth: 0.55 },
+  hero: { base: 0.03, depth: 1.3 },
+  letter: { base: 0.05, depth: 2.1 },
+} as const;
+
+const RAY_COUNT = 16;
+
+export default function Cover({ index }: { index: number }) {
+  const issue = ISSUES[index]!;
+  const ramp = toonRamp();
+  const art = useRef<Group>(null);
+  const hero = useRef<Group>(null);
+  const letter = useRef<Group>(null);
+  const tail = useRef<Group>(null);
+  const shadow = useRef<Mesh>(null);
+
+  // barcode bars derived deterministically from the GitHub handle
+  const barcode = useMemo(() => {
+    const bars: { x: number; w: number }[] = [];
+    let x = 0;
+    for (const ch of lettering.cover.barcode) {
+      const c = ch.charCodeAt(0);
+      const w1 = 0.022 + (c % 3) * 0.012;
+      bars.push({ x, w: w1 });
+      x += w1 + 0.016;
+      const w2 = 0.022 + ((c >> 3) % 3) * 0.012;
+      bars.push({ x, w: w2 });
+      x += w2 + 0.024;
+    }
+    return { bars, width: x - 0.024 };
+  }, []);
+
+  useFrame(({ clock }) => {
+    const { t, reducedMotion } = useScrollStore.getState();
+    // depth separation: pure f(t), fully open by the end of the cover range
+    const sep = easeOutCubic(clamp01(t / COVER_END));
+    // attract breathing fades out as the print gains real depth
+    const breathe = reducedMotion ? 0 : 1 - sep;
+    const el = clock.elapsedTime;
+    // breathe term stays >= 0: a raw sine dips layers BEHIND the opaque
+    // paper board (z < 0) and flat shapes vanish for half of every cycle.
+    // ONE shared phase for all layers: with per-layer phases the art sine
+    // can overtake the hero sine and the burst disc plane rises INTO the
+    // cat's intra-group z span, slicing the cat (flat torso/head circles
+    // hide behind the disc while capsule legs / torus tail bulge through).
+    // Shared phase + amplitudes that grow with the layer keep
+    // art < hero < letter invariant for every t and every breath.
+    const z = (l: { base: number; depth: number }, amp: number) =>
+      l.base + l.depth * sep + breathe * amp * (0.5 + 0.5 * Math.sin(el * 0.85));
+    if (art.current) art.current.position.z = z(LAYER.art, 0.05);
+    if (hero.current) hero.current.position.z = z(LAYER.hero, 0.09);
+    if (letter.current) letter.current.position.z = z(LAYER.letter, 0.13);
+    if (shadow.current) {
+      // pounce shadow shrinks away as the print separates (stays attached
+      // to the composition -- no orphaned ink blob during the crash push)
+      const k = 1 - sep;
+      shadow.current.scale.set(1.3 * k + 0.001, 0.22 * k + 0.001, 1);
+    }
+    if (tail.current) {
+      const s = stepTime(el, 12); // S2.8 -- 12fps tail flick, camera stays smooth
+      tail.current.rotation.z = reducedMotion
+        ? 0
+        : Math.sin(s * 2.6) * 0.28 + Math.sin(s * 0.6) * 0.1;
+    }
+  });
+
+  return (
+    <IssueShell index={index} issue={issue}>
+      {/* ink void behind the floating print */}
+      <mesh position={[0, 1, -8]}>
+        <planeGeometry args={[70, 70]} />
+        <meshToonMaterial color={INK} gradientMap={ramp} />
+      </mesh>
+
+      {/* the cover, centered at y=1 (camera in shots.ts frames this) */}
+      <group position={[0, 1, 0]}>
+        {/* L0 paper board + printed trim frame (stays flat, receives the tear) */}
+        <mesh>
+          <planeGeometry args={[6.4, 9.6]} />
+          <meshToonMaterial color={PAPER} gradientMap={ramp} />
+        </mesh>
+        <mesh position={[0, 4.73, 0.008]}>
+          <planeGeometry args={[6.4, 0.14]} />
+          <meshToonMaterial color={INK} gradientMap={ramp} />
+        </mesh>
+        <mesh position={[0, -4.73, 0.008]}>
+          <planeGeometry args={[6.4, 0.14]} />
+          <meshToonMaterial color={INK} gradientMap={ramp} />
+        </mesh>
+        <mesh position={[-3.13, 0, 0.008]}>
+          <planeGeometry args={[0.14, 9.6]} />
+          <meshToonMaterial color={INK} gradientMap={ramp} />
+        </mesh>
+        <mesh position={[3.13, 0, 0.008]}>
+          <planeGeometry args={[0.14, 9.6]} />
+          <meshToonMaterial color={INK} gradientMap={ramp} />
+        </mesh>
+
+        {/* L1 -- background art: comic sunburst. Teal core disc, tapered red
+            wedge rays (alternating long/short, bases tucked under the disc),
+            thin paper ring so it reads as printed energy, not a solid ball */}
+        <group ref={art}>
+          {Array.from({ length: RAY_COUNT }, (_, i) => {
+            const a = (i / RAY_COUNT) * Math.PI * 2 + 0.13;
+            const long = i % 2 === 0;
+            const r = long ? 2.35 : 2.3;
+            return (
+              <mesh
+                key={i}
+                position={[Math.cos(a) * r, -0.4 + Math.sin(a) * r, -0.004]}
+                rotation={[0, 0, a]}
+                scale={[long ? 0.65 : 0.5, long ? 0.42 : 0.34, 1]}
+              >
+                <circleGeometry args={[1, 3]} />
+                <meshToonMaterial color={RED} gradientMap={ramp} />
+              </mesh>
+            );
+          })}
+          <mesh position={[0, -0.4, 0]}>
+            <circleGeometry args={[2.55, 48]} />
+            <meshToonMaterial color={TEAL} gradientMap={ramp} />
+          </mesh>
+          <mesh position={[0, -0.4, 0.002]}>
+            <ringGeometry args={[2.28, 2.36, 64]} />
+            <meshToonMaterial color={PAPER} gradientMap={ramp} />
+          </mesh>
+        </group>
+
+        {/* L2 -- hero art: the cat, mid-pounce toward the masthead (S1
+            through-line; clickable meow, S5b.5). Flat-print silhouette:
+            overlapping ink shapes stay connected, paper face details, teal
+            collar + red tag (identity marks shared with the Desk cat),
+            torus-arc tail that flicks on stepped time. */}
+        <group
+          ref={hero}
+          position={[0, -0.75, 0.03]}
+          onClick={(e) => {
+            e.stopPropagation();
+            useScrollStore.getState().meow();
+          }}
+        >
+          {/* pounce shadow -- rides the SAME layer as the cat (never
+              spatially detaches under parallax); just behind the body ink
+              yet always in front of the burst (hero-art base gap 0.015).
+              Shrinks with separation, pure f(t). */}
+          <mesh ref={shadow} position={[-0.15, -1.3, -0.008]} scale={[1.3, 0.22, 1]}>
+            <circleGeometry args={[1, 32]} />
+            <meshToonMaterial color={INK} gradientMap={ramp} />
+          </mesh>
+          <group scale={1.3} rotation={[0, 0, 0.42]}>
+            {/* torso ellipse + haunch keep every limb rooted in one silhouette */}
+            <mesh scale={[1.5, 0.82, 1]}>
+              <circleGeometry args={[0.55, 40]} />
+              <meshToonMaterial color={INK} gradientMap={ramp} />
+            </mesh>
+            <mesh position={[-0.6, -0.05, 0.0005]}>
+              <circleGeometry args={[0.4, 40]} />
+              <meshToonMaterial color={INK} gradientMap={ramp} />
+            </mesh>
+
+            {/* front legs stretched at the masthead (rounded caps = paws).
+                Shoulder ends must land INSIDE the torso ellipse (rx 0.825,
+                ry 0.451) so the limbs stay rooted in the silhouette. */}
+            <mesh position={[0.88, -0.14, 0.0008]} rotation={[0, 0, -1.05]}>
+              <capsuleGeometry args={[0.08, 0.5, 4, 10]} />
+              <meshToonMaterial color={INK} gradientMap={ramp} />
+            </mesh>
+            <mesh position={[1.08, 0.06, 0.002]} rotation={[0, 0, -1.25]}>
+              <capsuleGeometry args={[0.08, 0.55, 4, 10]} />
+              <meshToonMaterial color={INK} gradientMap={ramp} />
+            </mesh>
+            {/* paper socks sit ON the capsule tips (Desk cat identity echo) */}
+            <mesh position={[1.42, 0.17, 0.004]}>
+              <circleGeometry args={[0.08, 16]} />
+              <meshToonMaterial color={PAPER} gradientMap={ramp} />
+            </mesh>
+            <mesh position={[1.17, 0.01, 0.004]}>
+              <circleGeometry args={[0.075, 16]} />
+              <meshToonMaterial color={PAPER} gradientMap={ramp} />
+            </mesh>
+
+            {/* hind legs trailing the pounce */}
+            <mesh position={[-0.68, -0.34, 0.0008]} rotation={[0, 0, -0.35]}>
+              <capsuleGeometry args={[0.085, 0.48, 4, 10]} />
+              <meshToonMaterial color={INK} gradientMap={ramp} />
+            </mesh>
+            <mesh position={[-0.86, -0.3, 0.002]} rotation={[0, 0, -0.75]}>
+              <capsuleGeometry args={[0.085, 0.55, 4, 10]} />
+              <meshToonMaterial color={INK} gradientMap={ramp} />
+            </mesh>
+
+            {/* head overlaps the torso front -- ears are 3-gon circles */}
+            <group position={[0.85, 0.36, 0.003]}>
+              <mesh>
+                <circleGeometry args={[0.37, 40]} />
+                <meshToonMaterial color={INK} gradientMap={ramp} />
+              </mesh>
+              <mesh position={[-0.17, 0.36, 0]} rotation={[0, 0, Math.PI / 2 + 0.15]}>
+                <circleGeometry args={[0.16, 3]} />
+                <meshToonMaterial color={INK} gradientMap={ramp} />
+              </mesh>
+              <mesh position={[0.17, 0.37, 0]} rotation={[0, 0, Math.PI / 2 - 0.15]}>
+                <circleGeometry args={[0.16, 3]} />
+                <meshToonMaterial color={INK} gradientMap={ramp} />
+              </mesh>
+              {/* eyes: paper almonds + ink pupils -- reads at 200px */}
+              <mesh position={[-0.13, 0.02, 0.002]} scale={[0.8, 1.15, 1]}>
+                <circleGeometry args={[0.085, 20]} />
+                <meshToonMaterial color={PAPER} gradientMap={ramp} />
+              </mesh>
+              <mesh position={[0.15, 0.04, 0.002]} scale={[0.8, 1.15, 1]}>
+                <circleGeometry args={[0.085, 20]} />
+                <meshToonMaterial color={PAPER} gradientMap={ramp} />
+              </mesh>
+              <mesh position={[-0.12, 0.01, 0.004]}>
+                <circleGeometry args={[0.035, 12]} />
+                <meshToonMaterial color={INK} gradientMap={ramp} />
+              </mesh>
+              <mesh position={[0.16, 0.03, 0.004]}>
+                <circleGeometry args={[0.035, 12]} />
+                <meshToonMaterial color={INK} gradientMap={ramp} />
+              </mesh>
+              {/* red 3-gon nose, point down */}
+              <mesh position={[0.02, -0.13, 0.002]} rotation={[0, 0, -Math.PI / 2]}>
+                <circleGeometry args={[0.055, 3]} />
+                <meshToonMaterial color={RED} gradientMap={ramp} />
+              </mesh>
+              {/* whiskers -- thin paper strokes */}
+              <mesh position={[-0.31, -0.09, 0.002]} rotation={[0, 0, 0.12]}>
+                <planeGeometry args={[0.26, 0.018]} />
+                <meshToonMaterial color={PAPER} gradientMap={ramp} />
+              </mesh>
+              <mesh position={[-0.32, -0.16, 0.002]} rotation={[0, 0, -0.06]}>
+                <planeGeometry args={[0.24, 0.018]} />
+                <meshToonMaterial color={PAPER} gradientMap={ramp} />
+              </mesh>
+              <mesh position={[0.34, -0.07, 0.002]} rotation={[0, 0, -0.12]}>
+                <planeGeometry args={[0.26, 0.018]} />
+                <meshToonMaterial color={PAPER} gradientMap={ramp} />
+              </mesh>
+              <mesh position={[0.35, -0.14, 0.002]} rotation={[0, 0, 0.06]}>
+                <planeGeometry args={[0.24, 0.018]} />
+                <meshToonMaterial color={PAPER} gradientMap={ramp} />
+              </mesh>
+            </group>
+
+            {/* teal collar band across the neck + red tag */}
+            <mesh position={[0.6, 0.05, 0.005]} rotation={[0, 0, -1.15]}>
+              <planeGeometry args={[0.46, 0.1]} />
+              <meshToonMaterial color={TEAL} gradientMap={ramp} />
+            </mesh>
+            <mesh position={[0.68, -0.1, 0.006]}>
+              <circleGeometry args={[0.06, 12]} />
+              <meshToonMaterial color={RED} gradientMap={ramp} />
+            </mesh>
+
+            {/* tail -- torus arc pivoting at its base, flicked on stepped
+                time. The arc's base end sits AT the group origin, so the
+                pivot must be INSIDE the haunch circle (center -0.6,-0.05
+                r 0.4) or the flick reads as a detached floating arc. */}
+            <group ref={tail} position={[-0.9, 0.15, 0.001]}>
+              <mesh position={[-0.42, 0, 0]}>
+                <torusGeometry args={[0.42, 0.07, 8, 24, 2.05]} />
+                <meshToonMaterial color={INK} gradientMap={ramp} />
+              </mesh>
+              <mesh position={[-0.614, 0.373, 0.002]}>
+                <circleGeometry args={[0.075, 12]} />
+                <meshToonMaterial color={RED} gradientMap={ramp} />
+              </mesh>
+            </group>
+
+            {/* speed dashes trailing the pounce (technique vocabulary, S1) */}
+            <mesh position={[-1.8, -0.55, 0.001]}>
+              <planeGeometry args={[0.8, 0.06]} />
+              <meshToonMaterial color={RED} gradientMap={ramp} />
+            </mesh>
+            <mesh position={[-2.0, -0.2, 0.001]}>
+              <planeGeometry args={[0.6, 0.05]} />
+              <meshToonMaterial color={RED} gradientMap={ramp} />
+            </mesh>
+            <mesh position={[-1.7, -0.9, 0.001]}>
+              <planeGeometry args={[0.5, 0.045]} />
+              <meshToonMaterial color={RED} gradientMap={ramp} />
+            </mesh>
+          </group>
+        </group>
+
+        {/* L3 -- lettering plate: masthead, issue line, price box, blurb, barcode */}
+        <group ref={letter}>
+          <Suspense fallback={null}>
+            {/* two-line masthead: small kicker centered above the big main
+                line -- both clear of the price box in the top-left corner */}
+            {MAST_KICKER !== "" && (
+              <Text
+                font={BANGERS}
+                fontSize={MAST_KICKER_SIZE}
+                letterSpacing={0.3}
+                position={[0, 4.14, 0]}
+                color={INK}
+                anchorX="center"
+                anchorY="middle"
+              >
+                {MAST_KICKER}
+              </Text>
+            )}
+            {/* main line with a solid offset print shadow (crisp, zero blur) */}
+            <Text
+              font={BANGERS}
+              fontSize={MAST_MAIN_SIZE}
+              letterSpacing={0.02}
+              position={[0.06, 3.08, -0.006]}
+              color={RED}
+              anchorX="center"
+              anchorY="middle"
+            >
+              {MAST_MAIN}
+            </Text>
+            <Text
+              font={BANGERS}
+              fontSize={MAST_MAIN_SIZE}
+              letterSpacing={0.02}
+              position={[0, 3.14, 0]}
+              color={INK}
+              anchorX="center"
+              anchorY="middle"
+            >
+              {MAST_MAIN}
+            </Text>
+            <Text
+              font={BANGERS}
+              fontSize={0.26}
+              letterSpacing={0.08}
+              position={[0, 2.4, 0]}
+              color={INK}
+              anchorX="center"
+              anchorY="middle"
+            >
+              {lettering.cover.issueLine}
+            </Text>
+
+            {/* price-box gag, top-left corner -- beside the kicker, fully
+                above the main masthead line (no overlap) */}
+            <group position={[-2.42, 4.14, 0.012]}>
+              <mesh>
+                <planeGeometry args={[1.4, 0.94]} />
+                <meshToonMaterial color={INK} gradientMap={ramp} />
+              </mesh>
+              <mesh position={[0, 0, 0.003]}>
+                <planeGeometry args={[1.3, 0.84]} />
+                <meshToonMaterial color={PAPER} gradientMap={ramp} />
+              </mesh>
+              <Text
+                font={BANGERS}
+                fontSize={0.2}
+                maxWidth={1.15}
+                textAlign="center"
+                lineHeight={1.1}
+                position={[0, 0, 0.006]}
+                color={INK}
+                anchorX="center"
+                anchorY="middle"
+              >
+                {lettering.cover.priceBox}
+              </Text>
+            </group>
+
+            {/* blurb banner */}
+            <group position={[0, -2.95, 0]}>
+              <mesh>
+                <planeGeometry args={[6.08, 1.14]} />
+                <meshToonMaterial color={INK} gradientMap={ramp} />
+              </mesh>
+              <mesh position={[0, 0, 0.003]}>
+                <planeGeometry args={[6.0, 1.06]} />
+                <meshToonMaterial color={RED} gradientMap={ramp} />
+              </mesh>
+              <Text
+                font={BANGERS}
+                fontSize={0.27}
+                maxWidth={5.6}
+                textAlign="center"
+                lineHeight={1.15}
+                position={[0, 0, 0.006]}
+                color={PAPER}
+                anchorX="center"
+                anchorY="middle"
+              >
+                {lettering.cover.blurb}
+              </Text>
+            </group>
+
+            {/* barcode = GitHub handle, bottom-right */}
+            <group position={[1.95, -4.02, 0.01]}>
+              <mesh>
+                <planeGeometry args={[1.88, 1.08]} />
+                <meshToonMaterial color={INK} gradientMap={ramp} />
+              </mesh>
+              <mesh position={[0, 0, 0.003]}>
+                <planeGeometry args={[1.8, 1.0]} />
+                <meshToonMaterial color={PAPER} gradientMap={ramp} />
+              </mesh>
+              {barcode.bars.map((b, i) => (
+                <mesh
+                  key={i}
+                  position={[-barcode.width / 2 + b.x + b.w / 2, 0.14, 0.006]}
+                  scale={[b.w, 0.52, 1]}
+                >
+                  <planeGeometry />
+                  <meshToonMaterial color={INK} gradientMap={ramp} />
+                </mesh>
+              ))}
+              <Text
+                font={BANGERS}
+                fontSize={0.15}
+                letterSpacing={0.12}
+                position={[0, -0.32, 0.006]}
+                color={INK}
+                anchorX="center"
+                anchorY="middle"
+              >
+                {lettering.cover.barcode}
+              </Text>
+            </group>
+          </Suspense>
+        </group>
+      </group>
+    </IssueShell>
+  );
+}

--- a/issues/00-cover/shots.md
+++ b/issues/00-cover/shots.md
@@ -1,0 +1,21 @@
+# Cover -- shot list (S0.8)
+
+Range 0.000-0.030 (RANGES[0]). Exits via the crash-through tear in the
+showcase gutter 0.030-0.040 (transition already implemented; the end frame
+of shot 1b is the snapshot the tear fragments carry).
+
+| # | kind | lens | share of issue | framing |
+|---|---|---|---|---|
+| 1a | hold (attract) | 33mm | 0.50 | head-on flat print floating in ink void; masthead top, cat + teal burst center, price box UL, blurb banner + barcode low; breathing parallax + 12fps tail flick idle; DOM attract prompt below (Lettering.tsx) |
+| 1b | crash | 33->28mm | 0.50 | layers split with t (art 0.55 / hero 1.3 / lettering 2.1 wu); camera crash-dollies at the cat, lettering flies off-frame edges; end frame = cat filling the burst -- feeds the punch-through |
+
+NOTE: 1a and 1b are ONE compiled Shot (`cover-attract-crash`) with a
+compound ease (flat drift for the first half, cubic acceleration in the
+back half). compileSegments hardcodes intra-issue gutters to "whip"; a whip
+smear across static readable cover lettering would break S2.16, so the
+cover carries no intra-issue gutter. shots.ts mirrors this table.
+
+S5b.4 checklist, shot 1: focal point = the leaping cat; three depth planes =
+lettering / hero+burst / paper board (separate on scroll); reads at 200px
+(masthead + cat silhouette + red banner); lettering is crisp drei Text,
+deliberately INSIDE the post pipeline -- the print treatment IS the cover.

--- a/issues/00-cover/shots.ts
+++ b/issues/00-cover/shots.ts
@@ -1,0 +1,35 @@
+import type { EaseFn, Shot } from "@/lib/shots";
+import { issueCenter, RANGES } from "../timeline";
+
+/**
+ * Cover shot list (S0.8, mirrored in ./shots.md).
+ *
+ * ONE compiled Shot with a compound ease instead of hold + crash as two
+ * shots: compileSegments hardcodes intra-issue gutters to "whip", and a
+ * whip smear over static, readable cover lettering violates S2.16. The
+ * hold phase lives in the flat first half of the ease (attract drift),
+ * the crash in the cubic back half. Scrub-safe pure f(t) either way.
+ */
+
+const [START, END] = RANGES[0]!;
+const [cx, cy, cz] = issueCenter(0);
+
+/** First half: slow attract drift (<=5% of travel). Back half: cubic crash. */
+const attractCrash: EaseFn = (x) => {
+  const k = Math.max(0, (x - 0.5) * 2);
+  return 0.1 * x + 0.9 * k * k * k;
+};
+
+export const COVER_SHOTS: Shot[] = [
+  {
+    id: "cover-attract-crash",
+    issue: 0,
+    range: [START, END],
+    kind: "dolly", // hold/dolly keep pointer parallax alive during attract
+    // attract pose leaves a ~8vh ink-void band below the cover: the DOM
+    // attract prompt (Lettering.tsx) lives there, clear of the barcode
+    from: { position: [cx, cy + 1, cz + 15.8], target: [cx, cy + 1, cz], roll: -0.012, fov: 40 },
+    to: { position: [cx, cy + 0.75, cz + 5.3], target: [cx, cy + 0.5, cz], roll: 0.025, fov: 47 },
+    ease: attractCrash,
+  },
+];

--- a/issues/01-noir/Noir.tsx
+++ b/issues/01-noir/Noir.tsx
@@ -1,0 +1,421 @@
+"use client";
+
+import { useEffect, useLayoutEffect, useMemo, useRef } from "react";
+import { useFrame } from "@react-three/fiber";
+import { InstancedMesh, Object3D, type Group, type Mesh } from "three";
+import { colorWindow } from "@/shaders/colorWindow";
+import { toonRamp } from "@/lib/toon";
+import { stepTime } from "@/lib/steppedClock";
+import { useScrollStore } from "@/lib/scrollStore";
+import { clamp01, lerp } from "@/lib/shots";
+import { sayWord } from "@/lib/onomatopoeia";
+import { lettering } from "@/lib/content";
+import { issueCenter } from "../timeline";
+import { NOIR_SHOTS, NOIR_WINDOW } from "./shots";
+
+/**
+ * ISSUE 1 -- NOIR (S0 Phase 1). Pure B&W hatched-ink street world (recipe 1
+ * carries mono + crosshatch); rain is an InstancedMesh of white dashes on
+ * stepped time; ONE window prints in full CMYK via the shaders/colorWindow
+ * rect -- the only color in the universe. All scroll-driven motion (the cat
+ * walk / trot / leap) is a pure function of t read via getState() (S2.2).
+ */
+
+// S0.4 row 1 palette + working grays (post drives the final ink look)
+const PAPER = "#0E0E10";
+const INK = "#F5F1E8";
+const AMBER = "#FFB347";
+const PINK = "#FF4FA3";
+const TEAL = "#39D0D8";
+const WALL = "#23232A";
+const WALL_DARK = "#17171C";
+const GLASS_DARK = "#060609";
+const STREET = "#101014";
+const RAIL = "#3A3A44";
+const SILHOUETTE = "#050507";
+
+const S3 = NOIR_SHOTS[2]!.range;
+const S4 = NOIR_SHOTS[3]!.range;
+const shotP = (t: number, r: [number, number]) => clamp01((t - r[0]) / (r[1] - r[0]));
+
+const frac = (x: number) => x - Math.floor(x);
+const hash = (i: number, k: number) => frac(Math.sin((i + 1) * k) * 43758.5453);
+
+/* ---------------------------------------------------------------- rain -- */
+
+const RAIN = { x0: -12, x1: 14, y0: -2, y1: 24, z0: -9, z1: 12, speed: 16 };
+const RAIN_H = RAIN.y1 - RAIN.y0;
+
+function Rain({ count }: { count: number }) {
+  const mesh = useRef<InstancedMesh>(null);
+  const dummy = useMemo(() => new Object3D(), []);
+  const lastStep = useRef(-1);
+
+  useFrame(({ clock }) => {
+    const m = mesh.current;
+    if (!m) return;
+    const st = stepTime(clock.elapsedTime, 12); // S2.8 chunky comic rain
+    if (st === lastStep.current) return;
+    lastStep.current = st;
+    for (let i = 0; i < count; i++) {
+      const sx = hash(i, 12.9898);
+      const sy = hash(i, 78.233);
+      const sz = hash(i, 39.425);
+      dummy.position.set(
+        RAIN.x0 + sx * (RAIN.x1 - RAIN.x0),
+        RAIN.y1 - ((sy * RAIN_H + st * RAIN.speed) % RAIN_H),
+        RAIN.z0 + sz * (RAIN.z1 - RAIN.z0),
+      );
+      dummy.rotation.set(0, 0, 0.07);
+      dummy.scale.set(1, 0.7 + sx * 0.6, 1);
+      dummy.updateMatrix();
+      m.setMatrixAt(i, dummy.matrix); // every instance set, every step
+    }
+    m.instanceMatrix.needsUpdate = true;
+  });
+
+  return (
+    <instancedMesh ref={mesh} args={[undefined, undefined, count]} frustumCulled={false}>
+      <boxGeometry args={[0.025, 0.55, 0.025]} />
+      <meshBasicMaterial color={INK} />
+    </instancedMesh>
+  );
+}
+
+/* -------------------------------------------------------------- facade -- */
+
+const GRID_COLS = [-9.5, -6, -2.5, 2.5, 6.5, 10];
+const GRID_ROWS = [2.5, 6.5, 10.5, 14.5, 18.5, 22.5];
+// every cell except THE window's slot
+const GRID_CELLS: [number, number][] = GRID_COLS.flatMap((x) =>
+  GRID_ROWS.filter((y) => !(x === NOIR_WINDOW.x && y === NOIR_WINDOW.y)).map(
+    (y) => [x, y] as [number, number],
+  ),
+);
+
+function DarkWindows() {
+  const mesh = useRef<InstancedMesh>(null);
+  const dummy = useMemo(() => new Object3D(), []);
+  useLayoutEffect(() => {
+    const m = mesh.current;
+    if (!m) return;
+    GRID_CELLS.forEach(([x, y], i) => {
+      dummy.position.set(x, y, -7.88);
+      dummy.updateMatrix();
+      m.setMatrixAt(i, dummy.matrix);
+    });
+    m.instanceMatrix.needsUpdate = true;
+  }, [dummy]);
+  return (
+    <instancedMesh ref={mesh} args={[undefined, undefined, GRID_CELLS.length]}>
+      <boxGeometry args={[1.6, 2.0, 0.1]} />
+      <meshToonMaterial color={GLASS_DARK} gradientMap={toonRamp()} />
+    </instancedMesh>
+  );
+}
+
+function Facade() {
+  const ramp = toonRamp();
+  return (
+    <group>
+      <mesh position={[1, 13, -8.2]}>
+        <boxGeometry args={[26, 30, 0.4]} />
+        <meshToonMaterial color={WALL} gradientMap={ramp} />
+      </mesh>
+      <DarkWindows />
+      {/* ledges + roofline give the ink-edge pass long horizontals */}
+      <mesh position={[1, 4.5, -7.75]}>
+        <boxGeometry args={[26, 0.25, 0.5]} />
+        <meshToonMaterial color={WALL_DARK} gradientMap={ramp} />
+      </mesh>
+      <mesh position={[1, 12.6, -7.75]}>
+        <boxGeometry args={[26, 0.25, 0.5]} />
+        <meshToonMaterial color={WALL_DARK} gradientMap={ramp} />
+      </mesh>
+      <mesh position={[1, 28, -7.9]}>
+        <boxGeometry args={[26, 0.6, 1]} />
+        <meshToonMaterial color={WALL_DARK} gradientMap={ramp} />
+      </mesh>
+      {/* right flank building closes the street canyon */}
+      <mesh position={[13.5, 8, -2]}>
+        <boxGeometry args={[5, 20, 8]} />
+        <meshToonMaterial color={WALL_DARK} gradientMap={ramp} />
+      </mesh>
+    </group>
+  );
+}
+
+/* --------------------------------------------- THE window (only color) -- */
+
+function TheWindow({ cx }: { cx: number }) {
+  useEffect(() => {
+    colorWindow.center = [cx + NOIR_WINDOW.x, NOIR_WINDOW.y, NOIR_WINDOW.z];
+    colorWindow.halfU = [0.95, 0, 0];
+    colorWindow.halfV = [0, 1.15, 0];
+    colorWindow.depth = 0.6;
+    colorWindow.enabled = 1;
+    return () => {
+      colorWindow.enabled = 0;
+    };
+  }, [cx]);
+
+  return (
+    <group position={[NOIR_WINDOW.x, NOIR_WINDOW.y, NOIR_WINDOW.z]}>
+      {/* dark frame plane exactly covers the color rect behind the pane */}
+      <mesh position={[0, 0, -0.04]}>
+        <planeGeometry args={[1.9, 2.3]} />
+        <meshToonMaterial color={WALL_DARK} gradientMap={toonRamp()} />
+      </mesh>
+      {/* warm backlit pane -- unlit, so the color stays flat and loud */}
+      <mesh>
+        <planeGeometry args={[1.6, 2.0]} />
+        <meshBasicMaterial color={AMBER} />
+      </mesh>
+      {/* interior story: pink lamp glow + teal monitor, the only accents
+          allowed inside the rect (S0.4 row 1) */}
+      <mesh position={[-0.42, -0.28, 0.02]}>
+        <circleGeometry args={[0.26, 20]} />
+        <meshBasicMaterial color={PINK} />
+      </mesh>
+      <mesh position={[0.42, -0.12, 0.02]}>
+        <planeGeometry args={[0.5, 0.34]} />
+        <meshBasicMaterial color={TEAL} />
+      </mesh>
+      {/* the human at the window: backlit dev, clean ink-black silhouette
+          shapes read against the amber pane / teal screen (flat unlit,
+          no gradients -- comic backlight). Desk line grounds the scene,
+          lamp stem grounds the pink glow. */}
+      <mesh position={[0, -0.66, 0.025]}>
+        <planeGeometry args={[1.5, 0.06]} />
+        <meshBasicMaterial color={SILHOUETTE} />
+      </mesh>
+      <mesh position={[-0.42, -0.5, 0.025]}>
+        <planeGeometry args={[0.035, 0.32]} />
+        <meshBasicMaterial color={SILHOUETTE} />
+      </mesh>
+      <mesh position={[0.4, -0.16, 0.03]}>
+        <circleGeometry args={[0.13, 24]} />
+        <meshBasicMaterial color={SILHOUETTE} />
+      </mesh>
+      <mesh position={[0.4, -0.16, 0.032]}>
+        <torusGeometry args={[0.145, 0.026, 8, 16, Math.PI]} />
+        <meshBasicMaterial color={SILHOUETTE} />
+      </mesh>
+      <mesh position={[0.4, -0.31, 0.03]}>
+        <planeGeometry args={[0.09, 0.1]} />
+        <meshBasicMaterial color={SILHOUETTE} />
+      </mesh>
+      <mesh position={[0.4, -0.5, 0.03]}>
+        <planeGeometry args={[0.54, 0.34]} />
+        <meshBasicMaterial color={SILHOUETTE} />
+      </mesh>
+      <mesh position={[0.14, -0.36, 0.03]}>
+        <circleGeometry args={[0.09, 16]} />
+        <meshBasicMaterial color={SILHOUETTE} />
+      </mesh>
+      <mesh position={[0.66, -0.36, 0.03]}>
+        <circleGeometry args={[0.09, 16]} />
+        <meshBasicMaterial color={SILHOUETTE} />
+      </mesh>
+      <mesh position={[0.02, -0.58, 0.028]}>
+        <planeGeometry args={[0.09, 0.1]} />
+        <meshBasicMaterial color={SILHOUETTE} />
+      </mesh>
+      {/* mullions keep it reading as a window */}
+      <mesh position={[0, 0, 0.04]}>
+        <boxGeometry args={[0.07, 2.0, 0.02]} />
+        <meshBasicMaterial color={PAPER} />
+      </mesh>
+      <mesh position={[0, 0.25, 0.04]}>
+        <boxGeometry args={[1.6, 0.07, 0.02]} />
+        <meshBasicMaterial color={PAPER} />
+      </mesh>
+      {/* warm kiss on the surrounding wall (mono-safe outside the rect) */}
+      <pointLight color={AMBER} intensity={6} distance={7} decay={2} position={[0, 0, 1]} />
+    </group>
+  );
+}
+
+/* ----------------------------------------------------------------- cat -- */
+
+function NoirCat({ cx }: { cx: number }) {
+  const group = useRef<Group>(null);
+  const tail = useRef<Mesh>(null);
+  const armed = useRef(true);
+  const ramp = toonRamp();
+
+  useFrame(({ clock }) => {
+    const g = group.current;
+    if (!g) return;
+    const { t } = useScrollStore.getState(); // per-frame read, no selector
+    const p3 = shotP(t, S3);
+    const p4 = shotP(t, S4);
+    const trot = clamp01(p4 / 0.72);
+    const k = clamp01((p4 - 0.72) / 0.28); // the leap window
+
+    // shot 3: walk in frame-left along the parapet (pure f(t))
+    let x = lerp(-7.2, -1.6, p3);
+    let y = 9.32;
+    let z = 2.5;
+    let ry = 0;
+    let rz = 0;
+    let squash = 1;
+
+    if (p4 > 0) {
+      // shot 4 pre-leap: trot toward the facade gap, crouch to anticipate
+      x = lerp(-1.6, -0.9, trot);
+      y = lerp(9.32, 9.02, clamp01(trot * 2));
+      z = lerp(2.5, 0.8, trot);
+      ry = lerp(0, 1.35, clamp01(trot * 4));
+      squash = 1 - 0.25 * clamp01((trot - 0.75) / 0.25);
+    }
+    if (k > 0) {
+      // the LEAP, frame-right toward the window -- the motivated cut (S5b.1).
+      // Flat arc (peak y ~10.4) stays inside the 85->35mm crash frame; the
+      // silhouette crosses the lit window in screen space at p~0.8 and exits
+      // frame-right by p~0.93 (NDC-verified against shot-4 poseAt).
+      x = lerp(-0.9, 6.2, k);
+      y = lerp(9.02, 9.6, k) + 1.1 * Math.sin(Math.PI * k);
+      z = lerp(0.8, -7.0, k);
+      ry = lerp(1.35, 0.85, k);
+      rz = lerp(0.55, -0.35, k);
+      squash = 1;
+      if (armed.current) {
+        armed.current = false;
+        sayWord(lettering.onomatopoeia.cat, [cx + x, y + 0.7, z], 0.37, INK);
+      }
+    } else if (!armed.current && p4 < 0.67) {
+      armed.current = true; // hysteresis re-arm for reverse scrollers
+    }
+
+    g.position.set(x, y, z);
+    g.rotation.set(0, ry, rz);
+    g.scale.set(1.2, 1.2 * squash, 1.2);
+    // 12 fps tail flick -- ambient stepped-time idle (S2.8)
+    if (tail.current) tail.current.rotation.x = Math.sin(stepTime(clock.elapsedTime, 12) * 2.4) * 0.45;
+  });
+
+  return (
+    <group
+      ref={group}
+      position={[-7.2, 9.32, 2.5]}
+      onClick={(e) => {
+        e.stopPropagation();
+        useScrollStore.getState().meow();
+      }}
+    >
+      {/* silhouette cat, built facing +x */}
+      <mesh position={[0, 0.2, 0]}>
+        <boxGeometry args={[0.85, 0.4, 0.32]} />
+        <meshToonMaterial color={SILHOUETTE} gradientMap={ramp} />
+      </mesh>
+      <mesh position={[0.5, 0.52, 0]}>
+        <boxGeometry args={[0.34, 0.34, 0.3]} />
+        <meshToonMaterial color={SILHOUETTE} gradientMap={ramp} />
+      </mesh>
+      <mesh position={[0.58, 0.78, 0.09]} rotation={[0, 0, -0.15]}>
+        <coneGeometry args={[0.08, 0.22, 4]} />
+        <meshToonMaterial color={SILHOUETTE} gradientMap={ramp} />
+      </mesh>
+      <mesh position={[0.58, 0.78, -0.09]} rotation={[0, 0, -0.15]}>
+        <coneGeometry args={[0.08, 0.22, 4]} />
+        <meshToonMaterial color={SILHOUETTE} gradientMap={ramp} />
+      </mesh>
+      <mesh ref={tail} position={[-0.55, 0.45, 0]} rotation={[0, 0, 1.0]}>
+        <cylinderGeometry args={[0.045, 0.06, 0.75, 8]} />
+        <meshToonMaterial color={SILHOUETTE} gradientMap={ramp} />
+      </mesh>
+    </group>
+  );
+}
+
+/* ------------------------------------------------------- street + set -- */
+
+function StreetLevel() {
+  const ramp = toonRamp();
+  const posts = [-7, -5, -3, -1, 1, 3, 5];
+  return (
+    <group>
+      <mesh position={[1, -2, 2]} rotation={[-Math.PI / 2, 0, 0]}>
+        <planeGeometry args={[34, 26]} />
+        <meshToonMaterial color={STREET} gradientMap={ramp} />
+      </mesh>
+      <mesh position={[0, -1.83, 9.9]}>
+        <boxGeometry args={[22, 0.35, 1.4]} />
+        <meshToonMaterial color={WALL_DARK} gradientMap={ramp} />
+      </mesh>
+      {/* FG railing for the street hold */}
+      {posts.map((x) => (
+        <mesh key={x} position={[x, -1.42, 9.2]}>
+          <cylinderGeometry args={[0.045, 0.045, 1.15, 8]} />
+          <meshToonMaterial color={RAIL} gradientMap={ramp} />
+        </mesh>
+      ))}
+      <mesh position={[-1, -0.92, 9.2]}>
+        <boxGeometry args={[12.6, 0.08, 0.08]} />
+        <meshToonMaterial color={RAIL} gradientMap={ramp} />
+      </mesh>
+      <mesh position={[-1, -1.28, 9.2]}>
+        <boxGeometry args={[12.6, 0.08, 0.08]} />
+        <meshToonMaterial color={RAIL} gradientMap={ramp} />
+      </mesh>
+      {/* dead lamppost, MG depth cue */}
+      <mesh position={[4.2, -0.2, 4]}>
+        <cylinderGeometry args={[0.08, 0.1, 3.6, 10]} />
+        <meshToonMaterial color={RAIL} gradientMap={ramp} />
+      </mesh>
+      <mesh position={[4.2, 1.7, 4]}>
+        <boxGeometry args={[0.5, 0.18, 0.25]} />
+        <meshToonMaterial color={RAIL} gradientMap={ramp} />
+      </mesh>
+    </group>
+  );
+}
+
+function FgRoof() {
+  const ramp = toonRamp();
+  return (
+    <group>
+      {/* foreground rooftop building the cat crosses (shots 3-4) */}
+      <mesh position={[-5.75, 3.5, 0]}>
+        <boxGeometry args={[10.5, 11, 6]} />
+        <meshToonMaterial color={WALL_DARK} gradientMap={ramp} />
+      </mesh>
+      <mesh position={[-5.75, 9.15, 2.5]}>
+        <boxGeometry args={[10.5, 0.35, 0.5]} />
+        <meshToonMaterial color={WALL} gradientMap={ramp} />
+      </mesh>
+      {/* rooftop clutter: vent box + pipe for the edge pass */}
+      <mesh position={[-8.5, 9.5, -0.8]}>
+        <boxGeometry args={[1.4, 1.0, 1.1]} />
+        <meshToonMaterial color={WALL} gradientMap={ramp} />
+      </mesh>
+      <mesh position={[-3.4, 9.6, -1.6]}>
+        <cylinderGeometry args={[0.22, 0.22, 1.2, 10]} />
+        <meshToonMaterial color={WALL} gradientMap={ramp} />
+      </mesh>
+    </group>
+  );
+}
+
+/* ----------------------------------------------------------- assembly -- */
+
+export default function Noir({ index }: { index: number }) {
+  const quality = useScrollStore((s) => s.quality); // mount-time, not per-frame
+  const [cx] = issueCenter(index);
+  const rainCount = quality === "low" ? 220 : 460;
+
+  return (
+    <group name="issue-noir" position={issueCenter(index)}>
+      {/* own lights (S2.5): cold key + dim city ambient, no shadows */}
+      <ambientLight intensity={0.5} color="#4A5060" />
+      <directionalLight position={[-6, 14, 8]} intensity={1.3} color="#C9D2E0" />
+      <Facade />
+      <FgRoof />
+      <StreetLevel />
+      <TheWindow cx={cx} />
+      <NoirCat cx={cx} />
+      <Rain key={rainCount} count={rainCount} />
+    </group>
+  );
+}

--- a/issues/01-noir/shots.md
+++ b/issues/01-noir/shots.md
@@ -1,0 +1,25 @@
+# Issue 1 -- NOIR: authored shot list (S0.8 canonical)
+
+Range 0.040-0.108 (RANGES[1]); three intra-issue whip gutters of 0.003.
+Shares apply to the span left after gutters (see shots.ts `seg`).
+
+| # | kind | lens | share of issue | framing |
+|---|---|---|---|---|
+| 1 | hold | 24mm | 0.30 | low dutch from street; window upper-third; FG railing, MG rain, BG facade |
+| 2 | whip | 28mm | 0.15 | vertical whip up the facade; speed lines |
+| 3 | dolly | 50mm | 0.35 | slow push to window; cat silhouette enters frame-left on rooftop FG |
+| 4 | crash | 85->35mm | 0.20 | crash to window; cat leaps frame-right at p~0.8 -- motivated cut |
+
+Notes
+- Shot 3 is the S5b color-reveal composition: the CMYK window lands
+  dead-center at 50mm compression while the rest of the universe stays B&W.
+- Shot 4 opens 85mm tight ON THE CAT (from-target on the crouch spot at
+  local (-0.9, 9.2, 0.8)), then the target racks cat->window as the camera
+  slams in. The leap window is p 0.72-1.0 with a flat arc (peak y ~10.4,
+  end local (6.2, 9.6, -7.0)): the silhouette crosses the lit window in
+  screen space at p~0.8 and is fully out frame-right by p~0.93, leaving
+  the window dead-center for the cut (gate fix attempt 1, NDC-verified).
+- Depth planes: 1 railing/rain/facade; 2 rain/window-grid/roofline;
+  3 parapet+cat/rain/window; 4 cat/window/facade wall.
+- Lettering.tsx maps the 3 noir captions onto shots 1-3 automatically.
+- Screen direction: cat exits frame-right; Issue 2 opens on the landing.

--- a/issues/01-noir/shots.ts
+++ b/issues/01-noir/shots.ts
@@ -1,0 +1,98 @@
+import { easeInOut, type EaseFn, type Shot, type Vec3 } from "@/lib/shots";
+import { issueCenter, RANGES } from "../timeline";
+
+/**
+ * Issue 1 -- NOIR authored shot list (S0.8 canonical table, see shots.md):
+ * hold 24mm 0.30 / whip 28mm 0.15 / dolly 50mm 0.35 / crash 85->35mm 0.20,
+ * chained inside RANGES[1] with three intra-issue whip gutters. Everything
+ * here is pure data; Lettering.tsx maps the 3 noir captions onto shots 1-3.
+ */
+
+/** vertical fov in degrees for a full-frame lens: 2*atan(12/mm) */
+const lens = (mm: number) => (2 * Math.atan(12 / mm) * 180) / Math.PI;
+
+/** crash grammar: hang back on the cat, slam in the last quarter */
+const easeInCubic: EaseFn = (x) => x * x * x;
+
+const [S, E] = RANGES[1]!;
+/** intra-issue whip gutters carved from the range (deadband-safe width) */
+const GUTTER = 0.003;
+const SHARES = [0.3, 0.15, 0.35, 0.2];
+const SPAN = E - S - GUTTER * (SHARES.length - 1);
+
+const seg = (i: number): [number, number] => {
+  let a = S;
+  for (let k = 0; k < i; k++) a += SHARES[k]! * SPAN + GUTTER;
+  return [a, a + SHARES[i]! * SPAN];
+};
+
+const [cx, cy, cz] = issueCenter(1);
+const at = (x: number, y: number, z: number): Vec3 => [cx + x, cy + y, cz + z];
+
+/** local-space center of THE window; shaders/colorWindow rect lives here too */
+export const NOIR_WINDOW = { x: 2.5, y: 10.5, z: -7.82 };
+
+export const NOIR_SHOTS: Shot[] = [
+  {
+    // low dutch from the street: FG railing, MG rain, BG facade,
+    // the one lit window in the upper third
+    id: "noir-street-hold",
+    issue: 1,
+    range: seg(0),
+    kind: "hold",
+    from: { position: at(-1.6, -1.1, 12.5), target: at(1.2, 5.2, -8), roll: -0.1, fov: lens(24) },
+    to: { position: at(-1.0, -0.9, 11.9), target: at(1.5, 5.6, -8), roll: -0.085, fov: lens(24) },
+    ease: easeInOut,
+  },
+  {
+    // vertical whip up the facade; velocity-driven speed lines from post
+    id: "noir-facade-whip",
+    issue: 1,
+    range: seg(1),
+    kind: "whip",
+    from: { position: at(1.0, 0.5, 3.5), target: at(2.5, 2.0, -8), roll: 0.02, fov: lens(28) },
+    to: { position: at(1.0, 13.5, 3.5), target: at(2.5, 17.5, -8), roll: -0.02, fov: lens(28) },
+    ease: easeInOut,
+  },
+  {
+    // slow 50mm push, window dead-center: the color reveal composition
+    // (S5b jaw-drop); cat silhouette walks in frame-left on the rooftop FG
+    id: "noir-window-dolly",
+    issue: 1,
+    range: seg(2),
+    kind: "dolly",
+    from: {
+      position: at(-4.5, 9.7, 10.5),
+      target: at(NOIR_WINDOW.x, NOIR_WINDOW.y, NOIR_WINDOW.z),
+      roll: 0.03,
+      fov: lens(50),
+    },
+    to: {
+      position: at(-0.5, 10.05, 4.0),
+      target: at(NOIR_WINDOW.x, NOIR_WINDOW.y, NOIR_WINDOW.z),
+      roll: 0,
+      fov: lens(50),
+    },
+    ease: easeInOut,
+  },
+  {
+    // 85mm tight on the cat (from-target sits ON the crouch spot so the
+    // cat holds frame through the rack), then the target racks to the
+    // window as the camera crashes; the cat leaps frame-right from p~0.72,
+    // crosses the lit window in screen space at p~0.8 and is fully out
+    // frame-right by p~0.93 -- motivated cut (gate fix attempt 1,
+    // framing iteration 1/3, verified by NDC projection sweep)
+    id: "noir-window-crash",
+    issue: 1,
+    range: seg(3),
+    kind: "crash",
+    from: { position: at(-1.2, 9.4, 10.5), target: at(-0.9, 9.2, 0.8), roll: -0.04, fov: lens(85) },
+    to: {
+      position: at(1.3, 10.3, -3.4),
+      target: at(NOIR_WINDOW.x, NOIR_WINDOW.y, NOIR_WINDOW.z),
+      roll: 0,
+      fov: lens(35),
+    },
+    ease: easeInCubic,
+  },
+];

--- a/issues/02-desk/Desk.tsx
+++ b/issues/02-desk/Desk.tsx
@@ -1,0 +1,698 @@
+"use client";
+
+import { useLayoutEffect, useRef } from "react";
+import { useFrame } from "@react-three/fiber";
+import { PerspectiveCamera, RenderTexture } from "@react-three/drei";
+import { BackSide, Color, Matrix4, Vector3, type Group, type InstancedMesh, type Mesh } from "three";
+import { toonRamp } from "@/lib/toon";
+import { stepTime } from "@/lib/steppedClock";
+import { useScrollStore } from "@/lib/scrollStore";
+import { sayWord } from "@/lib/onomatopoeia";
+import { lettering } from "@/lib/content";
+import { clamp01, easeInOut, lerp } from "@/lib/shots";
+import { issueCenter } from "../timeline";
+import { KEYS_R, LAND_R, MON_R, PANELS_R } from "./shots";
+
+/**
+ * Issue 2 - Desk: warm full-color halftone world (S0.4 row 2).
+ * Everything scroll-driven is pure f(t) read via getState() in useFrame;
+ * idle motion (tail flick, RGB strip, cursor) samples stepTime (S2.8).
+ * Jaw-drop: live 3-panel RT composite, mounted only inside its t window
+ * (3 live RTs high tier, 2 on low - the keyboard panel goes flat).
+ */
+
+const PAPER = "#F6EFE3";
+const INK = "#1C1B1A";
+const ORANGE = "#F5A623";
+const TEAL = "#2BB3A3";
+const RED = "#E2574C";
+const WOOD = "#D9A967";
+
+const CENTER = issueCenter(2);
+const CX = CENTER[0];
+
+// -- shared scratch (zero per-frame allocation) ------------------------------
+const MAT = new Matrix4();
+const COL = new Color();
+
+const crossed = (last: number, now: number, trig: number) =>
+  (last < trig && now >= trig) || (last > trig && now <= trig);
+
+// -- onomatopoeia pools (from content.ts; single-word slices stay pooled) ----
+const CAT_WORDS = lettering.onomatopoeia.cat as readonly string[];
+const KEYCAP_WORDS = lettering.onomatopoeia.keycaps;
+const THUMP = CAT_WORDS.filter((w) => w === "THUMP");
+const PADD = CAT_WORDS.filter((w) => w === "PADD");
+const THUMP_T = LAND_R[0] + 0.35 * (LAND_R[1] - LAND_R[0]);
+const THUMP_POS = new Vector3(CX - 2.7, 1.1, 0.9);
+const BAT_T = MON_R[0] + 0.86 * (MON_R[1] - MON_R[0]);
+const BAT_POS = new Vector3(CX - 0.45, 1.85, -0.05);
+
+// -- keyboard grid -----------------------------------------------------------
+const KEY_COLS = 13;
+const KEY_ROWS = 5;
+const KEY_COUNT = KEY_COLS * KEY_ROWS;
+const KB_X = 0.3;
+const KB_Z = 1.1;
+const KEY_Y = 0.16;
+const keyX = (col: number) => KB_X + (col - (KEY_COLS - 1) / 2) * 0.2;
+const keyZ = (row: number) => KB_Z + (row - (KEY_ROWS - 1) / 2) * 0.19;
+
+/** CLACK triggers along the shot-2 track (camera moves -x -> +x). */
+const CLACK_ROWS = [2, 1, 3, 2, 1, 2] as const;
+const CLACKS = [0.12, 0.3, 0.46, 0.62, 0.76, 0.9].map((p, j) => {
+  const col = Math.round(lerp(1, KEY_COLS - 2, p));
+  const row = CLACK_ROWS[j]!;
+  return {
+    t: KEYS_R[0] + p * (KEYS_R[1] - KEYS_R[0]),
+    idx: row * KEY_COLS + col,
+    pos: new Vector3(CX + keyX(col), 0.5, keyZ(row)),
+    seed: j * 0.161 + 0.05,
+  };
+});
+const KEY_TRIG = new Map(CLACKS.map((c) => [c.idx, c.t]));
+const DIP_HALF = 0.0012; // t half-width of a key dip envelope
+
+function KeyboardUnit({ say }: { say: boolean }) {
+  const inst = useRef<InstancedMesh>(null);
+  const lastT = useRef<number | null>(null);
+  const ramp = toonRamp();
+
+  useLayoutEffect(() => {
+    const m = inst.current;
+    if (!m) return;
+    for (let i = 0; i < KEY_COUNT; i++) {
+      const accent = (i * 37) % 97 < 12;
+      COL.set(accent ? [ORANGE, TEAL, RED][i % 3]! : INK);
+      m.setColorAt(i, COL);
+    }
+    if (m.instanceColor) m.instanceColor.needsUpdate = true;
+  }, []);
+
+  useFrame(() => {
+    const m = inst.current;
+    if (!m) return;
+    const { t, reducedMotion } = useScrollStore.getState();
+    for (let row = 0; row < KEY_ROWS; row++) {
+      for (let col = 0; col < KEY_COLS; col++) {
+        const idx = row * KEY_COLS + col;
+        const trig = KEY_TRIG.get(idx);
+        let dip = 0;
+        if (trig !== undefined) {
+          const b = Math.max(0, 1 - Math.abs(t - trig) / DIP_HALF);
+          dip = b * b * (3 - 2 * b) * 0.06;
+        }
+        MAT.makeTranslation(keyX(col), KEY_Y - dip, keyZ(row));
+        m.setMatrixAt(idx, MAT);
+      }
+    }
+    m.instanceMatrix.needsUpdate = true;
+    if (say) {
+      const last = lastT.current;
+      lastT.current = t;
+      if (last !== null && !reducedMotion) {
+        for (const c of CLACKS) {
+          if (crossed(last, t, c.t)) sayWord(KEYCAP_WORDS, c.pos, c.seed, ORANGE);
+        }
+      }
+    }
+  });
+
+  return (
+    <group>
+      <mesh position={[KB_X, 0.06, KB_Z]}>
+        <boxGeometry args={[3.0, 0.12, 1.15]} />
+        <meshToonMaterial color="#E7DECE" gradientMap={ramp} />
+      </mesh>
+      <instancedMesh ref={inst} args={[undefined, undefined, KEY_COUNT]}>
+        <boxGeometry args={[0.16, 0.09, 0.15]} />
+        <meshToonMaterial color="#FFFFFF" gradientMap={ramp} />
+      </instancedMesh>
+    </group>
+  );
+}
+
+// -- RGB strip along the desk's back edge, hue-cycled on stepped time --------
+const STRIP_N = 24;
+
+function LightStrip() {
+  const inst = useRef<InstancedMesh>(null);
+
+  useLayoutEffect(() => {
+    const m = inst.current;
+    if (!m) return;
+    for (let i = 0; i < STRIP_N; i++) {
+      MAT.makeTranslation(-4.4 + i * (8.8 / (STRIP_N - 1)), 0.08, -2.35);
+      m.setMatrixAt(i, MAT);
+      COL.setHSL(i / STRIP_N, 0.8, 0.6);
+      m.setColorAt(i, COL);
+    }
+    m.instanceMatrix.needsUpdate = true;
+    if (m.instanceColor) m.instanceColor.needsUpdate = true;
+  }, []);
+
+  useFrame(({ clock }) => {
+    const m = inst.current;
+    if (!m) return;
+    const s = stepTime(clock.elapsedTime, 12);
+    for (let i = 0; i < STRIP_N; i++) {
+      COL.setHSL((i / STRIP_N + s * 0.12) % 1, 0.8, 0.6);
+      m.setColorAt(i, COL);
+    }
+    if (m.instanceColor) m.instanceColor.needsUpdate = true;
+  });
+
+  return (
+    <instancedMesh ref={inst} args={[undefined, undefined, STRIP_N]}>
+      <boxGeometry args={[0.3, 0.09, 0.09]} />
+      <meshBasicMaterial color="#FFFFFF" />
+    </instancedMesh>
+  );
+}
+
+// -- monitor screen content (reused live on the desk AND inside RT panel 3) --
+const frac = (x: number) => x - Math.floor(x);
+const CODE_COLORS = [TEAL, ORANGE, RED, "#EDE6D6"] as const;
+const CODE_ROWS = Array.from({ length: 12 }, (_, i) => ({
+  indent: (i % 4) * 0.18,
+  w: 0.5 + frac(Math.sin((i + 1) * 12.9898) * 43758.5453) * 1.5,
+  color: CODE_COLORS[i % 4]!,
+}));
+
+function ScreenContent() {
+  const cursor = useRef<Mesh>(null);
+  useFrame(({ clock }) => {
+    if (cursor.current) cursor.current.visible = Math.floor(clock.elapsedTime * 2) % 2 === 0;
+  });
+  return (
+    <group>
+      <mesh>
+        <planeGeometry args={[3.2, 1.8]} />
+        <meshBasicMaterial color="#232020" />
+      </mesh>
+      {CODE_ROWS.map((r, i) => (
+        <mesh key={i} position={[-1.45 + r.indent + r.w / 2, 0.72 - i * 0.125, 0.005]}>
+          <planeGeometry args={[r.w, 0.055]} />
+          <meshBasicMaterial color={r.color} />
+        </mesh>
+      ))}
+      <mesh ref={cursor} position={[-1.2, 0.72 - 12 * 0.125, 0.006]}>
+        <planeGeometry args={[0.05, 0.09]} />
+        <meshBasicMaterial color={PAPER} />
+      </mesh>
+    </group>
+  );
+}
+
+// -- the cat (through-line, S5b.1) -------------------------------------------
+// Enters frame-left (Noir exits frame-right), lands with a THUMP, loafs,
+// then sits by the monitor for shot 4 and bats the halftone dot. All
+// positions pure f(t); tail flick samples 12 fps stepped time.
+const MON_SWITCH = PANELS_R[1] + 0.002; // reposition hidden inside the whip gutter
+
+function DeskCat({ say = false }: { say?: boolean }) {
+  const grp = useRef<Group>(null);
+  const head = useRef<Group>(null);
+  const tail = useRef<Group>(null);
+  const paw = useRef<Group>(null);
+  const lines = useRef<Group>(null);
+  const lastT = useRef<number | null>(null);
+  const ramp = toonRamp();
+
+  useFrame(({ clock }) => {
+    const g = grp.current;
+    if (!g || !head.current || !tail.current || !paw.current || !lines.current) return;
+    const { t, reducedMotion } = useScrollStore.getState();
+    const s = stepTime(clock.elapsedTime, 12);
+    let flick = Math.sin(s * 2.2) * 0.35;
+    let wrap = 0;
+    let pawSwing = 0;
+    let arc = 0;
+    // scrub-safe defaults (shot 4 overrides them; scrolling back restores)
+    head.current.rotation.z = 0;
+    paw.current.position.set(0.5, 0.42, 0.16);
+
+    if (t < MON_SWITCH) {
+      const p1 = clamp01((t - LAND_R[0]) / (LAND_R[1] - LAND_R[0]));
+      if (p1 < 0.35) {
+        // airborne arc in from frame-left (upper), stretched
+        const a = p1 / 0.35;
+        g.position.set(lerp(-6.4, -2.7, a), 3.1 * (1 - a) * (1 - a), 0.9);
+        g.rotation.set(0, 0, lerp(0.4, -0.05, a));
+        g.scale.set(1.12, 0.9, 1);
+        head.current.position.set(0.5, 0.62, 0);
+      } else {
+        // land (squash) then curl into a loaf
+        const q = clamp01((p1 - 0.35) / 0.15);
+        const squash = Math.sin(Math.PI * q);
+        const c = easeInOut(clamp01((p1 - 0.5) / 0.5));
+        g.position.set(-2.7, 0, 0.9);
+        g.rotation.set(0, 0, 0);
+        g.scale.set(1 + 0.18 * squash, 1 - 0.28 * squash - 0.12 * c, 1);
+        head.current.position.set(lerp(0.5, 0.42, c), lerp(0.62, 0.46, c), 0);
+        wrap = 1.4 * c;
+        flick *= 1 - 0.6 * c; // calmer tail once loafed
+      }
+    } else {
+      // shot 4: perched frame-right between camera and monitor (FG depth
+      // plane), gazing up at the bobbing dot. Rears up (wind-up), whips the
+      // paw at p4 ~ 0.86 -- contact matches the DotBat launch -- then
+      // settles. All envelopes pure f(p4), scrub-safe.
+      const p4 = clamp01((t - MON_R[0]) / (MON_R[1] - MON_R[0]));
+      const rear = easeInOut(clamp01((p4 - 0.7) / 0.15));
+      const strike = easeInOut(clamp01((p4 - 0.845) / 0.035));
+      const settle = easeInOut(clamp01((p4 - 0.93) / 0.07));
+      const up = rear * (1 - 0.45 * settle);
+      const pop = Math.sin(Math.PI * clamp01((p4 - 0.845) / 0.05)); // one-beat scale pop, no flash
+      g.position.set(-1.35, 0.3 * up, -0.5);
+      g.rotation.set(0, -0.3, 0.3 * up);
+      g.scale.setScalar(1 + 0.09 * pop);
+      head.current.position.set(0.5, 0.74, 0);
+      head.current.rotation.z = 0.15 * up + 0.06 * Math.sin(s * 2.4); // tracks the dot bob
+      paw.current.position.set(lerp(0.5, 0.82, strike), lerp(0.42, 0.6, strike), 0.16);
+      pawSwing = -0.7 * rear + 2.6 * strike * (1 - 0.55 * settle);
+      flick += 0.9 * up;
+      wrap = 0.35;
+      arc = Math.sin(Math.PI * clamp01((p4 - 0.85) / 0.06));
+    }
+
+    tail.current.rotation.set(flick, wrap, 0.9);
+    paw.current.rotation.set(0, 0, pawSwing);
+    lines.current.scale.setScalar(Math.max(arc, 1e-4));
+
+    if (say) {
+      const last = lastT.current;
+      lastT.current = t;
+      if (last !== null && !reducedMotion) {
+        if (crossed(last, t, THUMP_T)) sayWord(THUMP.length ? THUMP : CAT_WORDS, THUMP_POS, 0, "#FFFFFF");
+        if (crossed(last, t, BAT_T)) sayWord(PADD.length ? PADD : CAT_WORDS, BAT_POS, 0, TEAL);
+      }
+    }
+  });
+
+  return (
+    <group ref={grp}>
+      {/* body + paper rim outline (inverted hull) so ink reads against the
+          ink monitor bezel and dark screen, not just the wood */}
+      <mesh position={[0, 0.3, 0]}>
+        <boxGeometry args={[0.95, 0.5, 0.48]} />
+        <meshToonMaterial color={INK} gradientMap={ramp} />
+      </mesh>
+      <mesh position={[0, 0.3, 0]}>
+        <boxGeometry args={[1.01, 0.56, 0.54]} />
+        <meshBasicMaterial color={PAPER} side={BackSide} />
+      </mesh>
+      {/* chest patch */}
+      <mesh position={[0.44, 0.26, 0]}>
+        <boxGeometry args={[0.08, 0.26, 0.2]} />
+        <meshToonMaterial color={PAPER} gradientMap={ramp} />
+      </mesh>
+      {/* collar + tag */}
+      <mesh position={[0.42, 0.5, 0]}>
+        <boxGeometry args={[0.12, 0.07, 0.4]} />
+        <meshToonMaterial color={TEAL} gradientMap={ramp} />
+      </mesh>
+      <mesh position={[0.48, 0.43, 0]}>
+        <boxGeometry args={[0.05, 0.08, 0.08]} />
+        <meshToonMaterial color={RED} gradientMap={ramp} />
+      </mesh>
+      <group ref={head} position={[0.5, 0.62, 0]}>
+        <mesh>
+          <boxGeometry args={[0.44, 0.42, 0.42]} />
+          <meshToonMaterial color={INK} gradientMap={ramp} />
+        </mesh>
+        <mesh>
+          <boxGeometry args={[0.5, 0.48, 0.48]} />
+          <meshBasicMaterial color={PAPER} side={BackSide} />
+        </mesh>
+        {/* ears + orange inner ears */}
+        <mesh position={[0.08, 0.28, 0.12]} rotation={[0, 0, 0.25]}>
+          <coneGeometry args={[0.09, 0.22, 4]} />
+          <meshToonMaterial color={INK} gradientMap={ramp} />
+        </mesh>
+        <mesh position={[0.08, 0.28, -0.12]} rotation={[0, 0, -0.25]}>
+          <coneGeometry args={[0.09, 0.22, 4]} />
+          <meshToonMaterial color={INK} gradientMap={ramp} />
+        </mesh>
+        <mesh position={[0.1, 0.27, 0.12]} rotation={[0, 0, 0.25]}>
+          <coneGeometry args={[0.05, 0.14, 4]} />
+          <meshBasicMaterial color={ORANGE} />
+        </mesh>
+        <mesh position={[0.1, 0.27, -0.12]} rotation={[0, 0, -0.25]}>
+          <coneGeometry args={[0.05, 0.14, 4]} />
+          <meshBasicMaterial color={ORANGE} />
+        </mesh>
+        {/* eyes: flat orange + ink pupils (comic cat stare) */}
+        <mesh position={[0.225, 0.06, 0.11]}>
+          <boxGeometry args={[0.035, 0.11, 0.1]} />
+          <meshBasicMaterial color={ORANGE} />
+        </mesh>
+        <mesh position={[0.225, 0.06, -0.11]}>
+          <boxGeometry args={[0.035, 0.11, 0.1]} />
+          <meshBasicMaterial color={ORANGE} />
+        </mesh>
+        <mesh position={[0.235, 0.04, 0.11]}>
+          <boxGeometry args={[0.03, 0.06, 0.035]} />
+          <meshBasicMaterial color={INK} />
+        </mesh>
+        <mesh position={[0.235, 0.04, -0.11]}>
+          <boxGeometry args={[0.03, 0.06, 0.035]} />
+          <meshBasicMaterial color={INK} />
+        </mesh>
+        {/* paper muzzle + red nose */}
+        <mesh position={[0.225, -0.12, 0]}>
+          <boxGeometry args={[0.05, 0.13, 0.15]} />
+          <meshToonMaterial color={PAPER} gradientMap={ramp} />
+        </mesh>
+        <mesh position={[0.245, -0.05, 0]}>
+          <boxGeometry args={[0.03, 0.04, 0.05]} />
+          <meshBasicMaterial color={RED} />
+        </mesh>
+      </group>
+      <group ref={paw} position={[0.5, 0.42, 0.16]}>
+        <mesh position={[0, -0.18, 0]}>
+          <cylinderGeometry args={[0.055, 0.06, 0.36, 8]} />
+          <meshToonMaterial color={INK} gradientMap={ramp} />
+        </mesh>
+        {/* paper sock on the batting paw */}
+        <mesh position={[0, -0.33, 0]}>
+          <cylinderGeometry args={[0.06, 0.065, 0.1, 8]} />
+          <meshToonMaterial color={PAPER} gradientMap={ramp} />
+        </mesh>
+      </group>
+      <group ref={tail} position={[-0.48, 0.4, 0]}>
+        <mesh position={[-0.18, 0.18, 0]} rotation={[0, 0, 0.9]}>
+          <cylinderGeometry args={[0.05, 0.07, 0.55, 8]} />
+          <meshToonMaterial color={INK} gradientMap={ramp} />
+        </mesh>
+        <mesh position={[-0.37, 0.34, 0]} rotation={[0, 0, 0.9]}>
+          <cylinderGeometry args={[0.042, 0.05, 0.16, 8]} />
+          <meshToonMaterial color={ORANGE} gradientMap={ramp} />
+        </mesh>
+      </group>
+      {/* bat motion lines: speed-line fan at the strike arc, scale = f(p4) */}
+      <group ref={lines} position={[1.32, 0.95, 0.2]} scale={0.0001}>
+        <mesh position={[0, 0.12, 0]} rotation={[0, 0, 0.5]}>
+          <boxGeometry args={[0.3, 0.028, 0.01]} />
+          <meshBasicMaterial color={ORANGE} />
+        </mesh>
+        <mesh position={[0.06, 0, 0]} rotation={[0, 0, 0.05]}>
+          <boxGeometry args={[0.34, 0.028, 0.01]} />
+          <meshBasicMaterial color={ORANGE} />
+        </mesh>
+        <mesh position={[0, -0.12, 0]} rotation={[0, 0, -0.4]}>
+          <boxGeometry args={[0.3, 0.028, 0.01]} />
+          <meshBasicMaterial color={ORANGE} />
+        </mesh>
+      </group>
+    </group>
+  );
+}
+
+// -- floating halftone dot + bat trajectory (motivates the dot-zoom out) -----
+function DotBat() {
+  const ref = useRef<Group>(null);
+  useFrame(({ clock }) => {
+    const g = ref.current;
+    if (!g) return;
+    const { t } = useScrollStore.getState();
+    g.visible = t > PANELS_R[1];
+    if (!g.visible) return;
+    const p4 = clamp01((t - MON_R[0]) / (MON_R[1] - MON_R[0]));
+    const s = stepTime(clock.elapsedTime, 12);
+    const v = clamp01((p4 - 0.86) / 0.13);
+    const e = 1 - (1 - v) * (1 - v);
+    const bob = 0.09 * Math.sin(s * 2.4) * (1 - v);
+    g.position.set(lerp(-0.6, 0.2, e), lerp(1.3, 1.4, e) + bob, lerp(-0.15, -1.35, e));
+    g.scale.setScalar(lerp(1, 0.45, e));
+  });
+  return (
+    <group ref={ref}>
+      <mesh position={[0, 0, -0.005]}>
+        <circleGeometry args={[0.19, 24]} />
+        <meshBasicMaterial color={INK} />
+      </mesh>
+      <mesh>
+        <circleGeometry args={[0.16, 24]} />
+        <meshBasicMaterial color={ORANGE} />
+      </mesh>
+    </group>
+  );
+}
+
+// -- jaw-drop: live 3-panel composite (S0.6: max 3 live RTs, half-res) -------
+// Wall floats at y=8 so no desk shot frustum ever clips it. Mounted only
+// inside its t window; on low tier the keyboard panel drops to a flat quad
+// (3 -> 2 live RTs; the snapshot rung is engine-side ladder work).
+const WALL_Y = 8;
+const WALL_Z = 2.9;
+const PANEL_W = 1.4;
+const PANEL_H = 2.3;
+const PANEL_X = [-1.55, 0, 1.55] as const;
+const RT_W = 288;
+const RT_H = 448;
+
+const backOut = (x: number) => {
+  const c1 = 1.70158;
+  const y = x - 1;
+  return 1 + (c1 + 1) * y * y * y + c1 * y * y;
+};
+
+const FG_DOTS = [
+  { x: -2.3, y: 1.1, z: 2.2, r: 0.1, color: ORANGE },
+  { x: 1.9, y: -0.8, z: 2.6, r: 0.07, color: TEAL },
+  { x: 2.6, y: 1.4, z: 1.8, r: 0.12, color: ORANGE },
+  { x: -1.6, y: -1.3, z: 2.4, r: 0.08, color: RED },
+  { x: 0.4, y: 1.7, z: 2.9, r: 0.06, color: TEAL },
+];
+
+function PanelWall({ low }: { low: boolean }) {
+  const p0 = useRef<Group>(null);
+  const p1 = useRef<Group>(null);
+  const p2 = useRef<Group>(null);
+
+  useFrame(() => {
+    const { t } = useScrollStore.getState();
+    const p = clamp01((t - PANELS_R[0]) / (PANELS_R[1] - PANELS_R[0]));
+    const groups = [p0.current, p1.current, p2.current];
+    for (let i = 0; i < 3; i++) {
+      const g = groups[i];
+      if (!g) continue;
+      const si = clamp01((p - (0.04 + i * 0.07)) / 0.1);
+      const pop = Math.max(backOut(si), 0.001);
+      if (i < 2) {
+        g.scale.set(pop, pop, 1);
+      } else {
+        // monitor panel grows to full bleed (content is horizontal code
+        // bars, so the x-stretch reads as longer lines, not distortion)
+        const gr = easeInOut(clamp01((p - 0.72) / 0.26));
+        g.position.set(lerp(PANEL_X[2], 0, gr), 0, WALL_Z + 0.4 * gr);
+        g.scale.set(pop * lerp(1, 5.0, gr), pop * lerp(1, 1.45, gr), 1);
+      }
+    }
+  });
+
+  return (
+    <group position={[0, WALL_Y, 0]}>
+      {/* paper backdrop: hides the desk set behind the composite */}
+      <mesh position={[0, 0, WALL_Z - 0.5]}>
+        <planeGeometry args={[20, 9]} />
+        <meshBasicMaterial color={PAPER} />
+      </mesh>
+      {/* FG floating halftone dots: depth plane + foreshadow the dot exit */}
+      {FG_DOTS.map((d, i) => (
+        <mesh key={i} position={[d.x, d.y, WALL_Z + d.z]}>
+          <circleGeometry args={[d.r, 20]} />
+          <meshBasicMaterial color={d.color} />
+        </mesh>
+      ))}
+
+      {/* panel 1: keyboard macro (live RT on high tier, flat on low) */}
+      <group ref={p0} position={[PANEL_X[0], 0, WALL_Z]}>
+        <mesh position={[0, 0, -0.012]}>
+          <planeGeometry args={[PANEL_W + 0.1, PANEL_H + 0.1]} />
+          <meshBasicMaterial color={INK} />
+        </mesh>
+        {low ? (
+          <group>
+            <mesh>
+              <planeGeometry args={[PANEL_W, PANEL_H]} />
+              <meshBasicMaterial color={PAPER} />
+            </mesh>
+            {Array.from({ length: 12 }, (_, i) => (
+              <mesh key={i} position={[-0.42 + (i % 3) * 0.42, 0.66 - Math.floor(i / 3) * 0.44, 0.004]}>
+                <planeGeometry args={[0.3, 0.3]} />
+                <meshBasicMaterial color={i === 4 ? ORANGE : INK} />
+              </mesh>
+            ))}
+          </group>
+        ) : (
+          <mesh>
+            <planeGeometry args={[PANEL_W, PANEL_H]} />
+            <meshBasicMaterial>
+              <RenderTexture attach="map" width={RT_W} height={RT_H}>
+                <color attach="background" args={[PAPER]} />
+                <ambientLight intensity={0.9} color={PAPER} />
+                <directionalLight position={[2, 4, 3]} intensity={1.4} />
+                <PerspectiveCamera
+                  makeDefault
+                  position={[1.6, 1.1, 2.6]}
+                  fov={35}
+                  onUpdate={(c) => c.lookAt(KB_X, 0.12, KB_Z)}
+                />
+                <KeyboardUnit say={false} />
+              </RenderTexture>
+            </meshBasicMaterial>
+          </mesh>
+        )}
+      </group>
+
+      {/* panel 2: the cat, live (same pure-f(t) loaf as the main set) */}
+      <group ref={p1} position={[PANEL_X[1], 0, WALL_Z]}>
+        <mesh position={[0, 0, -0.012]}>
+          <planeGeometry args={[PANEL_W + 0.1, PANEL_H + 0.1]} />
+          <meshBasicMaterial color={INK} />
+        </mesh>
+        <mesh>
+          <planeGeometry args={[PANEL_W, PANEL_H]} />
+          <meshBasicMaterial>
+            <RenderTexture attach="map" width={RT_W} height={RT_H}>
+              <color attach="background" args={["#F0E3C8"]} />
+              <ambientLight intensity={0.9} color={PAPER} />
+              <directionalLight position={[3, 5, 4]} intensity={1.5} />
+              <PerspectiveCamera
+                makeDefault
+                position={[-0.8, 1.2, 3.0]}
+                fov={38}
+                onUpdate={(c) => c.lookAt(-2.7, 0.35, 0.9)}
+              />
+              <DeskCat />
+            </RenderTexture>
+          </meshBasicMaterial>
+        </mesh>
+      </group>
+
+      {/* panel 3: the monitor -- grows to full bleed at p > 0.72 */}
+      <group ref={p2} position={[PANEL_X[2], 0, WALL_Z]}>
+        <mesh position={[0, 0, -0.012]}>
+          <planeGeometry args={[PANEL_W + 0.1, PANEL_H + 0.1]} />
+          <meshBasicMaterial color={INK} />
+        </mesh>
+        <mesh>
+          <planeGeometry args={[PANEL_W, PANEL_H]} />
+          <meshBasicMaterial>
+            <RenderTexture attach="map" width={RT_W} height={RT_H}>
+              <color attach="background" args={["#232020"]} />
+              <PerspectiveCamera
+                makeDefault
+                position={[0, 0, 2.1]}
+                fov={52}
+                onUpdate={(c) => c.lookAt(0, 0, 0)}
+              />
+              <ScreenContent />
+            </RenderTexture>
+          </meshBasicMaterial>
+        </mesh>
+      </group>
+    </group>
+  );
+}
+
+// -- the set ------------------------------------------------------------------
+// Mount window: composite live only while shot 3 films (whip cutPoints at
+// t=0.168 in / t=0.194 out; margins keep RT warm-up off-screen).
+const PANELS_ON = PANELS_R[0] - 0.0035;
+const PANELS_OFF = PANELS_R[1] + 0.002;
+
+export default function Desk({ index }: { index: number }) {
+  const ramp = toonRamp();
+  const panelsOn = useScrollStore((s) => s.t > PANELS_ON && s.t < PANELS_OFF);
+  const low = useScrollStore((s) => s.quality === "low");
+
+  return (
+    <group name="issue-desk" position={issueCenter(index)}>
+      <ambientLight intensity={0.85} color={PAPER} />
+      <directionalLight position={[5, 9, 6]} intensity={1.5} color="#FFF6E8" />
+
+      {/* room */}
+      <mesh position={[0, -2.8, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+        <planeGeometry args={[26, 16]} />
+        <meshToonMaterial color="#E7DECE" gradientMap={ramp} />
+      </mesh>
+      <mesh position={[0, 2, -2.6]}>
+        <planeGeometry args={[26, 16]} />
+        <meshToonMaterial color="#EFE4CF" gradientMap={ramp} />
+      </mesh>
+      {/* wall posters (BG depth plane for the landing shot) */}
+      <mesh position={[-3.6, 3.1, -2.55]}>
+        <planeGeometry args={[1.4, 1.9]} />
+        <meshToonMaterial color={TEAL} gradientMap={ramp} />
+      </mesh>
+      <mesh position={[3.9, 3.4, -2.55]} rotation={[0, 0, -0.04]}>
+        <planeGeometry args={[1.2, 1.6]} />
+        <meshToonMaterial color={ORANGE} gradientMap={ramp} />
+      </mesh>
+
+      {/* desk */}
+      <mesh position={[0, -0.18, 0]}>
+        <boxGeometry args={[11, 0.35, 5.2]} />
+        <meshToonMaterial color={WOOD} gradientMap={ramp} />
+      </mesh>
+      <mesh position={[-5.0, -1.6, 0]}>
+        <boxGeometry args={[0.4, 2.6, 4.8]} />
+        <meshToonMaterial color={WOOD} gradientMap={ramp} />
+      </mesh>
+      <mesh position={[5.0, -1.6, 0]}>
+        <boxGeometry args={[0.4, 2.6, 4.8]} />
+        <meshToonMaterial color={WOOD} gradientMap={ramp} />
+      </mesh>
+
+      {/* monitor + live screen */}
+      <group position={[0.2, 1.35, -1.5]}>
+        <mesh>
+          <boxGeometry args={[3.6, 2.14, 0.14]} />
+          <meshToonMaterial color={INK} gradientMap={ramp} />
+        </mesh>
+        <group position={[0, 0, 0.08]}>
+          <ScreenContent />
+        </group>
+      </group>
+      <mesh position={[0.2, 0.35, -1.5]}>
+        <boxGeometry args={[0.35, 0.55, 0.3]} />
+        <meshToonMaterial color={INK} gradientMap={ramp} />
+      </mesh>
+      <mesh position={[0.2, 0.03, -1.5]}>
+        <boxGeometry args={[1.2, 0.06, 0.7]} />
+        <meshToonMaterial color={INK} gradientMap={ramp} />
+      </mesh>
+
+      {/* props: mug FG-left, paper stack, lamp frame-right */}
+      <mesh position={[-4.1, 0.34, 2.0]}>
+        <cylinderGeometry args={[0.22, 0.2, 0.5, 16]} />
+        <meshToonMaterial color={RED} gradientMap={ramp} />
+      </mesh>
+      <mesh position={[-4.3, 0.08, 0.1]} rotation={[0, 0.12, 0]}>
+        <boxGeometry args={[0.9, 0.16, 1.2]} />
+        <meshToonMaterial color={PAPER} gradientMap={ramp} />
+      </mesh>
+      <mesh position={[4.2, 0.05, -1.7]}>
+        <cylinderGeometry args={[0.28, 0.32, 0.1, 16]} />
+        <meshToonMaterial color={TEAL} gradientMap={ramp} />
+      </mesh>
+      <mesh position={[4.05, 0.8, -1.7]} rotation={[0, 0, 0.35]}>
+        <boxGeometry args={[0.08, 1.5, 0.08]} />
+        <meshToonMaterial color={TEAL} gradientMap={ramp} />
+      </mesh>
+      <mesh position={[3.7, 1.55, -1.6]} rotation={[0, 0, 1.2]}>
+        <coneGeometry args={[0.28, 0.5, 16]} />
+        <meshToonMaterial color={ORANGE} gradientMap={ramp} />
+      </mesh>
+
+      <KeyboardUnit say />
+      <LightStrip />
+      <DeskCat say />
+      <DotBat />
+      {panelsOn && <PanelWall low={low} />}
+    </group>
+  );
+}

--- a/issues/02-desk/shots.md
+++ b/issues/02-desk/shots.md
@@ -1,0 +1,21 @@
+# Issue 2 - Desk: shot list (S0.8)
+
+Range 0.123-0.210 (RANGES[2], locked). Intra-issue whip gutters of 0.004 t
+between shots. Continuity (S5b.1): Noir's cat exits frame-right, so shot 1
+opens with the cat entering frame-left. Exit is motivated by the cat batting
+the floating halftone dot into the screen center -> dot-zoom (engine-side;
+snapshot pool refreshes during the last 15% of shot 4).
+
+| # | kind | lens | share of issue | framing |
+|---|---|---|---|---|
+| 1 | hold | 50mm | 0.24 | desk establishing from left; cat arcs in frame-left, THUMP squash at p=0.35, curls to loaf; FG mug, MG cat on desktop, BG monitor + RGB strip + posters |
+| 2 | dolly | 65mm macro | 0.21 | low left-to-right track over the keyboard; keys dip pure-f(t) and pop CLACK at 6 t-crossings; FG near keycaps, MG popping keys, BG monitor base and strip glow |
+| 3 | dolly | 52mm | 0.25 | JAW-DROP: frame splits into a live 3-panel composite (keyboard-macro RT / cat RT / monitor RT) on paper; panels pop in staggered; monitor panel grows to full bleed at p>0.72; FG floating halftone dots, MG panels, BG paper |
+| 4 | hold | 60mm | 0.16 | push toward the monitor; FG keyboard edge, MG floating halftone dot + cat sitting frame-left, BG live screen; cat bats the dot at p=0.86, dot flies to screen center - motivated dot-zoom out |
+
+Shares exclude the 3 x 0.004 intra-issue gutters (0.14 of the issue).
+
+RT budget (S0.6): max 3 live RTs, 288x448 (half-res-class), mounted only for
+0.1665 < t < 0.194 (whip cutPoints hide mount/unmount). Ladder: low tier
+drops the keyboard panel to a flat quad (3 -> 2 live RTs); the snapshot rung
+is engine-side.

--- a/issues/02-desk/shots.ts
+++ b/issues/02-desk/shots.ts
@@ -1,0 +1,56 @@
+import { easeInOut, easeOutCubic, type Shot } from "@/lib/shots";
+import { issueCenter, RANGES } from "../timeline";
+
+/**
+ * Issue 2 - Desk (S0.3 range 0.123-0.210). Four shots, 0.004 intra-issue
+ * whip gutters. Continuity: Noir's cat exits frame-right, so shot 1 has the
+ * cat entering frame-left. Shot 4's dot-bat motivates the dot-zoom out.
+ * Absolute t windows are exported so Desk.tsx animation stays pure f(t).
+ */
+
+const [S, E] = RANGES[2]!;
+const [CX] = issueCenter(2);
+
+export const LAND_R: [number, number] = [S, S + 0.0205]; // 0.123 - 0.1435
+export const KEYS_R: [number, number] = [S + 0.0245, S + 0.043]; // 0.1475 - 0.166
+export const PANELS_R: [number, number] = [S + 0.047, S + 0.069]; // 0.170 - 0.192
+export const MON_R: [number, number] = [S + 0.073, E]; // 0.196 - 0.210
+
+export const DESK_SHOTS: Shot[] = [
+  {
+    id: "desk-landing",
+    issue: 2,
+    range: LAND_R,
+    kind: "hold",
+    from: { position: [CX - 3.2, 2.3, 6.4], target: [CX - 2.2, 0.7, 0.6], roll: -0.02, fov: 42 },
+    to: { position: [CX - 2.5, 1.9, 5.7], target: [CX - 2.2, 0.55, 0.6], roll: 0.015, fov: 42 },
+    ease: easeInOut,
+  },
+  {
+    id: "desk-keys",
+    issue: 2,
+    range: KEYS_R,
+    kind: "dolly",
+    from: { position: [CX - 1.9, 0.85, 2.9], target: [CX - 0.9, 0.16, 1.05], roll: 0.03, fov: 34 },
+    to: { position: [CX + 1.9, 0.75, 2.7], target: [CX + 1.75, 0.14, 1.0], roll: -0.02, fov: 34 },
+    ease: easeInOut,
+  },
+  {
+    id: "desk-panels",
+    issue: 2,
+    range: PANELS_R,
+    kind: "dolly",
+    from: { position: [CX, 8, 7.3], target: [CX, 8, 2.9], roll: 0, fov: 40 },
+    to: { position: [CX, 8, 6.6], target: [CX, 8, 2.9], roll: 0, fov: 40 },
+    ease: easeInOut,
+  },
+  {
+    id: "desk-monitor",
+    issue: 2,
+    range: MON_R,
+    kind: "hold",
+    from: { position: [CX + 2.3, 1.7, 3.4], target: [CX + 0.2, 1.3, -1.4], roll: -0.02, fov: 36 },
+    to: { position: [CX + 1.5, 1.45, 2.6], target: [CX + 0.2, 1.25, -1.4], roll: 0.01, fov: 36 },
+    ease: easeOutCubic,
+  },
+];

--- a/issues/03-neon/Neon.tsx
+++ b/issues/03-neon/Neon.tsx
@@ -1,0 +1,466 @@
+"use client";
+
+import { Suspense, useLayoutEffect, useRef } from "react";
+import { useFrame } from "@react-three/fiber";
+import { Text } from "@react-three/drei";
+import { Color, Object3D, type Group, type InstancedMesh, type MeshBasicMaterial } from "three";
+import IssueShell from "../_IssueShell";
+import { ISSUES } from "../registry";
+import { toonRamp } from "@/lib/toon";
+import { stepTime, stepNoise } from "@/lib/steppedClock";
+import { useScrollStore } from "@/lib/scrollStore";
+import { clamp01 } from "@/lib/shots";
+import { lettering } from "@/lib/content";
+import { NEON_CASCADE_T, NEON_CASCADE_END } from "./shots";
+
+/**
+ * Issue 3 NEON INK / CODE CITY (S0.3 range [0.225, 0.305], palette S0.4 row 3).
+ * Black-paper world printed in flat saturated neon inks: code-block buildings
+ * (facade stripes = syntax-highlighted code lines), roads as glowing ink
+ * lines, krackle energy dots, neon signage from content.lettering.neonSigns.
+ *
+ * JAW-DROP: the power-on cascade. The city boots in a quantized radial wave
+ * from the landing point -- pure f(t) through [NEON_CASCADE_T, NEON_CASCADE_END],
+ * so scrubbing either direction is deterministic. The wave radius is stepped
+ * into CASCADE_STEPS discrete rings (the "on 2s" block-by-block boot); color
+ * uploads happen only when the step changes. S2.16: power-on is a single
+ * dim->lit step per element, no oscillating emissives, no flicker loops; the
+ * only flash is the beat-driven fx.impact pop, which is requestFlash()-gated
+ * in lib/beats.ts.
+ */
+
+// ---- palette (S0.4 row 3 -- locked) ----------------------------------------
+const PAPER = "#060608";
+const INK = "#EDEDF2";
+const SYNTAX = ["#00E5FF", "#FF3D9A", "#B7FF2E", "#FF9E1F", "#8A7DFF"];
+const ROAD = "#00E5FF";
+
+// dim multipliers (palette colors scaled toward black paper, S0.4 allows this)
+const DIM_LINE = 0.12;
+const DIM_ROAD = 0.08;
+
+// ---- cascade ---------------------------------------------------------------
+const LANDING_X = 0;
+const LANDING_Z = 4;
+const CASCADE_STEPS = 10;
+const MAX_R = 58;
+
+const cascadeRadius = (t: number) => {
+  const p = clamp01((t - NEON_CASCADE_T) / (NEON_CASCADE_END - NEON_CASCADE_T));
+  const step = Math.min(CASCADE_STEPS, Math.floor(p * (CASCADE_STEPS + 1)));
+  return (step / CASCADE_STEPS) * MAX_R;
+};
+
+// ---- deterministic city layout (module scope, no window) --------------------
+function mulberry32(seed: number) {
+  return () => {
+    seed |= 0;
+    seed = (seed + 0x6d2b79f5) | 0;
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+interface BlockData {
+  x: number;
+  z: number;
+  w: number;
+  d: number;
+  h: number;
+  ci: number;
+  dist: number;
+  preLit: boolean;
+}
+interface LineData {
+  block: number;
+  x: number;
+  y: number;
+  z: number;
+  w: number;
+  ci: number;
+}
+interface RoadData {
+  x: number;
+  z: number;
+  horiz: boolean;
+  dist: number;
+}
+interface SignData {
+  text: string;
+  x: number;
+  y: number;
+  z: number;
+  size: number;
+  color: string;
+  dist: number;
+  preLit: boolean;
+}
+interface KrackleData {
+  x: number;
+  y: number;
+  z: number;
+  s: number;
+  ci: number;
+  dist: number;
+}
+
+const GRID = 9;
+// cells reserved for neon signage: "cell x,z" -> index into lettering.neonSigns
+const SIGN_CELLS = new Map<string, number>([
+  ["-2,1", 0], // REACT
+  ["2,2", 1], // TYPESCRIPT
+  ["-1,-1", 2], // RUST
+  ["1,2", 3], // NEXT.JS
+  ["-3,0", 4], // GRAPHQL
+  ["3,1", 5], // NODE.JS
+  ["0,-2", 6], // TAURI
+  ["1,0", 7], // AI OPEN 24H (hero tower)
+]);
+
+function buildCity() {
+  const r = mulberry32(20260702);
+  const blocks: BlockData[] = [];
+  const lines: LineData[] = [];
+  const roads: RoadData[] = [];
+  const signs: SignData[] = [];
+  const krackle: KrackleData[] = [];
+
+  for (let ix = -4; ix <= 4; ix++) {
+    for (let iz = -4; iz <= 4; iz++) {
+      // plaza corridor: dive/landing camera path stays clear
+      if (ix === 0 && iz >= 0 && iz <= 2) continue;
+      const hero = ix === 1 && iz === 0;
+      const signIdx = SIGN_CELLS.get(`${ix},${iz}`);
+      const x = ix * GRID;
+      const z = iz * GRID;
+      const w = hero ? 6 : 4.5 + r() * 1.8;
+      const d = hero ? 6 : 4.5 + r() * 1.8;
+      let h = hero ? 20 : 4 + r() * 12;
+      if (signIdx !== undefined) h = Math.max(h, 9);
+      const b: BlockData = {
+        x,
+        z,
+        w,
+        d,
+        h,
+        ci: Math.floor(r() * SYNTAX.length),
+        dist: Math.hypot(x - LANDING_X, z - LANDING_Z),
+        preLit: hero || (ix === -2 && iz === 1), // pilot lights: hero + REACT
+      };
+      const bi = blocks.length;
+      blocks.push(b);
+
+      // code lines on the +z facade: indented, varied width, syntax colors
+      const n = Math.min(9, Math.floor(h / 1.1));
+      for (let j = 0; j < n; j++) {
+        const y = h - 1.0 - j * 1.05;
+        if (y < 1.2) break;
+        const lw = (w - 1.2) * (0.3 + r() * 0.55);
+        const indent = r() < 0.35 ? 0.5 : 0;
+        lines.push({
+          block: bi,
+          x: x - w / 2 + 0.5 + indent + lw / 2,
+          y,
+          z: z + d / 2 + 0.05,
+          w: lw,
+          ci: Math.floor(r() * SYNTAX.length),
+        });
+      }
+
+      if (signIdx !== undefined) {
+        signs.push({
+          text: lettering.neonSigns[signIdx]!,
+          x,
+          y: h + 0.9,
+          z: z + 0.2,
+          size: hero ? 0.95 : 0.68,
+          color: SYNTAX[signIdx % SYNTAX.length]!,
+          dist: b.dist,
+          preLit: b.preLit,
+        });
+      }
+    }
+  }
+
+  // roads: glowing ink lines on the street grid, one segment per block span
+  for (let k = -4; k <= 3; k++) {
+    const c = 4.5 + k * GRID;
+    for (let m = -4; m <= 4; m++) {
+      const p = m * GRID;
+      roads.push({ x: p, z: c, horiz: true, dist: Math.hypot(p - LANDING_X, c - LANDING_Z) });
+      roads.push({ x: c, z: p, horiz: false, dist: Math.hypot(c - LANDING_X, p - LANDING_Z) });
+    }
+  }
+
+  // krackle energy dots: plaza cluster + rooftop sparks
+  for (let i = 0; i < 140; i++) {
+    if (i < 30) {
+      const x = (r() - 0.5) * 14;
+      const z = LANDING_Z + (r() - 0.5) * 14;
+      krackle.push({
+        x,
+        y: 0.4 + r() * 2,
+        z,
+        s: 0.08 + r() * 0.14,
+        ci: Math.floor(r() * SYNTAX.length),
+        dist: Math.hypot(x - LANDING_X, z - LANDING_Z),
+      });
+    } else {
+      const b = blocks[Math.floor(r() * blocks.length)]!;
+      const x = b.x + (r() - 0.5) * b.w * 1.6;
+      const z = b.z + (r() - 0.5) * b.d * 1.6;
+      krackle.push({
+        x,
+        y: b.h + 0.5 + r() * 2.5,
+        z,
+        s: 0.08 + r() * 0.14,
+        ci: Math.floor(r() * SYNTAX.length),
+        dist: Math.hypot(x - LANDING_X, z - LANDING_Z),
+      });
+    }
+  }
+
+  return { blocks, lines, roads, signs, krackle };
+}
+
+const CITY = buildCity();
+
+// reusable temps -- zero per-frame allocation
+const tmpO = new Object3D();
+const tmpC = new Color();
+const tmpC2 = new Color();
+const DIM_BODY = new Color(PAPER).lerp(new Color(INK), 0.05);
+
+export default function Neon({ index }: { index: number }) {
+  const issue = ISSUES[index]!;
+  const ramp = toonRamp();
+
+  const bodyRef = useRef<InstancedMesh>(null);
+  const lineRef = useRef<InstancedMesh>(null);
+  const roadRef = useRef<InstancedMesh>(null);
+  const krackleRef = useRef<InstancedMesh>(null);
+  const signRefs = useRef<(Group | null)[]>([]);
+  const padMat = useRef<MeshBasicMaterial>(null);
+  const cat = useRef<Group>(null);
+  const lastRadius = useRef(-1);
+
+  const applyRadius = (radius: number) => {
+    const body = bodyRef.current;
+    const line = lineRef.current;
+    const road = roadRef.current;
+    if (!body || !line || !road) return;
+    CITY.blocks.forEach((b, i) => {
+      const on = b.preLit || b.dist <= radius;
+      tmpC.copy(DIM_BODY);
+      if (on) tmpC.lerp(tmpC2.set(SYNTAX[b.ci]!), 0.16);
+      body.setColorAt(i, tmpC);
+    });
+    body.instanceColor!.needsUpdate = true;
+    CITY.lines.forEach((l, i) => {
+      const b = CITY.blocks[l.block]!;
+      const on = b.preLit || b.dist <= radius;
+      tmpC.set(SYNTAX[l.ci]!);
+      if (!on) tmpC.multiplyScalar(DIM_LINE);
+      line.setColorAt(i, tmpC);
+    });
+    line.instanceColor!.needsUpdate = true;
+    // roads ignite outward slightly ahead of the blocks
+    CITY.roads.forEach((seg, i) => {
+      tmpC.set(ROAD);
+      if (!(seg.dist <= radius * 1.15)) tmpC.multiplyScalar(DIM_ROAD);
+      road.setColorAt(i, tmpC);
+    });
+    road.instanceColor!.needsUpdate = true;
+    if (padMat.current) {
+      padMat.current.color.set(ROAD);
+      if (radius <= 0) padMat.current.color.multiplyScalar(DIM_LINE);
+    }
+  };
+
+  // static matrices + full initial color pass (unset instances render WHITE)
+  useLayoutEffect(() => {
+    const body = bodyRef.current!;
+    const line = lineRef.current!;
+    const road = roadRef.current!;
+    CITY.blocks.forEach((b, i) => {
+      tmpO.position.set(b.x, b.h / 2, b.z);
+      tmpO.rotation.set(0, 0, 0);
+      tmpO.scale.set(b.w, b.h, b.d);
+      tmpO.updateMatrix();
+      body.setMatrixAt(i, tmpO.matrix);
+    });
+    body.instanceMatrix.needsUpdate = true;
+    CITY.lines.forEach((l, i) => {
+      tmpO.position.set(l.x, l.y, l.z);
+      tmpO.rotation.set(0, 0, 0);
+      tmpO.scale.set(l.w, 0.16, 0.06);
+      tmpO.updateMatrix();
+      line.setMatrixAt(i, tmpO.matrix);
+    });
+    line.instanceMatrix.needsUpdate = true;
+    CITY.roads.forEach((seg, i) => {
+      tmpO.position.set(seg.x, 0.03, seg.z);
+      tmpO.rotation.set(0, 0, 0);
+      tmpO.scale.set(seg.horiz ? 8.4 : 0.35, 0.06, seg.horiz ? 0.35 : 8.4);
+      tmpO.updateMatrix();
+      road.setMatrixAt(i, tmpO.matrix);
+    });
+    road.instanceMatrix.needsUpdate = true;
+    // krackle colors set once here; matrices are rebuilt per frame
+    const kr = krackleRef.current!;
+    CITY.krackle.forEach((k, i) => kr.setColorAt(i, tmpC.set(SYNTAX[k.ci]!)));
+    kr.instanceColor!.needsUpdate = true;
+
+    const radius = cascadeRadius(useScrollStore.getState().t);
+    lastRadius.current = radius;
+    applyRadius(radius);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useFrame(({ clock }) => {
+    const { t, quality } = useScrollStore.getState();
+    const radius = cascadeRadius(t);
+
+    // color uploads only on wave-step change -- scrub-safe both directions
+    if (radius !== lastRadius.current) {
+      lastRadius.current = radius;
+      applyRadius(radius);
+    }
+
+    // signs pop on when the wave reaches them (visibility step, no fade)
+    CITY.signs.forEach((s, i) => {
+      const g = signRefs.current[i];
+      if (g) g.visible = s.preLit || s.dist <= radius;
+    });
+
+    // krackle: stepped-time jitter (ambient loop, S2.8), gated by the wave
+    const fps = quality === "low" ? 8 : 12;
+    const kr = krackleRef.current;
+    if (kr) {
+      const el = clock.elapsedTime;
+      CITY.krackle.forEach((k, i) => {
+        const on = k.dist <= radius;
+        if (on) {
+          const n1 = stepNoise(el, fps, i);
+          const n2 = stepNoise(el, fps, i + 311);
+          const n3 = stepNoise(el, fps, i + 977);
+          tmpO.position.set(k.x + n1 * 0.45, k.y + n2 * 0.45, k.z + n3 * 0.45);
+          tmpO.rotation.set(n1 * 3, n2 * 3, 0);
+          tmpO.scale.setScalar(k.s * (0.7 + 0.3 * Math.abs(n3)));
+        } else {
+          tmpO.position.set(k.x, k.y, k.z);
+          tmpO.rotation.set(0, 0, 0);
+          tmpO.scale.setScalar(0);
+        }
+        tmpO.updateMatrix();
+        kr.setMatrixAt(i, tmpO.matrix);
+      });
+      kr.instanceMatrix.needsUpdate = true;
+    }
+
+    // cat tail idle on 2s (same ambient pattern as the demo cube)
+    if (cat.current) cat.current.rotation.z = Math.sin(stepTime(clock.elapsedTime, fps) * 2.1) * 0.1;
+  });
+
+  return (
+    <IssueShell index={index} issue={issue}>
+      {/* black paper ground */}
+      <mesh position={[0, -0.01, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+        <planeGeometry args={[120, 120]} />
+        <meshToonMaterial color={PAPER} gradientMap={ramp} />
+      </mesh>
+
+      {/* code-block buildings (toon bodies, per-instance boot tint) */}
+      <instancedMesh ref={bodyRef} args={[undefined, undefined, CITY.blocks.length]} frustumCulled={false}>
+        <boxGeometry args={[1, 1, 1]} />
+        <meshToonMaterial color="#FFFFFF" gradientMap={ramp} />
+      </instancedMesh>
+
+      {/* facade code lines -- flat neon ink, unlit */}
+      <instancedMesh ref={lineRef} args={[undefined, undefined, CITY.lines.length]} frustumCulled={false}>
+        <boxGeometry args={[1, 1, 1]} />
+        <meshBasicMaterial color="#FFFFFF" />
+      </instancedMesh>
+
+      {/* roads as glowing ink lines */}
+      <instancedMesh ref={roadRef} args={[undefined, undefined, CITY.roads.length]} frustumCulled={false}>
+        <boxGeometry args={[1, 1, 1]} />
+        <meshBasicMaterial color="#FFFFFF" />
+      </instancedMesh>
+
+      {/* krackle energy dots */}
+      <instancedMesh ref={krackleRef} args={[undefined, undefined, CITY.krackle.length]} frustumCulled={false}>
+        <octahedronGeometry args={[1, 0]} />
+        <meshBasicMaterial color="#FFFFFF" />
+      </instancedMesh>
+
+      {/* landing pad ring at the cascade origin */}
+      <mesh position={[LANDING_X, 0.02, LANDING_Z]} rotation={[-Math.PI / 2, 0, 0]}>
+        <ringGeometry args={[1.4, 1.8, 48]} />
+        <meshBasicMaterial ref={padMat} color={ROAD} />
+      </mesh>
+
+      {/* neon signage: dead plate always visible, lettering pops with the wave */}
+      <Suspense fallback={null}>
+        {CITY.signs.map((s, i) => (
+          <group key={s.text} position={[s.x, s.y, s.z]}>
+            <mesh position={[0, 0, -0.06]}>
+              <boxGeometry args={[s.text.length * s.size * 0.62 + 0.6, s.size + 0.7, 0.08]} />
+              <meshToonMaterial color={DIM_BODY} gradientMap={ramp} />
+            </mesh>
+            <group
+              ref={(el) => {
+                signRefs.current[i] = el;
+              }}
+              visible={s.preLit}
+            >
+              <Text
+                font="/fonts/Bangers-Regular.ttf"
+                fontSize={s.size}
+                color={s.color}
+                anchorX="center"
+                anchorY="middle"
+              >
+                {s.text}
+              </Text>
+            </group>
+          </group>
+        ))}
+      </Suspense>
+
+      {/* the cat (S1) -- perched on the hero tower roof edge, clickable */}
+      <group
+        ref={cat}
+        position={[7.2, 20, 2.4]}
+        rotation={[0, -2.4, 0]}
+        scale={0.9}
+        onClick={(e) => {
+          e.stopPropagation();
+          useScrollStore.getState().meow();
+        }}
+      >
+        <mesh position={[0, 0.25, 0]}>
+          <boxGeometry args={[0.9, 0.5, 0.45]} />
+          <meshToonMaterial color={INK} gradientMap={ramp} />
+        </mesh>
+        <mesh position={[0.45, 0.62, 0]}>
+          <boxGeometry args={[0.42, 0.4, 0.4]} />
+          <meshToonMaterial color={INK} gradientMap={ramp} />
+        </mesh>
+        <mesh position={[0.55, 0.88, 0.1]} rotation={[0, 0, 0.3]}>
+          <coneGeometry args={[0.09, 0.22, 4]} />
+          <meshToonMaterial color={INK} gradientMap={ramp} />
+        </mesh>
+        <mesh position={[0.35, 0.88, -0.1]} rotation={[0, 0, -0.2]}>
+          <coneGeometry args={[0.09, 0.22, 4]} />
+          <meshToonMaterial color={INK} gradientMap={ramp} />
+        </mesh>
+        <mesh position={[-0.55, 0.45, 0]} rotation={[0, 0, 1.1]}>
+          <cylinderGeometry args={[0.05, 0.07, 0.7, 8]} />
+          <meshToonMaterial color={INK} gradientMap={ramp} />
+        </mesh>
+      </group>
+    </IssueShell>
+  );
+}

--- a/issues/03-neon/shots.md
+++ b/issues/03-neon/shots.md
@@ -1,0 +1,27 @@
+# Issue 3 -- NEON INK / CODE CITY (t 0.225-0.305, intensity 5)
+
+S0.8 shot table (mirrored exactly in ./shots.ts). Palette S0.4 row 3: paper
+#060608, ink #EDEDF2, accents #00E5FF #FF3D9A #B7FF2E #FF9E1F #8A7DFF.
+
+| # | kind | lens | share of issue | framing |
+|---|---|---|---|---|
+| 1 | crash | 20mm | 0.32 | free-fall dive straight down at the plaza; dead city grid fills frame, dim code-line facades; pre-lit AI OPEN 24H hero tower upper-right, REACT sign far-left; FG black void, MG rooftops + cat on hero roof, BG street grid |
+| 2 | crash | 85->40mm | 0.20 | crash-zoom down the hero tower face; AI OPEN 24H sign rakes past upper-third; FG facade code lines, MG plaza landing ring, BG far dark blocks |
+| 3 | hold | 50mm | 0.33 | dutch (-8 deg) street-level landing hold; landing ring lower-left, avenue vanishing point right-third = focal point; the power-on cascade rolls block-by-block into depth; FG igniting road lines, MG signs popping on, BG skyline booting |
+
+Intra-issue gutters (0.075 x range each) take the default whip; issue exit
+stays on the registry outTransition (stamp -> cut fallback until Phase 2).
+
+## Jaw-drop: power-on cascade
+- Window: t in [NEON_CASCADE_T, NEON_CASCADE_END] (exported from shots.ts) =
+  landing-shot entry to 70% through the hold. Pure f(t), scrub-safe both ways.
+- Wave radius quantized to 10 rings (block-by-block on 2s feel); roads ignite
+  at 1.15x the wave radius so they lead the blocks outward.
+- Sub-thump: `neon-cascade` beat in lib/beats.ts at NEON_CASCADE_T --
+  fx.impact double-pop, requestFlash()-gated, hysteresis 0.006 re-arm.
+
+## S2.16 check (max-contrast issue)
+- Power-on is a single dim->lit step per element; no oscillating emissives,
+  no flicker loops, no strobe. Krackle is position jitter at 12 fps (8 low
+  tier), constant luminance. Lettering (troika SDF) is single-layer crisp.
+- Grain/paperTex already lowered in the neon recipe (lib/recipes.ts row 3).

--- a/issues/03-neon/shots.ts
+++ b/issues/03-neon/shots.ts
@@ -1,0 +1,59 @@
+import { easeInOut, easeOutCubic, type EaseFn, type Shot } from "@/lib/shots";
+import { issueCenter, RANGES } from "../timeline";
+
+/**
+ * Issue 3 NEON INK / CODE CITY -- authored shots (S0.8 table in ./shots.md).
+ * Free-fall dive -> crash-zoom past the hero tower -> dutch landing hold.
+ * All fractions of the locked neon range (S0.3); intra-issue gutters get the
+ * default whip from compileSegments.
+ */
+
+const [S, E] = RANGES[3]!;
+const W = E - S;
+const at = (f: number) => S + f * W;
+const [CX, CY, CZ] = issueCenter(3);
+
+/** accelerating fall */
+const easeInQuad: EaseFn = (x) => x * x;
+
+/**
+ * Power-on cascade window (the jaw-drop): starts the instant the landing
+ * shot begins, wave fully out 70% into the hold. Pure f(t) -- Neon.tsx maps
+ * t through this window into a quantized radial wave; lib/beats.ts fires the
+ * sub-thump at the same trigger.
+ */
+export const NEON_CASCADE_T = at(0.67);
+export const NEON_CASCADE_END = at(0.67 + 0.33 * 0.7);
+
+export const NEON_SHOTS: Shot[] = [
+  {
+    // free-fall dive: straight down at the dead city, pre-lit signs only
+    id: "neon-dive",
+    issue: 3,
+    range: [at(0), at(0.32)],
+    kind: "crash",
+    from: { position: [CX, CY + 85, CZ + 30], target: [CX, CY, CZ + 4], roll: 0.02, fov: 62 },
+    to: { position: [CX + 2, CY + 38, CZ + 14], target: [CX, CY, CZ + 4], roll: -0.04, fov: 66 },
+    ease: easeInQuad,
+  },
+  {
+    // crash-zoom down the hero tower face, sign raking past
+    id: "neon-crash",
+    issue: 3,
+    range: [at(0.395), at(0.595)],
+    kind: "crash",
+    from: { position: [CX + 3.5, CY + 26, CZ + 8], target: [CX + 9, CY + 18, CZ + 1], roll: 0.03, fov: 24 },
+    to: { position: [CX + 1.5, CY + 4, CZ + 10], target: [CX, CY + 1, CZ + 4], roll: -0.05, fov: 54 },
+    ease: easeOutCubic,
+  },
+  {
+    // dutch landing hold: street level, cascade wave rolls out into depth
+    id: "neon-landing",
+    issue: 3,
+    range: [at(0.67), at(1)],
+    kind: "hold",
+    from: { position: [CX - 4, CY + 2.6, CZ + 15], target: [CX + 2, CY + 2.8, CZ - 10], roll: -0.14, fov: 46 },
+    to: { position: [CX - 2.5, CY + 2.1, CZ + 13.5], target: [CX + 2, CY + 3.2, CZ - 10], roll: -0.11, fov: 44 },
+    ease: easeInOut,
+  },
+];

--- a/issues/registry.ts
+++ b/issues/registry.ts
@@ -1,16 +1,21 @@
-import {
-  compileSegments,
-  easeInOut,
-  easeOutCubic,
-  type Segment,
-  type Shot,
-  type TransitionKind,
-  type Vec3,
-} from "@/lib/shots";
+import type { ComponentType } from "react";
+import { compileSegments, type Segment, type Shot, type TransitionKind } from "@/lib/shots";
 import { ACCENTS, RECIPES, type PrintRecipe } from "@/lib/recipes";
+import { ISSUE_SPACING, issueCenter, placeholderShots, RANGES } from "./timeline";
+import PlaceholderIssue from "./PlaceholderIssue";
+import Cover from "./00-cover/Cover";
+import Noir from "./01-noir/Noir";
+import Desk from "./02-desk/Desk";
+import Neon from "./03-neon/Neon";
+import { COVER_SHOTS } from "./00-cover/shots";
+import { NOIR_SHOTS } from "./01-noir/shots";
+import { DESK_SHOTS } from "./02-desk/shots";
+import { NEON_SHOTS } from "./03-neon/shots";
 
-/** World-space distance between issue set origins (S2.5 -- isolated sets). */
-export const ISSUE_SPACING = 200;
+// Timeline numbers live in ./timeline (leaf); re-exported here for consumers.
+export { ISSUE_SPACING, issueCenter };
+
+export type IssueComponent = ComponentType<{ index: number }>;
 
 export interface IssueEntry {
   id: string;
@@ -23,75 +28,52 @@ export interface IssueEntry {
   outTransition: TransitionKind;
   recipe: PrintRecipe;
   accents: string[];
+  /** scene set rendered by SceneManager (entries 4-11 stay on the placeholder) */
+  component: IssueComponent;
 }
 
 const row = (
   id: string,
   title: string,
-  range: [number, number],
+  index: number,
   intensity: number,
   outTransition: TransitionKind,
-  index: number,
+  component: IssueComponent,
 ): IssueEntry => ({
   id,
   title,
-  range,
+  range: [RANGES[index]![0], RANGES[index]![1]],
   intensity,
   outTransition,
   recipe: RECIPES[index]!,
   accents: ACCENTS[index]!,
+  component,
 });
 
 /** S0.3 locked timeline -- ranges + gutters chain exactly to 1.000. Do not re-balance. */
 export const ISSUES: IssueEntry[] = [
-  row("cover", "PANEL JUMP", [0.0, 0.03], 1, "crash-through", 0),
-  row("noir", "ISSUE 1 - NOIR", [0.04, 0.108], 2, "title-drop", 1),
-  row("desk", "ISSUE 2 - DESK", [0.123, 0.21], 2, "dot-zoom", 2),
-  row("neon", "ISSUE 3 - NEON INK", [0.225, 0.305], 5, "panel-wipe", 3),
-  row("origin", "ISSUE 4 - ORIGIN PAGE", [0.315, 0.378], 1, "panel-portal", 4),
-  row("press", "ISSUE 5 - THE PRESS", [0.388, 0.478], 3, "stamp", 5),
-  row("newsprint", "ISSUE 6 - NEWSPRINT", [0.488, 0.566], 3, "paper-tear", 6),
-  row("screentone", "ISSUE 7 - SCREENTONE", [0.576, 0.656], 4, "page-flip", 7),
-  row("pop", "ISSUE 8 - POP PRINT", [0.671, 0.752], 5, "whip", 8),
-  row("sketch", "ISSUE 9 - SKETCHBOOK", [0.762, 0.838], 2, "ink-flood", 9),
-  row("spread", "ISSUE 10 - THE SPREAD", [0.848, 0.93], 5, "dot-match", 10),
-  row("terminal", "ISSUE 11 - LETTERS PAGE", [0.94, 1.0], 1, "cut", 11),
+  row("cover", "PANEL JUMP", 0, 1, "crash-through", Cover),
+  row("noir", "ISSUE 1 - NOIR", 1, 2, "title-drop", Noir),
+  row("desk", "ISSUE 2 - DESK", 2, 2, "dot-zoom", Desk),
+  row("neon", "ISSUE 3 - NEON INK", 3, 5, "panel-wipe", Neon),
+  row("origin", "ISSUE 4 - ORIGIN PAGE", 4, 1, "panel-portal", PlaceholderIssue),
+  row("press", "ISSUE 5 - THE PRESS", 5, 3, "stamp", PlaceholderIssue),
+  row("newsprint", "ISSUE 6 - NEWSPRINT", 6, 3, "paper-tear", PlaceholderIssue),
+  row("screentone", "ISSUE 7 - SCREENTONE", 7, 4, "page-flip", PlaceholderIssue),
+  row("pop", "ISSUE 8 - POP PRINT", 8, 5, "whip", PlaceholderIssue),
+  row("sketch", "ISSUE 9 - SKETCHBOOK", 9, 2, "ink-flood", PlaceholderIssue),
+  row("spread", "ISSUE 10 - THE SPREAD", 10, 5, "dot-match", PlaceholderIssue),
+  row("terminal", "ISSUE 11 - LETTERS PAGE", 11, 1, "cut", PlaceholderIssue),
 ];
 
-export const issueCenter = (index: number): Vec3 => [index * ISSUE_SPACING, 0, 0];
-
-/**
- * Phase 0 placeholder coverage: 2 shots per issue (hold, then a push-in
- * dolly with a mild crash feel), separated by a small intra-issue whip
- * gutter. Real per-issue shot lists replace this in Phases 1/3 (S0.8).
- */
-function placeholderShots(issue: IssueEntry, index: number): Shot[] {
-  const [s, e] = issue.range;
-  const w = e - s;
-  const [cx, cy, cz] = issueCenter(index);
-  return [
-    {
-      id: `${issue.id}-hold`,
-      issue: index,
-      range: [s, s + 0.46 * w],
-      kind: "hold",
-      from: { position: [cx - 1.2, cy + 2.2, cz + 9.5], target: [cx, cy + 1, cz], roll: -0.03, fov: 42 },
-      to: { position: [cx + 1.2, cy + 2.6, cz + 8.8], target: [cx, cy + 1, cz], roll: 0.03, fov: 42 },
-      ease: easeInOut,
-    },
-    {
-      id: `${issue.id}-dolly`,
-      issue: index,
-      range: [s + 0.54 * w, e],
-      kind: "dolly",
-      from: { position: [cx - 5, cy + 2.8, cz + 7], target: [cx, cy + 1, cz], roll: 0.06, fov: 50 },
-      to: { position: [cx, cy + 1.4, cz + 4], target: [cx, cy + 1, cz], roll: 0, fov: 36 },
-      ease: easeOutCubic,
-    },
-  ];
-}
-
-export const SHOTS: Shot[] = ISSUES.flatMap((issue, i) => placeholderShots(issue, i));
+// Entries 0-3 own their shot lists (issues/XX-*/shots.ts); 4-11 stay placeholder.
+export const SHOTS: Shot[] = [
+  ...COVER_SHOTS,
+  ...NOIR_SHOTS,
+  ...DESK_SHOTS,
+  ...NEON_SHOTS,
+  ...ISSUES.slice(4).flatMap((issue, i) => placeholderShots(issue.id, i + 4)),
+];
 
 export const SEGMENTS: Segment[] = compileSegments(
   SHOTS,

--- a/issues/timeline.ts
+++ b/issues/timeline.ts
@@ -1,0 +1,59 @@
+import { easeInOut, easeOutCubic, type Shot, type Vec3 } from "@/lib/shots";
+
+/**
+ * Leaf module: locked timeline numbers + placeholder shot generator.
+ * Lives below registry.ts so per-issue shots.ts files can import ranges
+ * without creating an import cycle (registry imports the shot lists).
+ */
+
+/** World-space distance between issue set origins (S2.5 -- isolated sets). */
+export const ISSUE_SPACING = 200;
+
+export const issueCenter = (index: number): Vec3 => [index * ISSUE_SPACING, 0, 0];
+
+/** S0.3 locked timeline -- ranges + gutters chain exactly to 1.000. Do not re-balance. */
+export const RANGES: readonly [number, number][] = [
+  [0.0, 0.03], // 0 cover
+  [0.04, 0.108], // 1 noir
+  [0.123, 0.21], // 2 desk
+  [0.225, 0.305], // 3 neon
+  [0.315, 0.378], // 4 origin
+  [0.388, 0.478], // 5 press
+  [0.488, 0.566], // 6 newsprint
+  [0.576, 0.656], // 7 screentone
+  [0.671, 0.752], // 8 pop
+  [0.762, 0.838], // 9 sketch
+  [0.848, 0.93], // 10 spread
+  [0.94, 1.0], // 11 terminal
+];
+
+/**
+ * Placeholder coverage: 2 shots per issue (hold, then a push-in dolly with a
+ * mild crash feel), separated by a small intra-issue whip gutter. Real
+ * per-issue shot lists replace this per phase (S0.8).
+ */
+export function placeholderShots(id: string, index: number): Shot[] {
+  const [s, e] = RANGES[index]!;
+  const w = e - s;
+  const [cx, cy, cz] = issueCenter(index);
+  return [
+    {
+      id: `${id}-hold`,
+      issue: index,
+      range: [s, s + 0.46 * w],
+      kind: "hold",
+      from: { position: [cx - 1.2, cy + 2.2, cz + 9.5], target: [cx, cy + 1, cz], roll: -0.03, fov: 42 },
+      to: { position: [cx + 1.2, cy + 2.6, cz + 8.8], target: [cx, cy + 1, cz], roll: 0.03, fov: 42 },
+      ease: easeInOut,
+    },
+    {
+      id: `${id}-dolly`,
+      issue: index,
+      range: [s + 0.54 * w, e],
+      kind: "dolly",
+      from: { position: [cx - 5, cy + 2.8, cz + 7], target: [cx, cy + 1, cz], roll: 0.06, fov: 50 },
+      to: { position: [cx, cy + 1.4, cz + 4], target: [cx, cy + 1, cz], roll: 0, fov: 36 },
+      ease: easeOutCubic,
+    },
+  ];
+}

--- a/lib/beats.ts
+++ b/lib/beats.ts
@@ -1,6 +1,8 @@
 import gsap from "gsap";
 import { fx } from "./fx";
 import { requestFlash } from "./flashBudget";
+import { RANGES } from "@/issues/timeline";
+import { NEON_CASCADE_T } from "@/issues/03-neon/shots";
 
 /**
  * S2.14 beat engine -- authored-time sequences fired when t crosses a
@@ -47,23 +49,53 @@ export class BeatRunner {
   }
 }
 
+/** Issue 1 -> Issue 2 gutter entry (noir range end, S0.3): the title drop. */
+const TITLE_DROP_T = RANGES[1]![1];
+
+let titleTl: gsap.core.Timeline | null = null;
+
 /**
- * Phase 0 demo beat -- a flash-safe impact frame at the title-drop gutter
- * entry (t = 0.108). Plays at authored speed for fast and slow scrollers.
+ * S5b.3 title drop -- the name card slams in as a full-frame comic title at
+ * authored speed (the card itself lives in components/Lettering.tsx and reads
+ * fx.title), with a flash-budget-guarded impact double pop as the sub-thump.
+ * Re-fires cleanly after hysteresis re-arm: the previous timeline is killed.
  */
-export function makeDemoBeats(): Beat[] {
+export function makeBeats(): Beat[] {
   return [
     {
-      id: "demo-impact",
-      trigger: 0.108,
+      id: "title-drop",
+      trigger: TITLE_DROP_T,
       hysteresis: 0.006,
       fire: () => {
-        if (!requestFlash()) return;
+        titleTl?.kill();
+        titleTl = gsap
+          .timeline()
+          .set(fx, { title: 0 })
+          .to(fx, { title: 1, duration: 0.22, ease: "back.out(2.5)" })
+          .to(fx, { title: 0, duration: 0.16, ease: "power3.in" }, "+=0.72");
+        if (!requestFlash()) return; // card still plays; only the flashes are budgeted
         gsap
           .timeline()
           .to(fx, { impact: 1, duration: 0.05, ease: "none" })
           .to(fx, { impact: 0, duration: 0.12, ease: "power2.out" })
-          .to(fx, { impact: 0.7, duration: 0.04, ease: "none" }, "+=0.06")
+          .to(fx, { impact: 0.7, duration: 0.04, ease: "none" }, "+=0.06") // sub-thump
+          .to(fx, { impact: 0, duration: 0.18, ease: "power2.out" });
+      },
+    },
+    {
+      // Issue 3 jaw-drop: the power-on cascade sub-thump. The cascade itself
+      // is pure f(t) in issues/03-neon (scrub-safe); only this authored-time
+      // impact double pop rides the beat engine. Same trigger t as the wave.
+      id: "neon-cascade",
+      trigger: NEON_CASCADE_T,
+      hysteresis: 0.006,
+      fire: () => {
+        if (!requestFlash()) return; // flash budget (S2.13); wave plays regardless
+        gsap
+          .timeline()
+          .to(fx, { impact: 1, duration: 0.05, ease: "none" })
+          .to(fx, { impact: 0, duration: 0.12, ease: "power2.out" })
+          .to(fx, { impact: 0.7, duration: 0.04, ease: "none" }, "+=0.06") // sub-thump
           .to(fx, { impact: 0, duration: 0.18, ease: "power2.out" });
       },
     },

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -26,3 +26,34 @@ export const links = {
   blogUrl: "", // optional -- `blog` command hidden until set
   resumePdf: "", // path in /public; empty => `resume` prints an "out of stock" gag page
 };
+
+// Phase 1 lettering & copy -- cover, title drop, onomatopoeia pools, captions, signage.
+// PURE ASCII (Turbopack rope bug); no franchise vocabulary (SPEC S1). Pool the words at runtime.
+export const lettering = {
+  cover: {
+    masthead: "SAEED KOLIVAND",
+    issueLine: "ISSUE #1 - JUL 2026 - FIRST PRINTING",
+    priceBox: "STILL ONLY 200 OK",
+    blurb: "The origin issue: one dev, three worlds, zero ghosting.",
+    barcode: "saeedkolivand", // GitHub handle, set as the cover barcode digits
+    attractPrompt: "SCROLL TO CRACK THE SPINE",
+  },
+  titleDrop: {
+    name: "SAEED KOLIVAND",
+    sub: "SENIOR FRONTEND ENGINEER - AI & AGENTIC TOOLS",
+  },
+  onomatopoeia: {
+    keycaps: ["CLACK", "CLACK-CLACK", "CLAK", "KACHUNK", "TAK-TAK", "CLICK"],
+    whip: ["WHOOSH", "FWISH", "SWISH", "VWOOO", "FWOOSH", "WHIP"],
+    impact: ["WHAM", "THOOM", "KRAKA-THOOM", "BADOOM", "SLAM", "KRUNCH"],
+    neonPowerOn: ["BZZT", "VNNN", "ZAP", "KRZZT", "TZAK", "HMMMM"],
+    rain: ["TAP TAP", "DRIP", "PATTER", "TIK TIK", "PLINK", "DRIP-DRIP"],
+    cat: ["MEW", "PRRR", "MRRP", "THUMP", "PADD", "MROW"],
+  },
+  noirCaptions: [
+    "Rain again. The kind that gets into your commits.",
+    "One window lit on the whole dead block. Mine.",
+    "Then the cat jumped. Cats always know the cut.",
+  ],
+  neonSigns: ["REACT", "TYPESCRIPT", "RUST", "NEXT.JS", "GRAPHQL", "NODE.JS", "TAURI", "AI OPEN 24H"],
+} as const;

--- a/lib/fx.ts
+++ b/lib/fx.ts
@@ -6,4 +6,6 @@
 export const fx = {
   /** 0..1 impact-frame flash (flash-budget guarded at the beat that drives it) */
   impact: 0,
+  /** 0..1(+overshoot) title-drop card presence, driven by the title-drop beat */
+  title: 0,
 };

--- a/lib/onomatopoeia.ts
+++ b/lib/onomatopoeia.ts
@@ -1,0 +1,62 @@
+import { Vector3 } from "three";
+
+/**
+ * Pooled comic onomatopoeia (S5b) -- fixed-size slot pool, zero per-frame
+ * allocation. Scenes call sayWord() from useFrame/event code with a word
+ * list from content.lettering.onomatopoeia; components/Onomatopoeia.tsx
+ * renders the pool as crisp Hud lettering above the post pipeline (S2.16).
+ */
+
+export const WORD_POOL_SIZE = 12;
+/** authored pop envelope length, seconds */
+export const WORD_LIFE = 0.9;
+
+export interface WordSlot {
+  active: boolean;
+  /** bumped on (re)spawn so the renderer knows to re-sync glyphs */
+  gen: number;
+  word: string;
+  color: string;
+  /** world-space anchor, projected to screen each frame */
+  pos: Vector3;
+  /** performance.now() at spawn (ms) */
+  start: number;
+  /** 0..1, drives word pick + rotation jitter */
+  seed: number;
+}
+
+export const wordPool: WordSlot[] = Array.from({ length: WORD_POOL_SIZE }, () => ({
+  active: false,
+  gen: 0,
+  word: "",
+  color: "#FFFFFF",
+  pos: new Vector3(),
+  start: 0,
+  seed: 0,
+}));
+
+let cursor = 0;
+
+/**
+ * Fire a comic word at a world position. Round-robin over the pool -- the
+ * oldest slot is recycled, nothing is allocated.
+ */
+export function sayWord(
+  list: readonly string[],
+  worldPos: Vector3 | readonly [number, number, number],
+  seed: number = Math.random(),
+  color = "#FFFFFF",
+): void {
+  if (list.length === 0) return;
+  const slot = wordPool[cursor]!;
+  cursor = (cursor + 1) % WORD_POOL_SIZE;
+  const s = seed - Math.floor(seed); // wrap into [0,1)
+  slot.word = list[Math.floor(s * list.length) % list.length]!;
+  slot.color = color;
+  if (worldPos instanceof Vector3) slot.pos.copy(worldPos);
+  else slot.pos.set(worldPos[0], worldPos[1], worldPos[2]);
+  slot.seed = s;
+  slot.start = performance.now();
+  slot.gen++;
+  slot.active = true;
+}

--- a/lib/recipes.ts
+++ b/lib/recipes.ts
@@ -23,6 +23,10 @@ export interface PrintRecipe {
   vignette: number;
   /** line-boil amplitude 0..1 */
   boil: number;
+  /** crosshatch shadow shading 0..1 (noir/sketch looks) */
+  hatch: number;
+  /** hatch stroke pitch in px */
+  hatchScale: number;
 }
 
 const base: Omit<PrintRecipe, "paper" | "ink" | "bg"> = {
@@ -35,18 +39,26 @@ const base: Omit<PrintRecipe, "paper" | "ink" | "bg"> = {
   paperTex: 0.1,
   vignette: 0.25,
   boil: 0.5,
+  hatch: 0,
+  hatchScale: 7,
 };
 
 /** One recipe per registry entry, S0.4 palettes. Visibly distinct per S7 Phase 0 gate. */
 export const RECIPES: PrintRecipe[] = [
   // 0 Cover -- printed cover, mid halftone
   { ...base, paper: "#F2EAD9", ink: "#201D18", bg: "#F2EAD9", halftone: 0.45, halftoneScale: 7 },
-  // 1 Noir -- B&W hatched ink, dark paper, light ink
-  { ...base, paper: "#0E0E10", ink: "#F5F1E8", bg: "#0E0E10", mono: 1, edge: 0.95, edgeColor: "#F5F1E8", halftone: 0.2, halftoneScale: 4, vignette: 0.45 },
+  // 1 Noir -- B&W hatched ink: crosshatch carries the shadow shading now,
+  // halftone drops to a whisper so dots and strokes never fight.
+  // Dark paper flips halftone/hatch polarity inside PrintEffect (derived
+  // from paper luminance): white ink lands on lit forms, deep shadow stays
+  // paper-black silhouette (ruling 2026-07-02, gate fix attempt 1)
+  { ...base, paper: "#0E0E10", ink: "#F5F1E8", bg: "#0E0E10", mono: 1, edge: 0.95, edgeColor: "#F5F1E8", halftone: 0.12, halftoneScale: 4, vignette: 0.45, hatch: 1, hatchScale: 6 },
   // 2 Desk -- warm full-color halftone
   { ...base, paper: "#F6EFE3", ink: "#1C1B1A", bg: "#F6EFE3", halftone: 0.6, halftoneScale: 8, grain: 0.08 },
-  // 3 Neon Ink -- flat neon on black, razor edges, barely any dots
-  { ...base, paper: "#060608", ink: "#EDEDF2", bg: "#060608", edge: 1, edgeColor: "#EDEDF2", halftone: 0.08, halftoneScale: 4, vignette: 0.4, boil: 0.7 },
+  // 3 Neon Ink -- flat neon on black, razor edges, barely any dots.
+  // grain/paperTex lowered: 10Hz grain flicker on a max-contrast black
+  // world edged toward strobe territory (S2.16 check, 2026-07-02)
+  { ...base, paper: "#060608", ink: "#EDEDF2", bg: "#060608", edge: 1, edgeColor: "#EDEDF2", halftone: 0.08, halftoneScale: 4, grain: 0.03, paperTex: 0.05, vignette: 0.4, boil: 0.7 },
   // 4 Origin -- muted valley
   { ...base, paper: "#EDE7DB", ink: "#2A2722", bg: "#EDE7DB", halftone: 0.3, edge: 0.5, boil: 0.3 },
   // 5 Press -- dark factory, strong ink

--- a/lib/shots.ts
+++ b/lib/shots.ts
@@ -25,16 +25,16 @@ export type TransitionKind =
   | "ink-flood"
   | "dot-match";
 
-/** What the TransitionEffect can render in Phase 0. */
-export type TransitionMode = "cut" | "whip" | "dot-zoom";
+/** What the TransitionEffect can render (Phase 1: + crash-through). */
+export type TransitionMode = "cut" | "whip" | "dot-zoom" | "crash-through";
 
-// ponytail: Phase 0 ships 3 transition modes; unbuilt kinds map to nearest analog (S0.1),
-// swapped for real implementations in Phases 1-2 without touching the registry.
+// ponytail: unbuilt kinds map to nearest analog (S0.1), swapped for real
+// implementations in Phases 1-2 without touching the registry.
 export const TRANSITION_FALLBACK: Record<TransitionKind, TransitionMode> = {
   cut: "cut",
   whip: "whip",
   "dot-zoom": "dot-zoom",
-  "crash-through": "whip",
+  "crash-through": "crash-through",
   "title-drop": "whip",
   "panel-wipe": "cut",
   "panel-portal": "cut",
@@ -101,9 +101,9 @@ export function poseAt(shot: Shot, p: number): Pose {
 
 /** Where within a gutter the camera jumps from the outgoing to the incoming shot. */
 function cutPoint(mode: TransitionMode): number {
-  // dot-zoom films the incoming issue for the whole gutter -- the outgoing
-  // issue is only present as its collapsing snapshot overlay.
-  return mode === "dot-zoom" ? 0 : 0.5;
+  // dot-zoom and crash-through film the incoming issue for the whole
+  // gutter -- the outgoing issue is only present as its snapshot overlay.
+  return mode === "dot-zoom" || mode === "crash-through" ? 0 : 0.5;
 }
 
 export interface TransitionSample {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "panel-jump",
+  "name": "saeed-kolivand-portfolio",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "panel-jump",
+      "name": "saeed-kolivand-portfolio",
       "version": "0.1.0",
       "dependencies": {
         "@gsap/react": "2.1.2",
@@ -1165,6 +1165,72 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.3.2",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "panel-jump",
+  "name": "saeed-kolivand-portfolio",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/shaders/PrintEffect.ts
+++ b/shaders/PrintEffect.ts
@@ -1,11 +1,28 @@
 import { Effect, EffectAttribute } from "postprocessing";
-import { Color, Uniform, type Texture } from "three";
+import { Color, Matrix4, Uniform, Vector3, type Texture } from "three";
 
 /**
- * The shared "print" pass (S2.6): mono grade -> ink edge (Sobel on
- * normals+depth, one uniform line weight) -> registered single-screen
- * halftone -> paper+grain multiply -> vignette -> impact flash. One effect,
- * recipe-driven uniforms, zero channel offsets (S2.16).
+ * The shared "print" pass (S2.6): color-window mask -> mono grade ->
+ * registered single-screen halftone -> crosshatch shadow steps -> ink edge
+ * (Sobel on normals+depth, one uniform line weight) -> paper+grain multiply
+ * -> vignette -> impact flash. One effect, recipe-driven uniforms, zero
+ * channel offsets (S2.16).
+ *
+ * Crosshatch (noir): screen-space, luminance-stepped -- one stroke
+ * direction in shadow, the cross direction added deeper, bolder strokes in
+ * the deepest step. Static in screen space (no boil jitter) so instanced
+ * rain can move over it without shimmer.
+ *
+ * Dark-paper polarity (ruling 2026-07-02): halftone + hatch coverage is
+ * driven by a tonal axis flipped when uPaper is dark (light ink on dark
+ * paper) -- dark subjects stay paper-black silhouettes, ink lands on lit
+ * forms and midtones. Derived in-shader from uPaper luminance; no recipe
+ * field, so cross-fades between polarities stay smooth.
+ *
+ * Color window (S0 Phase 1 noir): ONE world-space rect exempt from mono +
+ * hatch, reconstructed per pixel from the depth buffer via
+ * uInvViewProjection -- costs zero render targets. Positioned at runtime
+ * through shaders/colorWindow.ts.
  *
  * verified 2026-07 (postprocessing v6.39): uniforms must be a Map of
  * three.Uniform; mainImage signature with EffectAttribute.DEPTH gains a
@@ -25,6 +42,14 @@ const fragment = /* glsl */ `
   uniform float uImpact;
   uniform vec2 uBoilJitter;
   uniform float uStepSeed;
+  uniform float uHatch;
+  uniform float uHatchScale;
+  uniform float uWindow;
+  uniform vec3 uWinCenter;
+  uniform vec3 uWinU;
+  uniform vec3 uWinV;
+  uniform float uWinDepth;
+  uniform mat4 uInvViewProjection;
 
   float pjLuma(const in vec3 c) { return dot(c, vec3(0.299, 0.587, 0.114)); }
 
@@ -50,26 +75,75 @@ const fragment = /* glsl */ `
     return clamp(e, 0.0, 1.0);
   }
 
-  float pjHalftone(const in vec2 fragPx, const in float lum) {
+  float pjHalftone(const in vec2 fragPx, const in float shade) {
     mat2 R = mat2(0.70710678, -0.70710678, 0.70710678, 0.70710678);
     vec2 p = (R * fragPx) / max(uHalftoneScale, 1.0);
     vec2 f = fract(p) - 0.5;
-    float r = (1.0 - lum) * 0.75;
+    float r = (1.0 - shade) * 0.75;
     float d = length(f);
     float aa = fwidth(d) + 1e-4;
     return 1.0 - smoothstep(r - aa, r + aa, d);
+  }
+
+  float pjHatchLine(const in float x, const in float w) {
+    float aa = fwidth(x) * 0.75 + 1e-3;
+    return 1.0 - smoothstep(w, w + aa, abs(fract(x) - 0.5));
+  }
+
+  // "shade" is the polarity-mapped tone: low = take ink, high = stay paper
+  float pjHatch(const in vec2 fragPx, const in float shade) {
+    float pitch = max(uHatchScale, 2.0);
+    // two fixed stroke directions ~60deg apart, static in screen space
+    float xa = (fragPx.x * 0.5 + fragPx.y * 0.866) / pitch;
+    float xb = (fragPx.x * 0.866 - fragPx.y * 0.5) / pitch;
+    float s1 = smoothstep(0.5, 0.34, shade);  // first step: direction A
+    float s2 = smoothstep(0.3, 0.16, shade);  // deeper: direction B crosses A
+    float s3 = smoothstep(0.14, 0.05, shade); // deepest: bolder strokes
+    float w = 0.16 + s3 * 0.14;
+    return clamp(pjHatchLine(xa, w) * s1 + pjHatchLine(xb, w) * s2, 0.0, 1.0);
+  }
+
+  float pjWindow(const in vec2 uv, const in float depth) {
+    if (uWindow < 0.001) return 0.0;
+    vec4 h = uInvViewProjection * vec4(vec3(uv, depth) * 2.0 - 1.0, 1.0);
+    vec3 q = h.xyz / max(h.w, 1e-6) - uWinCenter;
+    float a = abs(dot(q, uWinU)) / max(dot(uWinU, uWinU), 1e-5);
+    float b = abs(dot(q, uWinV)) / max(dot(uWinV, uWinV), 1e-5);
+    float n = abs(dot(q, normalize(cross(uWinU, uWinV)))) / max(uWinDepth, 1e-3);
+    float edge = 1.0 - smoothstep(0.92, 1.0, max(a, b));
+    return edge * (1.0 - step(1.0, n)) * uWindow;
   }
 
   void mainImage(const in vec4 inputColor, const in vec2 uv, const in float depth, out vec4 outputColor) {
     vec3 col = inputColor.rgb;
     vec2 fragPx = uv * resolution;
 
-    // 1 -- mono grade
-    col = mix(col, vec3(pjLuma(col)), uMono);
+    // 0 -- color window: world-space rect exempt from mono + hatch, so one
+    // rect prints in full color inside an otherwise mono recipe
+    float win = pjWindow(uv, depth);
 
-    // 2 -- registered halftone: ink dots on paper, dot size from luminance
-    float dotMask = pjHalftone(fragPx, pjLuma(col));
+    // 1 -- mono grade
+    col = mix(col, vec3(pjLuma(col)), uMono * (1.0 - win));
+
+    // pre-halftone luminance feeds both screens (avoids dot/hatch moire)
+    float lum = pjLuma(col);
+
+    // 1b -- dark-paper polarity: both screens assume dark ink on light
+    // paper (darkness -> coverage). On a dark-paper recipe the ink is
+    // LIGHT, so coverage must track brightness instead: light ink goes to
+    // lit forms and midtone hatch, deep shadow stays paper-black
+    // silhouette. Derived from uPaper luminance (linear space: dark papers
+    // < 0.02, light papers > 0.7) so recipe cross-fades stay smooth.
+    float flip = 1.0 - smoothstep(0.05, 0.25, pjLuma(uPaper));
+    float shade = mix(lum, 1.0 - lum, flip);
+
+    // 2 -- registered halftone: ink dots on paper, dot size from tone
+    float dotMask = pjHalftone(fragPx, shade);
     col = mix(col, mix(uPaper, col * 0.88, dotMask), uHalftone);
+
+    // 2b -- crosshatch shading in shadow steps (2 directions + cross)
+    float hm = pjHatch(fragPx, shade) * uHatch * (1.0 - win);
+    col = mix(col, uEdgeColor, hm * 0.85);
 
     // 3 -- one uniform ink line for the whole frame, boiling at step rate
     float e = pjEdge(uv + uBoilJitter * texelSize, texelSize * (1.0 + uBoilJitter.x * 2.0));
@@ -110,6 +184,14 @@ export class PrintEffect extends Effect {
         ["uImpact", new Uniform(0)],
         ["uBoilJitter", new Uniform({ x: 0, y: 0 })],
         ["uStepSeed", new Uniform(0)],
+        ["uHatch", new Uniform(0)],
+        ["uHatchScale", new Uniform(7)],
+        ["uWindow", new Uniform(0)],
+        ["uWinCenter", new Uniform(new Vector3())],
+        ["uWinU", new Uniform(new Vector3(1, 0, 0))],
+        ["uWinV", new Uniform(new Vector3(0, 1, 0))],
+        ["uWinDepth", new Uniform(0.6)],
+        ["uInvViewProjection", new Uniform(new Matrix4())],
       ]),
     });
   }

--- a/shaders/TransitionEffect.ts
+++ b/shaders/TransitionEffect.ts
@@ -1,17 +1,28 @@
-import { Effect } from "postprocessing";
+import { Effect, EffectAttribute } from "postprocessing";
 import { Color, Uniform, type Texture } from "three";
 
 /**
  * S5 transition layer as a final fullscreen effect, driven by scrub-safe
- * local p from the gutter evaluator. Phase 0 modes: 0 none, 1 whip
- * (radial speed lines, no directional blur yet -- S2.16-safe), 2 dot-zoom
- * (outgoing snapshot collapsing into a registered dot screen), 3 cut
- * (paper-color page blink masking the pose jump). Velocity speed lines
- * (S2.9) ride the same lines function outside gutters.
+ * local p from the gutter evaluator. Modes: 0 none, 1 whip (directional
+ * smear along the whip axis + radial speed lines), 2 dot-zoom (outgoing
+ * snapshot collapsing into a registered dot screen), 3 cut (paper-color
+ * page blink), 4 crash-through (cover tears radially into paper fragments
+ * over a settling zoom punch -- Cover -> Issue 1). Everything is a pure
+ * function of uP: scrub-deterministic both directions. Velocity speed
+ * lines (S2.9) ride the same lines function outside gutters.
  *
- * verified 2026-07 (three r185 + project memory): canvas snapshots are
- * sRGB-encoded and FramebufferTexture is NOT auto-decoded in custom
- * shaders -- decode with pow(rgb, 2.2) before linear-space mixing.
+ * verified 2026-07 (postprocessing wiki Custom-Effects): sampling the
+ * INPUT BUFFER at neighbor texels requires EffectAttribute.CONVOLUTION;
+ * one convolution effect per EffectPass -- this is it (DECISIONS
+ * 2026-07-02). inputBuffer holds the PRE-print linear frame, so smear /
+ * punch taps are re-graded with uSmearMono (the cross-faded recipe mono)
+ * to stay consistent with the printed frame they blend into. Canvas
+ * snapshots are sRGB-encoded and NOT auto-decoded in custom shaders --
+ * decode pow(rgb, 2.2) before linear-space mixing (project memory).
+ *
+ * S2.16: the smear is a single-layer box average (no channel offsets, no
+ * ghosting) and only exists inside a whip gutter (whipK == 0 at rest);
+ * the crash punch is a single-layer radial resample, zero chromatic ops.
  */
 const fragment = /* glsl */ `
   uniform sampler2D uSnapshot;
@@ -20,9 +31,17 @@ const fragment = /* glsl */ `
   uniform float uP;
   uniform float uVelocity;
   uniform vec3 uFallback;
+  uniform vec2 uWhipDir;
+  uniform float uSmearMono;
+
+  float pjtLuma(const in vec3 c) { return dot(c, vec3(0.299, 0.587, 0.114)); }
 
   float pjtHash(const in vec2 p) {
     return fract(sin(dot(p, vec2(269.5, 183.3))) * 43758.5453);
+  }
+
+  vec3 pjtGrade(const in vec3 c) {
+    return mix(c, vec3(pjtLuma(c)), uSmearMono);
   }
 
   float pjtSpeedLines(const in vec2 uv, const in float k) {
@@ -40,9 +59,25 @@ const fragment = /* glsl */ `
 
   void mainImage(const in vec4 inputColor, const in vec2 uv, out vec4 outputColor) {
     vec3 col = inputColor.rgb;
+    float p = clamp(uP, 0.0, 1.0);
 
-    // whip intensity: peaks mid-gutter; velocity lines fade in on hard scroll
-    float whipK = uMode == 1.0 ? sin(clamp(uP, 0.0, 1.0) * 3.14159) : 0.0;
+    // whip intensity peaks mid-gutter; velocity lines fade in on hard scroll
+    float whipK = uMode == 1.0 ? sin(p * 3.14159) : 0.0;
+
+    // directional smear along the whip axis (the pass's one CONVOLUTION
+    // job): 8 dithered taps of the raw buffer, re-graded to the active
+    // mono level. whipK gates it to gutter interiors only (S2.16).
+    if (whipK > 0.004) {
+      float spread = whipK * 0.12;
+      float j = pjtHash(uv * 913.7) - 0.5;
+      vec3 acc = vec3(0.0);
+      for (int i = 0; i < 8; i++) {
+        float s = (float(i) + j) / 7.0 - 0.5;
+        acc += texture2D(inputBuffer, uv + uWhipDir * spread * s).rgb;
+      }
+      col = mix(col, pjtGrade(acc * 0.125), smoothstep(0.0, 0.35, whipK));
+    }
+
     float velK = clamp((abs(uVelocity) - 0.35) * 1.2, 0.0, 0.6);
     float lines = pjtSpeedLines(uv, max(whipK, velK));
     col = mix(col, vec3(1.0), lines * 0.85);
@@ -50,11 +85,11 @@ const fragment = /* glsl */ `
     if (uMode == 2.0) {
       // dot-zoom: outgoing frame lives inside a dot screen that shrinks away
       mat2 R = mat2(0.70710678, -0.70710678, 0.70710678, 0.70710678);
-      float scale = mix(90.0, 14.0, uP);
-      vec2 p = (R * (uv * resolution)) / scale;
-      vec2 f = fract(p) - 0.5;
+      float scale = mix(90.0, 14.0, p);
+      vec2 q = (R * (uv * resolution)) / scale;
+      vec2 f = fract(q) - 0.5;
       float radial = 1.0 - distance(uv, vec2(0.5)) * 0.35;
-      float r = pow(1.0 - uP, 1.3) * 0.85 * radial;
+      float r = pow(1.0 - p, 1.3) * 0.85 * radial;
       float d = length(f);
       float aa = fwidth(d) + 1e-4;
       float cover = 1.0 - smoothstep(r - aa, r + aa, d);
@@ -64,20 +99,52 @@ const fragment = /* glsl */ `
       col = mix(col, snap, cover);
     } else if (uMode == 3.0) {
       // cut: quick paper-tone page blink centered on the pose jump
-      float q = 1.0 - abs(2.0 * uP - 1.0);
+      float q = 1.0 - abs(2.0 * p - 1.0);
       col = mix(col, uFallback, smoothstep(0.62, 0.95, q));
+    } else if (uMode == 4.0) {
+      // crash-through: the live incoming frame takes a settling zoom punch
+      // while the printed cover bursts center-out into paper fragments.
+      float punch = smoothstep(0.12, 0.5, p) * (1.0 - smoothstep(0.5, 0.92, p));
+      vec2 zuv = 0.5 + (uv - 0.5) / (1.0 + punch * 0.35);
+      vec3 live = pjtGrade(texture2D(inputBuffer, zuv).rgb);
+      col = mix(col, live, clamp(punch * 2.5, 0.0, 1.0));
+
+      // polar fragment grid: each cell departs when p passes its threshold
+      // (radius + hash), so the tear opens at the center and races outward
+      vec2 d = uv - 0.5;
+      d.x *= aspect;
+      float r = length(d);
+      vec2 cell = vec2((atan(d.y, d.x) * 0.15915494 + 0.5) * 18.0, r * 6.0);
+      float h = pjtHash(floor(cell));
+      float tearP = clamp(p * 1.43, 0.0, 1.0);
+      float f = clamp((tearP - (r * 0.5 + h * 0.4)) * 3.5, 0.0, 1.0);
+      if (f < 1.0) {
+        // departing fragments scale outward and drift tangentially,
+        // carrying their patch of the printed cover with them
+        vec2 snapUv = 0.5 + (uv - 0.5) / (1.0 + f * (0.6 + h * 0.8));
+        snapUv += vec2(-d.y, d.x) * (h - 0.5) * f * 0.3;
+        vec3 snap = uHasSnapshot > 0.5
+          ? pow(texture2D(uSnapshot, snapUv).rgb, vec3(2.2))
+          : uFallback;
+        // torn paper edge in the cover's page color along fragment borders
+        vec2 e2 = min(fract(cell), 1.0 - fract(cell));
+        float torn = smoothstep(0.10, 0.02, min(e2.x, e2.y)) * step(0.001, f);
+        snap = mix(snap, uFallback, torn * 0.9);
+        col = mix(col, snap, 1.0 - smoothstep(0.85, 1.0, f));
+      }
     }
 
     outputColor = vec4(col, inputColor.a);
   }
 `;
 
-const MODE = { none: 0, whip: 1, "dot-zoom": 2, cut: 3 } as const;
+const MODE = { none: 0, whip: 1, "dot-zoom": 2, cut: 3, "crash-through": 4 } as const;
 export type EffectModeName = keyof typeof MODE;
 
 export class TransitionEffect extends Effect {
   constructor() {
     super("TransitionEffect", fragment, {
+      attributes: EffectAttribute.CONVOLUTION,
       uniforms: new Map<string, Uniform>([
         ["uSnapshot", new Uniform<Texture | null>(null)],
         ["uHasSnapshot", new Uniform(0)],
@@ -85,6 +152,8 @@ export class TransitionEffect extends Effect {
         ["uP", new Uniform(0)],
         ["uVelocity", new Uniform(0)],
         ["uFallback", new Uniform(new Color("#F2EAD9"))],
+        ["uWhipDir", new Uniform({ x: 1, y: 0 })],
+        ["uSmearMono", new Uniform(0)],
       ]),
     });
   }

--- a/shaders/colorWindow.ts
+++ b/shaders/colorWindow.ts
@@ -1,0 +1,25 @@
+/**
+ * Runtime channel for the S0 Phase 1 noir COLOR WINDOW: one world-space
+ * rect that prints in full color inside an otherwise mono recipe. Issue
+ * components write here (plain mutable module state, same pattern as
+ * lib/fx); PostPipeline uploads it to PrintEffect every frame. The mask is
+ * reconstructed per pixel from the depth buffer, so this costs zero render
+ * targets and no extra draw (ruling 2026-07-02).
+ *
+ * The rect is center + two half-axis vectors: center + halfU is the middle
+ * of the right edge, center + halfV the middle of the top edge. `depth` is
+ * the half-thickness tolerance along the rect normal in world units --
+ * keep it just deep enough to catch the window geometry.
+ */
+export const colorWindow = {
+  /** 0..1 master blend; 0 skips the shader branch entirely */
+  enabled: 0,
+  /** rect center in world units */
+  center: [0, 0, 0] as [number, number, number],
+  /** half-width axis, world units */
+  halfU: [1, 0, 0] as [number, number, number],
+  /** half-height axis, world units */
+  halfV: [0, 1, 0] as [number, number, number],
+  /** half-thickness along the rect normal, world units */
+  depth: 0.6,
+};


### PR DESCRIPTION
## PANEL JUMP Phase 1 - Cover + Issues 1-3 (t 0.000-0.305)

**35 files, +3472/-127.** The vertical slice that proves the thesis: three maximally different print treatments + the signature transitions, all scroll-driven as pure functions of t.

### What is in it
- **Cover**: printed comic cover (masthead SAEED KOLIVAND, price-box gag, GitHub-handle barcode), attract mode with breathing parallax + 12fps tail flick, layer separation on first scroll feeding the new **crash-through-cover** transition.
- **Issue 1 Noir**: B&W hatched-ink street, instanced rain, ONE full-color CMYK window (zero-RT world-space depth mask), 4 authored shots per the S0.8 canonical table, cat leap = motivated cut.
- **Title-drop beat**: full-frame name card at authored speed (velocity-independent, hysteresis re-arm), whip with new directional smear.
- **Issue 2 Desk**: cat landing continuity, warm halftone, live **3-panel RT composite** (budget 3 -> 2 on low tier), keycap CLACK onomatopoeia, cat dot-bat motivating the dot-zoom.
- **Issue 3 Neon**: code-block city in flat neon inks, krackle, **10-ring power-on cascade** (scrub-deterministic) + sub-thump beat.
- **Engine**: post-exempt lettering (DOM overlay + Hud pool at renderPriority 2), pooled onomatopoeia (zero GC churn, trace-verified), dark-paper recipe polarity derived in-shader, timeline constants extracted to `issues/timeline.ts`.

### Gate (Chrome DevTools MCP, formal)
12/12 PASS after one fix loop (noir dark-paper tonal wash -> in-shader polarity fix; leap framing; desk cat character pass). Steady 60 FPS incl. the RT moment; flash budget respected; scrub-deterministic transitions; Phase 0 self-reported items re-traced and closed. Full record: DECISIONS.md 2026-07-02.

### Follow-ups queued (PLAN.md Phase 2)
Scroll pacing (user feedback), deep-jump mount blank, shared CatModel extraction. Asset upgrade prompt queued: `assets/prompts/noir-window-figure.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)