### PR TITLE
Phase 2: framework hardening

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -223,3 +223,68 @@ pinned 5.9.3, an external edit bumped it - kept, builds clean),
   library. (4) Neon diegetic drei-Text signs are environmental art, not
   "readable lettering" under S2.16 - whip smear may touch them; avoid
   centering a sign in frame at a whip gutter when authoring future shots.
+
+## 2026-07-02 - Phase 2 (framework hardening)
+
+- Transition library complete: TransitionEffect modes panel-wipe=5,
+  paper-tear=6, page-flip=7, stamp=8, dot-match=9, ink-flood=10; all pure
+  f(uP), single-layer, zero new RTs; TransitionEffect remains the pass's
+  single CONVOLUTION effect. New uniforms uSmearHalftone/uSmearScale/
+  uSmearPaper feed pjtPrint(), an in-shader mono+halftone+paper approximation
+  of PrintEffect applied to displaced taps - closes PR #22 ruling 3
+  (crash-through pre-print flash) at zero cost; stamp uses the same handoff.
+- Fallback map remainder (reasoning logged in lib/shots.ts): title-drop->whip
+  (the slam is an authored-time BEAT per S5b.3; the gutter only carries the
+  whip) and panel-portal->panel-wipe (portal fly-through is scene/camera work,
+  not a post op; nearest native analog for the Issue 4 exit). cutPoint now
+  derives from usesSnapshot(): snapshot modes film incoming at p=0; cut/whip/
+  ink-flood jump at 0.5 (ink-flood full-cover window p .375-.625 hides it).
+- Scroll pacing (user 2026-07-02: too fast per wheel): docs-researcher
+  verified Lenis 1.3.25 - lerp (default .1) and duration are mutually
+  exclusive (lerp wins), neither changes distance-per-notch; spacer growth is
+  the primary lever and survives reduced-motion. Applied SPACER_VH=2400 +
+  WHEEL_MULTIPLIER=0.7 (named constants in ScrollProxy.tsx for feel-tuning);
+  gate measured 0.478x t per notch vs the 1200vh baseline.
+- Deep-jump blank fix: SceneManager premount window centers on an anchor
+  state; on |active-anchor|>1 the new JumpCover paints an opaque target-paper
+  + ink-dot screen synchronously (zustand subscribe, pre-React-commit), the
+  target trio mounts one rAF later, reveal after a double-rAF so the first
+  compile frame lands under the cover; opacity-only .25s fade, instant under
+  reduced motion, mid-fade re-jump idempotent (S2.16 clean).
+- CatModel extraction: components/CatModel.tsx, params pose (sitting/crouch/
+  walking/leaping) x mode (flat/toon) x palette x optional rig refs; cover +
+  desk cats migrated with every numeric constant preserved (silhouette
+  equivalence re-verified visually at the gate). Noir's leaping cat NOT
+  migrated: it is a dimensional prop rotated ry 0->1.35 (a flat build
+  vanishes edge-on) and its proportions were NDC-verified against the
+  approved shot-4 leap framing - left byte-untouched. Unused pose presets are
+  authored-but-unused until Issues 4-11.
+- Framework APIs: printRecipe({paper, ink, ...overrides}) with
+  RECIPE_DEFAULTS (RECIPES rewritten byte-identical); PopPool<T> + popScale()
+  zero-alloc pop pool (onomatopoeia migrated, Issue 8 balloons / Issue 11
+  panels build on it); snapshots.retain/release/isRetained (tail-capture +
+  evict-proof, snapshots are not RTs so the RT budget is untouched);
+  registerJawDrop({id, t, flash?, animate?, hysteresis?}) with central
+  hysteresis (default .006) + requestFlash budget - title-drop and
+  neon-cascade migrated onto it with identical envelopes; registry row()
+  makes an issue entry self-contained (component + recipe + shots).
+- Live user fixes during the phase: noir shot shares 0.30/0.15/0.35/0.20 ->
+  0.35/0.23/0.22/0.20, share taken from the static dolly dwell only; shot-4
+  t-range bit-identical (leap invariants untouched); wide->close travel
+  +40% t. Noir caption fades 0.18 -> 0.30 in/out (~40% plateau), pure f(t).
+
+### Phase 2 gate result (Chrome DevTools MCP, formal)
+- 10/10 PASS, zero fix loops: console clean full scrub; all 7 new/polished
+  transitions styled + scrub-deterministic both directions; S2.16 comfort
+  (no chromatic split, no strobe, lettering crisp); CatModel silhouettes read
+  as the approved characters; JumpCover verified incl. mid-fade re-jump;
+  pacing 0.478x per notch; noir shot-4 leap + caption plateaus verified;
+  title-drop hysteresis re-arm (fireCount=2) + neon cascade fire; perf median
+  2.1ms / p95 2.5ms / 99.8% frames under 16.7ms; flash budget sole-path
+  verified (2 gated jaw-drops per full scrub).
+- Gate proof of the Phase 2 criterion: throwaway test issue rendered with
+  full print treatment + panel-wipe entry from exactly ONE component file +
+  ONE registry row + ONE printRecipe(), then deleted completely.
+- Advisory (non-blocking): reproducible single-frame ~58ms scene-mount hitch
+  at t~0.172 during fast desk-region scrubbing (0.2% of frames, warm-pass
+  confirmed one-off) - hand to perf-profiler if it worsens on the low tier.

--- a/PLAN.md
+++ b/PLAN.md
@@ -37,20 +37,31 @@ Session protocol (S0.9): one phase per session. Kickoff every session with
 - [x] Asset prompt queued: assets/prompts/noir-window-figure.md
 - Ships as PR (new workflow): branch phase-1-vertical-slice
 
-## Phase 2 - Framework hardening
-Full transition library (page-flip, tear, panel-wipe, match-cut, stamp),
-recipe API extraction, balloon/word pooling, snapshot pool generalization,
-jaw-drop trigger helper. Gate: new issue = component + registry entry + recipe.
-Also: scroll pacing pass (user 2026-07-02: one wheel scroll moves scenes too
-fast) - grow the 1200vh ScrollProxy spacer and/or tune Lenis duration/
-wheelMultiplier; pure t-space means zero scene re-authoring; user judges feel.
-Also: SceneManager mount latency on discrete deep jumps (gate 2026-07-02:
-~1s cream blank jumping straight into neon; continuous scrub unaffected by
-active+/-1 premounts) - premount on large t deltas or cheap loading treatment.
-Also: extract shared CatModel component (user 2026-07-02: no more
-shapes-taped-together cats) from the approved cover/desk cats - organic
-primitives, palette + pose + material-mode params - before Issues 4-11 reuse
-the mascot.
+## Phase 2 - Framework hardening -- DONE (2026-07-02)
+- [x] Transition library complete: native panel-wipe/paper-tear/page-flip/
+      stamp/dot-match/ink-flood (modes 5-10) + in-shader pre-print polish for
+      crash-through/stamp (closes PR #22 ruling 3). Fallback map remainder:
+      title-drop->whip (beat by design), panel-portal->panel-wipe (scene work)
+- [x] printRecipe() one-object recipe API; RECIPES byte-identical rewrite
+- [x] PopPool<T> generic pooled lettering/balloons (onomatopoeia migrated;
+      Issue 8 balloons / Issue 11 panels build on it)
+- [x] snapshots.retain/release/isRetained - snapshot pool requestable by any
+      consumer; RT budget rules intact
+- [x] registerJawDrop() declarative beat helper (hysteresis + flash budget
+      centralized); title-drop + neon-cascade migrated
+- [x] Scroll pacing: SPACER_VH=2400, WHEEL_MULTIPLIER=0.7 (docs-verified
+      levers; ~0.48x t per wheel notch); user-tunable named constants
+- [x] Deep-jump fix: JumpCover paper-dot screen, sync paint + double-rAF
+      reveal; no cream blank, re-jump idempotent
+- [x] CatModel extraction (pose x mode x palette x rig); cover + desk
+      migrated constant-identical; noir cat deliberately left (dimensional
+      prop, approved leap framing risk)
+- [x] Live user fixes: noir shares 0.30/0.15/0.35/0.20 -> 0.35/0.23/0.22/0.20
+      (wide->close travel +40%); caption fades 0.18 -> 0.30 in/out
+- [x] Gate: 10/10 PASS (DevTools MCP, zero fix loops); gate proof: test issue
+      = 1 component + 1 registry row + 1 recipe, then deleted. Advisory: 58ms
+      one-off mount hitch t~0.172 (0.2% frames) - perf-profiler if it worsens
+- Ships as PR: branch phase-2-framework-hardening
 
 ## Phase 3 - Issues 4-11, one commit each (styled placeholders -> real)
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 import Experience from "@/components/Experience";
+import JumpCover from "@/components/JumpCover";
 import Lettering from "@/components/Lettering";
 import ScrollProxy from "@/components/ScrollProxy";
 import { content } from "@/lib/content";
@@ -13,6 +14,7 @@ export default function Home() {
       <p className="sr-only">{content.tagline}</p>
       <Experience />
       <Lettering />
+      <JumpCover />
       <ScrollProxy />
     </main>
   );

--- a/components/CatModel.tsx
+++ b/components/CatModel.tsx
@@ -1,0 +1,385 @@
+"use client";
+
+import type { RefObject } from "react";
+import { BackSide, type Group } from "three";
+import { toonRamp } from "@/lib/toon";
+
+/**
+ * CatModel -- the shared mascot (S1 through-line), extracted from the two
+ * user-approved Phase 1 cats. Two builds under one API:
+ *
+ * - mode "flat": the flat-print 2D silhouette build (Cover style):
+ *   overlapping connected shapes with tiny z offsets, viewed face-on inside
+ *   a printed composition. pose "leaping" IS the approved cover cat
+ *   (exact Phase 1 numbers).
+ * - mode "toon": the dimensional lit-toon build (Desk style): ink volumes
+ *   with paper rim hulls (inverted BackSide) so the cat reads from any
+ *   angle and against dark surroundings. pose "sitting" IS the approved
+ *   desk cat (exact Phase 1 numbers).
+ *
+ * Invariants carried from the Phase 1 user-directed fixes (DECISIONS.md
+ * 2026-07-02): every leg/sock root sits INSIDE a body silhouette and the
+ * tail pivot sits INSIDE the haunch, in every pose. Scene behavior
+ * (breathe phase, pounce shadow, onomatopoeia, click meow) stays in the
+ * scenes; parents animate head/paw/tail through the rig refs. Idle motion
+ * a parent adds must sample stepTime (S2.8); scroll motion stays pure f(t).
+ */
+
+export type CatPose = "sitting" | "crouch" | "walking" | "leaping";
+export type CatMode = "flat" | "toon";
+
+export interface CatPalette {
+  ink: string; // body
+  paper: string; // socks, chest, muzzle, eye whites, whiskers, rim hulls
+  collar: string; // collar band (identity mark, teal everywhere so far)
+  tag: string; // collar tag + nose (identity mark, red everywhere so far)
+  accent: string; // tail tip, toon eyes + inner ears (issue accent color)
+}
+
+export interface CatRig {
+  head?: RefObject<Group | null>;
+  paw?: RefObject<Group | null>; // toon build only (flat legs are static)
+  tail?: RefObject<Group | null>;
+}
+
+interface CatModelProps {
+  pose: CatPose;
+  mode: CatMode;
+  palette: CatPalette;
+  rig?: CatRig;
+}
+
+type Vec3 = [number, number, number];
+
+/* ----------------------------------------------------- flat-print build -- */
+
+interface FlatPose {
+  torso: [number, number]; // scale of the r 0.55 torso ellipse
+  haunch: [number, number]; // xy of the r 0.4 hip circle
+  head: { pos: Vec3; rot: number };
+  legs: { pos: Vec3; rot: number; r: number; len: number }[];
+  socks: { pos: Vec3; r: number }[]; // paper caps ON the capsule tips
+  collar: { pos: Vec3; rot: number };
+  tag: Vec3;
+  tail: { pivot: Vec3; rot: number }; // pivot INSIDE the haunch
+}
+
+const FLAT_POSES: Record<CatPose, FlatPose> = {
+  // mid-pounce: the approved Cover hero cat, byte-for-byte
+  leaping: {
+    torso: [1.5, 0.82],
+    haunch: [-0.6, -0.05],
+    head: { pos: [0.85, 0.36, 0.003], rot: 0 },
+    legs: [
+      { pos: [0.88, -0.14, 0.0008], rot: -1.05, r: 0.08, len: 0.5 },
+      { pos: [1.08, 0.06, 0.002], rot: -1.25, r: 0.08, len: 0.55 },
+      { pos: [-0.68, -0.34, 0.0008], rot: -0.35, r: 0.085, len: 0.48 },
+      { pos: [-0.86, -0.3, 0.002], rot: -0.75, r: 0.085, len: 0.55 },
+    ],
+    socks: [
+      { pos: [1.42, 0.17, 0.004], r: 0.08 },
+      { pos: [1.17, 0.01, 0.004], r: 0.075 },
+    ],
+    collar: { pos: [0.6, 0.05, 0.005], rot: -1.15 },
+    tag: [0.68, -0.1, 0.006],
+    tail: { pivot: [-0.9, 0.15, 0.001], rot: 0 },
+  },
+  // upright sit, front paws planted, tail curled around the base
+  sitting: {
+    torso: [1.0, 1.3],
+    haunch: [-0.12, -0.55],
+    head: { pos: [0.12, 0.78, 0.003], rot: 0 },
+    legs: [
+      { pos: [0.22, -0.52, 0.0008], rot: 0, r: 0.08, len: 0.5 },
+      { pos: [0.4, -0.5, 0.002], rot: -0.08, r: 0.08, len: 0.48 },
+      { pos: [-0.12, -0.82, 0.002], rot: 1.45, r: 0.085, len: 0.3 },
+    ],
+    socks: [
+      { pos: [0.22, -0.85, 0.004], r: 0.08 },
+      { pos: [0.38, -0.82, 0.004], r: 0.075 },
+    ],
+    collar: { pos: [0.12, 0.44, 0.005], rot: 0 },
+    tag: [0.12, 0.3, 0.006],
+    tail: { pivot: [-0.35, -0.62, 0.001], rot: 0.85 },
+  },
+  // low anticipation crouch, legs tucked, tail flat behind
+  crouch: {
+    torso: [1.7, 0.62],
+    haunch: [-0.7, -0.02],
+    head: { pos: [0.88, 0.12, 0.003], rot: -0.1 },
+    legs: [
+      { pos: [0.6, -0.22, 0.0008], rot: 1.35, r: 0.08, len: 0.42 },
+      { pos: [-0.52, -0.24, 0.002], rot: 1.45, r: 0.085, len: 0.42 },
+    ],
+    socks: [{ pos: [0.86, -0.28, 0.004], r: 0.07 }],
+    collar: { pos: [0.66, 0.08, 0.005], rot: -1.3 },
+    tag: [0.72, -0.06, 0.006],
+    tail: { pivot: [-0.95, 0.05, 0.001], rot: -0.85 },
+  },
+  // mid-stride walk, diagonal legs, question-mark tail
+  walking: {
+    torso: [1.55, 0.78],
+    haunch: [-0.62, -0.06],
+    head: { pos: [0.84, 0.32, 0.003], rot: 0 },
+    legs: [
+      { pos: [0.55, -0.42, 0.0008], rot: 0.3, r: 0.08, len: 0.46 },
+      { pos: [0.3, -0.38, 0.002], rot: -0.35, r: 0.08, len: 0.46 },
+      { pos: [-0.58, -0.42, 0.0008], rot: -0.3, r: 0.085, len: 0.46 },
+      { pos: [-0.78, -0.36, 0.002], rot: 0.4, r: 0.085, len: 0.46 },
+    ],
+    socks: [
+      { pos: [0.64, -0.71, 0.004], r: 0.08 },
+      { pos: [0.19, -0.67, 0.004], r: 0.075 },
+    ],
+    collar: { pos: [0.58, 0.1, 0.005], rot: -1.2 },
+    tag: [0.64, -0.04, 0.006],
+    tail: { pivot: [-0.88, 0.1, 0.001], rot: 0.5 },
+  },
+};
+
+function FlatCat({ def, p, rig }: { def: FlatPose; p: CatPalette; rig?: CatRig }) {
+  const ramp = toonRamp();
+  return (
+    <group>
+      {/* torso ellipse + haunch keep every limb rooted in one silhouette */}
+      <mesh scale={[def.torso[0], def.torso[1], 1]}>
+        <circleGeometry args={[0.55, 40]} />
+        <meshToonMaterial color={p.ink} gradientMap={ramp} />
+      </mesh>
+      <mesh position={[def.haunch[0], def.haunch[1], 0.0005]}>
+        <circleGeometry args={[0.4, 40]} />
+        <meshToonMaterial color={p.ink} gradientMap={ramp} />
+      </mesh>
+
+      {/* legs: rounded capsules (caps = paws); root ends stay INSIDE the
+          torso/haunch silhouette in every pose (Phase 1 invariant) */}
+      {def.legs.map((l, i) => (
+        <mesh key={i} position={l.pos} rotation={[0, 0, l.rot]}>
+          <capsuleGeometry args={[l.r, l.len, 4, 10]} />
+          <meshToonMaterial color={p.ink} gradientMap={ramp} />
+        </mesh>
+      ))}
+      {/* paper socks sit ON the capsule tips (Desk cat identity echo) */}
+      {def.socks.map((s, i) => (
+        <mesh key={i} position={s.pos}>
+          <circleGeometry args={[s.r, 16]} />
+          <meshToonMaterial color={p.paper} gradientMap={ramp} />
+        </mesh>
+      ))}
+
+      {/* head overlaps the torso -- ears are 3-gon circles */}
+      <group ref={rig?.head} position={def.head.pos} rotation={[0, 0, def.head.rot]}>
+        <mesh>
+          <circleGeometry args={[0.37, 40]} />
+          <meshToonMaterial color={p.ink} gradientMap={ramp} />
+        </mesh>
+        <mesh position={[-0.17, 0.36, 0]} rotation={[0, 0, Math.PI / 2 + 0.15]}>
+          <circleGeometry args={[0.16, 3]} />
+          <meshToonMaterial color={p.ink} gradientMap={ramp} />
+        </mesh>
+        <mesh position={[0.17, 0.37, 0]} rotation={[0, 0, Math.PI / 2 - 0.15]}>
+          <circleGeometry args={[0.16, 3]} />
+          <meshToonMaterial color={p.ink} gradientMap={ramp} />
+        </mesh>
+        {/* eyes: paper almonds + ink pupils -- reads at 200px */}
+        <mesh position={[-0.13, 0.02, 0.002]} scale={[0.8, 1.15, 1]}>
+          <circleGeometry args={[0.085, 20]} />
+          <meshToonMaterial color={p.paper} gradientMap={ramp} />
+        </mesh>
+        <mesh position={[0.15, 0.04, 0.002]} scale={[0.8, 1.15, 1]}>
+          <circleGeometry args={[0.085, 20]} />
+          <meshToonMaterial color={p.paper} gradientMap={ramp} />
+        </mesh>
+        <mesh position={[-0.12, 0.01, 0.004]}>
+          <circleGeometry args={[0.035, 12]} />
+          <meshToonMaterial color={p.ink} gradientMap={ramp} />
+        </mesh>
+        <mesh position={[0.16, 0.03, 0.004]}>
+          <circleGeometry args={[0.035, 12]} />
+          <meshToonMaterial color={p.ink} gradientMap={ramp} />
+        </mesh>
+        {/* 3-gon nose, point down */}
+        <mesh position={[0.02, -0.13, 0.002]} rotation={[0, 0, -Math.PI / 2]}>
+          <circleGeometry args={[0.055, 3]} />
+          <meshToonMaterial color={p.tag} gradientMap={ramp} />
+        </mesh>
+        {/* whiskers -- thin paper strokes */}
+        <mesh position={[-0.31, -0.09, 0.002]} rotation={[0, 0, 0.12]}>
+          <planeGeometry args={[0.26, 0.018]} />
+          <meshToonMaterial color={p.paper} gradientMap={ramp} />
+        </mesh>
+        <mesh position={[-0.32, -0.16, 0.002]} rotation={[0, 0, -0.06]}>
+          <planeGeometry args={[0.24, 0.018]} />
+          <meshToonMaterial color={p.paper} gradientMap={ramp} />
+        </mesh>
+        <mesh position={[0.34, -0.07, 0.002]} rotation={[0, 0, -0.12]}>
+          <planeGeometry args={[0.26, 0.018]} />
+          <meshToonMaterial color={p.paper} gradientMap={ramp} />
+        </mesh>
+        <mesh position={[0.35, -0.14, 0.002]} rotation={[0, 0, 0.06]}>
+          <planeGeometry args={[0.24, 0.018]} />
+          <meshToonMaterial color={p.paper} gradientMap={ramp} />
+        </mesh>
+      </group>
+
+      {/* collar band across the neck + tag */}
+      <mesh position={def.collar.pos} rotation={[0, 0, def.collar.rot]}>
+        <planeGeometry args={[0.46, 0.1]} />
+        <meshToonMaterial color={p.collar} gradientMap={ramp} />
+      </mesh>
+      <mesh position={def.tag}>
+        <circleGeometry args={[0.06, 12]} />
+        <meshToonMaterial color={p.tag} gradientMap={ramp} />
+      </mesh>
+
+      {/* tail -- torus arc pivoting at its base end; the pivot sits INSIDE
+          the haunch circle in every pose or a flick reads as a detached
+          floating arc (Phase 1 invariant). Parents flick rotation.z. */}
+      <group ref={rig?.tail} position={def.tail.pivot} rotation={[0, 0, def.tail.rot]}>
+        <mesh position={[-0.42, 0, 0]}>
+          <torusGeometry args={[0.42, 0.07, 8, 24, 2.05]} />
+          <meshToonMaterial color={p.ink} gradientMap={ramp} />
+        </mesh>
+        <mesh position={[-0.614, 0.373, 0.002]}>
+          <circleGeometry args={[0.075, 12]} />
+          <meshToonMaterial color={p.accent} gradientMap={ramp} />
+        </mesh>
+      </group>
+    </group>
+  );
+}
+
+/* ------------------------------------------------------ lit-toon build -- */
+
+interface ToonPose {
+  scale: Vec3; // pose transform on the whole rig (sitting = identity)
+  rot: number;
+  head: Vec3; // default group positions -- rig-ref parents override per frame
+  paw: Vec3;
+}
+
+const TOON_POSES: Record<CatPose, ToonPose> = {
+  // neutral perch/loaf rig: the approved Desk cat, byte-for-byte (identity
+  // pose transform; the Desk scene animates land/loaf/rear via rig refs)
+  sitting: { scale: [1, 1, 1], rot: 0, head: [0.5, 0.62, 0], paw: [0.5, 0.42, 0.16] },
+  crouch: { scale: [1.06, 0.78, 1], rot: 0, head: [0.54, 0.5, 0], paw: [0.52, 0.34, 0.16] },
+  walking: { scale: [1.04, 0.96, 1], rot: -0.04, head: [0.56, 0.6, 0], paw: [0.64, 0.4, 0.16] },
+  // stretched airborne attitude (echoes the Desk entrance squash-stretch)
+  leaping: { scale: [1.12, 0.9, 1], rot: 0.2, head: [0.6, 0.68, 0], paw: [0.68, 0.52, 0.16] },
+};
+
+function ToonCat({ def, p, rig }: { def: ToonPose; p: CatPalette; rig?: CatRig }) {
+  const ramp = toonRamp();
+  return (
+    <group scale={def.scale} rotation={[0, 0, def.rot]}>
+      {/* body + paper rim outline (inverted hull) so ink reads against
+          dark set pieces, not just light ones */}
+      <mesh position={[0, 0.3, 0]}>
+        <boxGeometry args={[0.95, 0.5, 0.48]} />
+        <meshToonMaterial color={p.ink} gradientMap={ramp} />
+      </mesh>
+      <mesh position={[0, 0.3, 0]}>
+        <boxGeometry args={[1.01, 0.56, 0.54]} />
+        <meshBasicMaterial color={p.paper} side={BackSide} />
+      </mesh>
+      {/* chest patch */}
+      <mesh position={[0.44, 0.26, 0]}>
+        <boxGeometry args={[0.08, 0.26, 0.2]} />
+        <meshToonMaterial color={p.paper} gradientMap={ramp} />
+      </mesh>
+      {/* collar + tag */}
+      <mesh position={[0.42, 0.5, 0]}>
+        <boxGeometry args={[0.12, 0.07, 0.4]} />
+        <meshToonMaterial color={p.collar} gradientMap={ramp} />
+      </mesh>
+      <mesh position={[0.48, 0.43, 0]}>
+        <boxGeometry args={[0.05, 0.08, 0.08]} />
+        <meshToonMaterial color={p.tag} gradientMap={ramp} />
+      </mesh>
+      <group ref={rig?.head} position={def.head}>
+        <mesh>
+          <boxGeometry args={[0.44, 0.42, 0.42]} />
+          <meshToonMaterial color={p.ink} gradientMap={ramp} />
+        </mesh>
+        <mesh>
+          <boxGeometry args={[0.5, 0.48, 0.48]} />
+          <meshBasicMaterial color={p.paper} side={BackSide} />
+        </mesh>
+        {/* ears + accent inner ears */}
+        <mesh position={[0.08, 0.28, 0.12]} rotation={[0, 0, 0.25]}>
+          <coneGeometry args={[0.09, 0.22, 4]} />
+          <meshToonMaterial color={p.ink} gradientMap={ramp} />
+        </mesh>
+        <mesh position={[0.08, 0.28, -0.12]} rotation={[0, 0, -0.25]}>
+          <coneGeometry args={[0.09, 0.22, 4]} />
+          <meshToonMaterial color={p.ink} gradientMap={ramp} />
+        </mesh>
+        <mesh position={[0.1, 0.27, 0.12]} rotation={[0, 0, 0.25]}>
+          <coneGeometry args={[0.05, 0.14, 4]} />
+          <meshBasicMaterial color={p.accent} />
+        </mesh>
+        <mesh position={[0.1, 0.27, -0.12]} rotation={[0, 0, -0.25]}>
+          <coneGeometry args={[0.05, 0.14, 4]} />
+          <meshBasicMaterial color={p.accent} />
+        </mesh>
+        {/* eyes: flat accent + ink pupils (comic cat stare) */}
+        <mesh position={[0.225, 0.06, 0.11]}>
+          <boxGeometry args={[0.035, 0.11, 0.1]} />
+          <meshBasicMaterial color={p.accent} />
+        </mesh>
+        <mesh position={[0.225, 0.06, -0.11]}>
+          <boxGeometry args={[0.035, 0.11, 0.1]} />
+          <meshBasicMaterial color={p.accent} />
+        </mesh>
+        <mesh position={[0.235, 0.04, 0.11]}>
+          <boxGeometry args={[0.03, 0.06, 0.035]} />
+          <meshBasicMaterial color={p.ink} />
+        </mesh>
+        <mesh position={[0.235, 0.04, -0.11]}>
+          <boxGeometry args={[0.03, 0.06, 0.035]} />
+          <meshBasicMaterial color={p.ink} />
+        </mesh>
+        {/* paper muzzle + nose */}
+        <mesh position={[0.225, -0.12, 0]}>
+          <boxGeometry args={[0.05, 0.13, 0.15]} />
+          <meshToonMaterial color={p.paper} gradientMap={ramp} />
+        </mesh>
+        <mesh position={[0.245, -0.05, 0]}>
+          <boxGeometry args={[0.03, 0.04, 0.05]} />
+          <meshBasicMaterial color={p.tag} />
+        </mesh>
+      </group>
+      <group ref={rig?.paw} position={def.paw}>
+        <mesh position={[0, -0.18, 0]}>
+          <cylinderGeometry args={[0.055, 0.06, 0.36, 8]} />
+          <meshToonMaterial color={p.ink} gradientMap={ramp} />
+        </mesh>
+        {/* paper sock on the batting paw */}
+        <mesh position={[0, -0.33, 0]}>
+          <cylinderGeometry args={[0.06, 0.065, 0.1, 8]} />
+          <meshToonMaterial color={p.paper} gradientMap={ramp} />
+        </mesh>
+      </group>
+      <group ref={rig?.tail} position={[-0.48, 0.4, 0]} rotation={[0, 0, 0.9]}>
+        <mesh position={[-0.18, 0.18, 0]} rotation={[0, 0, 0.9]}>
+          <cylinderGeometry args={[0.05, 0.07, 0.55, 8]} />
+          <meshToonMaterial color={p.ink} gradientMap={ramp} />
+        </mesh>
+        <mesh position={[-0.37, 0.34, 0]} rotation={[0, 0, 0.9]}>
+          <cylinderGeometry args={[0.042, 0.05, 0.16, 8]} />
+          <meshToonMaterial color={p.accent} gradientMap={ramp} />
+        </mesh>
+      </group>
+    </group>
+  );
+}
+
+/* -------------------------------------------------------------- export -- */
+
+export default function CatModel({ pose, mode, palette, rig }: CatModelProps) {
+  return mode === "flat" ? (
+    <FlatCat def={FLAT_POSES[pose]} p={palette} rig={rig} />
+  ) : (
+    <ToonCat def={TOON_POSES[pose]} p={palette} rig={rig} />
+  );
+}

--- a/components/JumpCover.tsx
+++ b/components/JumpCover.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { ISSUES } from "@/issues/registry";
+import { useScrollStore } from "@/lib/scrollStore";
+
+/**
+ * Paper-color halftone-dot fill that hides the mount/compile stall when a
+ * deep jump lands past SceneManager's premount window (deep link, scrollbar
+ * yank). Shown/hidden by direct style mutation inside a store subscription:
+ * the show is synchronous with setJumpCover, so the fill is painted before
+ * the heavy scene commit regardless of React scheduling. Static opaque fill,
+ * instant show, short opacity-only fade out -- S2.16 safe (no channel
+ * separation, ghosting, or blur), and the fade is skipped under reduced
+ * motion. Scroll behavior itself is untouched.
+ */
+export default function JumpCover() {
+  const el = useRef<HTMLDivElement>(null);
+
+  useEffect(
+    () =>
+      useScrollStore.subscribe((s, prev) => {
+        const div = el.current;
+        if (!div || s.jumpCover === prev.jumpCover) return;
+        if (s.jumpCover !== null) {
+          const r = ISSUES[s.jumpCover]!.recipe;
+          div.style.backgroundColor = r.bg;
+          // ink-tone dot screen (#RRGGBBAA, ~12% alpha) in the print language
+          div.style.backgroundImage = `radial-gradient(circle, ${r.ink}1f 1.5px, transparent 1.6px)`;
+          div.style.transition = "none";
+          div.style.opacity = "1";
+        } else {
+          div.style.transition = s.reducedMotion ? "none" : "opacity 0.25s ease-out";
+          div.style.opacity = "0";
+        }
+      }),
+    [],
+  );
+
+  return (
+    <div
+      ref={el}
+      aria-hidden
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 30, // above the canvas and Lettering (z-20)
+        opacity: 0,
+        pointerEvents: "none",
+        backgroundSize: "9px 9px",
+      }}
+    />
+  );
+}

--- a/components/Lettering.tsx
+++ b/components/Lettering.tsx
@@ -30,11 +30,15 @@ const CAPTION_WINDOWS: [number, number][] =
         return [NOIR_RANGE[0] + i * w, NOIR_RANGE[0] + (i + 1) * w];
       });
 
-/** fade in over the first 18% of a window, out over the last 18% -- pure f(t) */
+/**
+ * fade in over the first 30% of a window, out over the last 30% (~40%
+ * full-opacity plateau) -- pure f(t), opacity only (S2.16). Was 18%/18%;
+ * slowed per user feedback 2026-07-02 (captions entered/exited too fast).
+ */
 function windowOpacity(t: number, a: number, b: number): number {
   const p = (t - a) / (b - a);
   if (p <= 0 || p >= 1) return 0;
-  return Math.min(1, p / 0.18, (1 - p) / 0.18);
+  return Math.min(1, p / 0.3, (1 - p) / 0.3);
 }
 
 const INK = "#14110E";

--- a/components/Onomatopoeia.tsx
+++ b/components/Onomatopoeia.tsx
@@ -4,16 +4,16 @@ import { Suspense, useRef } from "react";
 import { useFrame, useThree } from "@react-three/fiber";
 import { Hud, OrthographicCamera, Text } from "@react-three/drei";
 import { Vector3, type Camera, type Mesh } from "three";
-import { wordPool, WORD_POOL_SIZE, WORD_LIFE } from "@/lib/onomatopoeia";
+import { words } from "@/lib/onomatopoeia";
+import { popScale } from "@/lib/pops";
 import { stepTime } from "@/lib/steppedClock";
-import { clamp01 } from "@/lib/shots";
 
 /**
- * Renders the lib/onomatopoeia pool as Bangers lettering in a screen-space
- * Hud scene. renderPriority 2 draws AFTER the composer (priority 1), so the
- * words stay post-exempt and pixel-crisp (S2.16). Pop-in/pop-out scale +
- * rotation envelopes sample stepped time (S2.8); the per-frame loop only
- * mutates pooled objects -- zero allocation.
+ * Renders the lib/onomatopoeia PopPool as Bangers lettering in a
+ * screen-space Hud scene. renderPriority 2 draws AFTER the composer
+ * (priority 1), so the words stay post-exempt and pixel-crisp (S2.16).
+ * Pop-in/pop-out scale + rotation envelopes sample stepped time (S2.8); the
+ * per-frame loop only mutates pooled objects -- zero allocation.
  */
 
 type TroikaText = Mesh & { text: string; color: string; sync: () => void };
@@ -23,30 +23,29 @@ const ndc = new Vector3(); // shared projection scratch
 function WordSprites({ mainCamera }: { mainCamera: Camera }) {
   const size = useThree((s) => s.size); // Hud portal inherits root size
   const refs = useRef<(TroikaText | null)[]>([]);
-  const gens = useRef<number[]>(new Array<number>(WORD_POOL_SIZE).fill(-1));
+  const gens = useRef<number[]>(new Array<number>(words.slots.length).fill(-1));
 
   useFrame(() => {
     const now = performance.now();
     const halfW = size.width * 0.5;
     const halfH = size.height * 0.5;
-    for (let i = 0; i < WORD_POOL_SIZE; i++) {
+    for (let i = 0; i < words.slots.length; i++) {
       const mesh = refs.current[i];
       if (!mesh) continue;
-      const slot = wordPool[i]!;
+      const slot = words.slots[i]!;
       if (!slot.active) {
         mesh.visible = false;
         continue;
       }
-      const age = (now - slot.start) / 1000;
-      if (age >= WORD_LIFE) {
-        slot.active = false;
-        mesh.visible = false;
+      const age = words.age(slot, now);
+      if (!slot.active) {
+        mesh.visible = false; // outlived words.life, retired by age()
         continue;
       }
       if (gens.current[i] !== slot.gen) {
         gens.current[i] = slot.gen;
-        mesh.text = slot.word;
-        mesh.color = slot.color;
+        mesh.text = slot.data.word;
+        mesh.color = slot.data.color;
         mesh.sync();
       }
       ndc.copy(slot.pos).project(mainCamera);
@@ -54,10 +53,7 @@ function WordSprites({ mainCamera }: { mainCamera: Camera }) {
         mesh.visible = false; // behind the camera / out of depth range
         continue;
       }
-      const sAge = stepTime(age, 12);
-      const inP = clamp01(sAge / 0.14);
-      const outP = clamp01((WORD_LIFE - sAge) / 0.18);
-      const scale = inP * (1 + 0.4 * Math.sin(inP * Math.PI)) * outP;
+      const scale = popScale(age, words.life);
       if (scale <= 0.001) {
         mesh.visible = false;
         continue;
@@ -65,13 +61,13 @@ function WordSprites({ mainCamera }: { mainCamera: Camera }) {
       mesh.visible = true;
       mesh.position.set(ndc.x * halfW, ndc.y * halfH, 0);
       mesh.scale.setScalar(scale);
-      mesh.rotation.z = (slot.seed - 0.5) * 0.5 + 0.05 * Math.sin(sAge * 18);
+      mesh.rotation.z = (slot.seed - 0.5) * 0.5 + 0.05 * Math.sin(stepTime(age, 12) * 18);
     }
   });
 
   return (
     <Suspense fallback={null}>
-      {wordPool.map((_, i) => (
+      {words.slots.map((_, i) => (
         <Text
           key={i}
           ref={(el: unknown) => {

--- a/components/PostPipeline.tsx
+++ b/components/PostPipeline.tsx
@@ -7,7 +7,7 @@ import { Color, HalfFloatType, Matrix4, Vector3, type Texture } from "three";
 import { PrintEffect } from "@/shaders/PrintEffect";
 import { TransitionEffect } from "@/shaders/TransitionEffect";
 import { colorWindow } from "@/shaders/colorWindow";
-import { evaluateTimeline, lerp, poseAt, type Pose, type Vec3 } from "@/lib/shots";
+import { evaluateTimeline, lerp, poseAt, usesSnapshot, type Pose, type Vec3 } from "@/lib/shots";
 import { ISSUES, SEGMENTS } from "@/issues/registry";
 import { useScrollStore } from "@/lib/scrollStore";
 import { fx } from "@/lib/fx";
@@ -156,10 +156,14 @@ export default function PostPipeline() {
     jitter.y = stepNoise(el, 10, 2) * boilAmp;
     print.u<number>("uStepSeed").value = stepNoise(el, 10, 3);
 
-    // transition layer
+    // transition layer -- uSmear* feed the shader's pjtPrint approximation
+    // of the print pass for displaced inputBuffer taps (PR #22 ruling 3)
     const tr = sample.transition;
     transition.u<number>("uVelocity").value = velocity;
     transition.u<number>("uSmearMono").value = c.mono;
+    transition.u<number>("uSmearHalftone").value = c.halftone;
+    transition.u<number>("uSmearScale").value = c.halftoneScale;
+    transition.u<Color>("uSmearPaper").value.copy(paper.current);
     if (tr) {
       transition.setMode(tr.mode);
       transition.u<number>("uP").value = tr.p;
@@ -173,7 +177,7 @@ export default function PostPipeline() {
         wd.x = wx;
         wd.y = wy;
       }
-      if (tr.mode === "dot-zoom" || tr.mode === "crash-through") {
+      if (usesSnapshot(tr.mode)) {
         const snap = snapshots.get(tr.fromIssue);
         transition.u<Texture | null>("uSnapshot").value = snap;
         transition.u<number>("uHasSnapshot").value = snap ? 1 : 0;
@@ -185,16 +189,14 @@ export default function PostPipeline() {
     composer.render(delta);
 
     // S2.11 -- refresh the outgoing issue's snapshot in the tail of a shot
-    // that exits through a snapshot-driven transition
+    // that exits through a snapshot-driven transition, or whenever any
+    // consumer has retained this issue's snapshot (lib/snapshots.ts)
     if (sample.segment.type === "shot" && sample.shotP > 0.85) {
+      const issue = sample.segment.shot.issue;
       const next = SEGMENTS[SEGMENTS.indexOf(sample.segment) + 1];
-      if (
-        next?.type === "gutter" &&
-        next.interIssue &&
-        (next.mode === "dot-zoom" || next.mode === "crash-through")
-      ) {
-        snapshots.capture(gl, sample.segment.shot.issue);
-      }
+      const gutterWants =
+        next?.type === "gutter" && next.interIssue && usesSnapshot(next.mode);
+      if (gutterWants || snapshots.isRetained(issue)) snapshots.capture(gl, issue);
     }
   }, 1);
 

--- a/components/SceneManager.tsx
+++ b/components/SceneManager.tsx
@@ -1,15 +1,55 @@
 "use client";
 
+import { useEffect, useRef, useState } from "react";
 import { ISSUES } from "@/issues/registry";
 import { useScrollStore } from "@/lib/scrollStore";
 
 /**
  * S2.5 -- keeps active +/- 1 issue sets mounted, the rest unmounted (R3F
  * disposes their GPU resources). Both gutter neighbors are always live.
+ *
+ * Deep jumps (deep link / scrollbar yank past the premount window): the
+ * mounted window is centered on `anchor`, which follows `active` in the same
+ * render pass for continuous scroll but on a jump lags one painted frame so
+ * JumpCover's paper fill is on screen first. The target window's initial
+ * (shader-compiling, main-thread-blocking) render then happens behind the
+ * cover instead of showing as a raw cream blank (Phase 1 gate fix).
  */
 export default function SceneManager() {
   const active = useScrollStore((s) => s.activeIssue);
-  const mounted = [active - 1, active, active + 1].filter(
+  const [anchor, setAnchor] = useState(active);
+  const jumped = Math.abs(active - anchor) > 1;
+  // continuous scroll (also reduced motion): window follows with zero lag
+  if (!jumped && active !== anchor) setAnchor(active);
+
+  const covering = useRef(false);
+
+  useEffect(() => {
+    if (jumped) {
+      // cover up (idempotent on re-jump: opacity is already 1, no strobe),
+      // give it one frame to paint, then mount the target's window at once
+      covering.current = true;
+      useScrollStore.getState().setJumpCover(active);
+      const raf = requestAnimationFrame(() => setAnchor(active));
+      return () => cancelAnimationFrame(raf);
+    }
+    if (!covering.current) return;
+    // anchor caught up (or the jump was aborted by scrolling back inside the
+    // old window). R3F's frameloop rAF precedes callbacks queued here, so the
+    // second tick below lands after the target's first blocking render --
+    // only then reveal. A new jump before then cancels this via cleanup.
+    covering.current = false;
+    let r2 = 0;
+    const r1 = requestAnimationFrame(() => {
+      r2 = requestAnimationFrame(() => useScrollStore.getState().setJumpCover(null));
+    });
+    return () => {
+      cancelAnimationFrame(r1);
+      cancelAnimationFrame(r2);
+    };
+  }, [jumped, active]);
+
+  const mounted = [anchor - 1, anchor, anchor + 1].filter(
     (i) => i >= 0 && i < ISSUES.length,
   );
   return (

--- a/components/ScrollProxy.tsx
+++ b/components/ScrollProxy.tsx
@@ -8,17 +8,23 @@ import { useScrollStore } from "@/lib/scrollStore";
 
 /**
  * S2.2 scroll model: Lenis -> one ScrollTrigger -> normalized t in the store.
- * The 1200vh spacer below is the entire scrollable document.
+ * The SPACER_VH spacer below is the entire scrollable document.
  *
  * verified 2026-07 (lenis 1.3.25 README): drive vanilla Lenis from
  * gsap.ticker with lenis.raf(time * 1000), lagSmoothing(0), and
  * lenis.on('scroll', ScrollTrigger.update); no scrollerProxy needed on
  * window, and vanilla autoRaf already defaults to false.
  */
+
+/** Total scroll length (vh). A wheel notch is fixed px, so more height = less t per notch -- primary pacing knob. */
+const SPACER_VH = 2400;
+/** Lenis wheel gain (default 1). Below 1 softens each notch a bit more -- secondary pacing knob. */
+const WHEEL_MULTIPLIER = 0.7;
+
 export default function ScrollProxy() {
   useEffect(() => {
     gsap.registerPlugin(ScrollTrigger);
-    const lenis = new Lenis();
+    const lenis = new Lenis({ wheelMultiplier: WHEEL_MULTIPLIER });
     lenis.on("scroll", ScrollTrigger.update);
     const tick = (time: number) => lenis.raf(time * 1000);
     gsap.ticker.add(tick);
@@ -57,6 +63,6 @@ export default function ScrollProxy() {
     };
   }, []);
 
-  // S0.3 -- total scroll length ~ 1200vh
-  return <div aria-hidden style={{ height: "1200vh" }} />;
+  // total scroll length (pacing ruling 2026-07-02: 2x the original ~1200vh)
+  return <div aria-hidden style={{ height: `${SPACER_VH}vh` }} />;
 }

--- a/components/ShotDirector.tsx
+++ b/components/ShotDirector.tsx
@@ -6,7 +6,7 @@ import { Color, Vector3, type PerspectiveCamera } from "three";
 import { evaluateTimeline, type TimelineSample } from "@/lib/shots";
 import { SEGMENTS, ISSUES } from "@/issues/registry";
 import { useScrollStore } from "@/lib/scrollStore";
-import { BeatRunner, makeBeats } from "@/lib/beats";
+import { allBeats, BeatRunner } from "@/lib/beats";
 
 /**
  * S2.3 -- evaluates the shot list from t and drives the camera: pose lerp
@@ -20,7 +20,7 @@ export default function ShotDirector({
 }) {
   const camera = useThree((s) => s.camera);
   const scene = useThree((s) => s.scene);
-  const beats = useMemo(() => new BeatRunner(makeBeats()), []);
+  const beats = useMemo(() => new BeatRunner(allBeats), []);
 
   const pos = useRef(new Vector3());
   const tgt = useRef(new Vector3());

--- a/issues/00-cover/Cover.tsx
+++ b/issues/00-cover/Cover.tsx
@@ -7,6 +7,7 @@ import type { Group, Mesh } from "three";
 import IssueShell from "../_IssueShell";
 import { ISSUES } from "../registry";
 import { RANGES } from "../timeline";
+import CatModel, { type CatPalette } from "@/components/CatModel";
 import { toonRamp } from "@/lib/toon";
 import { stepTime } from "@/lib/steppedClock";
 import { useScrollStore } from "@/lib/scrollStore";
@@ -35,6 +36,9 @@ const TEAL = "#2BB3A3";
 
 const BANGERS = "/fonts/Bangers-Regular.ttf";
 const COVER_END = RANGES[0]![1];
+
+// mascot identity marks shared with the Desk cat: teal collar, red tag
+const CAT_PALETTE: CatPalette = { ink: INK, paper: PAPER, collar: TEAL, tag: RED, accent: RED };
 
 // Masthead splits into a small kicker line + a big main line so long names
 // ("SAEED KOLIVAND", 14 chars) never clip or collide with the price box.
@@ -198,126 +202,10 @@ export default function Cover({ index }: { index: number }) {
             <meshToonMaterial color={INK} gradientMap={ramp} />
           </mesh>
           <group scale={1.3} rotation={[0, 0, 0.42]}>
-            {/* torso ellipse + haunch keep every limb rooted in one silhouette */}
-            <mesh scale={[1.5, 0.82, 1]}>
-              <circleGeometry args={[0.55, 40]} />
-              <meshToonMaterial color={INK} gradientMap={ramp} />
-            </mesh>
-            <mesh position={[-0.6, -0.05, 0.0005]}>
-              <circleGeometry args={[0.4, 40]} />
-              <meshToonMaterial color={INK} gradientMap={ramp} />
-            </mesh>
-
-            {/* front legs stretched at the masthead (rounded caps = paws).
-                Shoulder ends must land INSIDE the torso ellipse (rx 0.825,
-                ry 0.451) so the limbs stay rooted in the silhouette. */}
-            <mesh position={[0.88, -0.14, 0.0008]} rotation={[0, 0, -1.05]}>
-              <capsuleGeometry args={[0.08, 0.5, 4, 10]} />
-              <meshToonMaterial color={INK} gradientMap={ramp} />
-            </mesh>
-            <mesh position={[1.08, 0.06, 0.002]} rotation={[0, 0, -1.25]}>
-              <capsuleGeometry args={[0.08, 0.55, 4, 10]} />
-              <meshToonMaterial color={INK} gradientMap={ramp} />
-            </mesh>
-            {/* paper socks sit ON the capsule tips (Desk cat identity echo) */}
-            <mesh position={[1.42, 0.17, 0.004]}>
-              <circleGeometry args={[0.08, 16]} />
-              <meshToonMaterial color={PAPER} gradientMap={ramp} />
-            </mesh>
-            <mesh position={[1.17, 0.01, 0.004]}>
-              <circleGeometry args={[0.075, 16]} />
-              <meshToonMaterial color={PAPER} gradientMap={ramp} />
-            </mesh>
-
-            {/* hind legs trailing the pounce */}
-            <mesh position={[-0.68, -0.34, 0.0008]} rotation={[0, 0, -0.35]}>
-              <capsuleGeometry args={[0.085, 0.48, 4, 10]} />
-              <meshToonMaterial color={INK} gradientMap={ramp} />
-            </mesh>
-            <mesh position={[-0.86, -0.3, 0.002]} rotation={[0, 0, -0.75]}>
-              <capsuleGeometry args={[0.085, 0.55, 4, 10]} />
-              <meshToonMaterial color={INK} gradientMap={ramp} />
-            </mesh>
-
-            {/* head overlaps the torso front -- ears are 3-gon circles */}
-            <group position={[0.85, 0.36, 0.003]}>
-              <mesh>
-                <circleGeometry args={[0.37, 40]} />
-                <meshToonMaterial color={INK} gradientMap={ramp} />
-              </mesh>
-              <mesh position={[-0.17, 0.36, 0]} rotation={[0, 0, Math.PI / 2 + 0.15]}>
-                <circleGeometry args={[0.16, 3]} />
-                <meshToonMaterial color={INK} gradientMap={ramp} />
-              </mesh>
-              <mesh position={[0.17, 0.37, 0]} rotation={[0, 0, Math.PI / 2 - 0.15]}>
-                <circleGeometry args={[0.16, 3]} />
-                <meshToonMaterial color={INK} gradientMap={ramp} />
-              </mesh>
-              {/* eyes: paper almonds + ink pupils -- reads at 200px */}
-              <mesh position={[-0.13, 0.02, 0.002]} scale={[0.8, 1.15, 1]}>
-                <circleGeometry args={[0.085, 20]} />
-                <meshToonMaterial color={PAPER} gradientMap={ramp} />
-              </mesh>
-              <mesh position={[0.15, 0.04, 0.002]} scale={[0.8, 1.15, 1]}>
-                <circleGeometry args={[0.085, 20]} />
-                <meshToonMaterial color={PAPER} gradientMap={ramp} />
-              </mesh>
-              <mesh position={[-0.12, 0.01, 0.004]}>
-                <circleGeometry args={[0.035, 12]} />
-                <meshToonMaterial color={INK} gradientMap={ramp} />
-              </mesh>
-              <mesh position={[0.16, 0.03, 0.004]}>
-                <circleGeometry args={[0.035, 12]} />
-                <meshToonMaterial color={INK} gradientMap={ramp} />
-              </mesh>
-              {/* red 3-gon nose, point down */}
-              <mesh position={[0.02, -0.13, 0.002]} rotation={[0, 0, -Math.PI / 2]}>
-                <circleGeometry args={[0.055, 3]} />
-                <meshToonMaterial color={RED} gradientMap={ramp} />
-              </mesh>
-              {/* whiskers -- thin paper strokes */}
-              <mesh position={[-0.31, -0.09, 0.002]} rotation={[0, 0, 0.12]}>
-                <planeGeometry args={[0.26, 0.018]} />
-                <meshToonMaterial color={PAPER} gradientMap={ramp} />
-              </mesh>
-              <mesh position={[-0.32, -0.16, 0.002]} rotation={[0, 0, -0.06]}>
-                <planeGeometry args={[0.24, 0.018]} />
-                <meshToonMaterial color={PAPER} gradientMap={ramp} />
-              </mesh>
-              <mesh position={[0.34, -0.07, 0.002]} rotation={[0, 0, -0.12]}>
-                <planeGeometry args={[0.26, 0.018]} />
-                <meshToonMaterial color={PAPER} gradientMap={ramp} />
-              </mesh>
-              <mesh position={[0.35, -0.14, 0.002]} rotation={[0, 0, 0.06]}>
-                <planeGeometry args={[0.24, 0.018]} />
-                <meshToonMaterial color={PAPER} gradientMap={ramp} />
-              </mesh>
-            </group>
-
-            {/* teal collar band across the neck + red tag */}
-            <mesh position={[0.6, 0.05, 0.005]} rotation={[0, 0, -1.15]}>
-              <planeGeometry args={[0.46, 0.1]} />
-              <meshToonMaterial color={TEAL} gradientMap={ramp} />
-            </mesh>
-            <mesh position={[0.68, -0.1, 0.006]}>
-              <circleGeometry args={[0.06, 12]} />
-              <meshToonMaterial color={RED} gradientMap={ramp} />
-            </mesh>
-
-            {/* tail -- torus arc pivoting at its base, flicked on stepped
-                time. The arc's base end sits AT the group origin, so the
-                pivot must be INSIDE the haunch circle (center -0.6,-0.05
-                r 0.4) or the flick reads as a detached floating arc. */}
-            <group ref={tail} position={[-0.9, 0.15, 0.001]}>
-              <mesh position={[-0.42, 0, 0]}>
-                <torusGeometry args={[0.42, 0.07, 8, 24, 2.05]} />
-                <meshToonMaterial color={INK} gradientMap={ramp} />
-              </mesh>
-              <mesh position={[-0.614, 0.373, 0.002]}>
-                <circleGeometry args={[0.075, 12]} />
-                <meshToonMaterial color={RED} gradientMap={ramp} />
-              </mesh>
-            </group>
+            {/* shared mascot (components/CatModel): flat-print pounce build;
+                tail rig ref is flicked on stepped time in the useFrame above,
+                its pivot sits INSIDE the haunch (Phase 1 invariant) */}
+            <CatModel mode="flat" pose="leaping" palette={CAT_PALETTE} rig={{ tail }} />
 
             {/* speed dashes trailing the pounce (technique vocabulary, S1) */}
             <mesh position={[-1.8, -0.55, 0.001]}>

--- a/issues/01-noir/shots.md
+++ b/issues/01-noir/shots.md
@@ -5,9 +5,9 @@ Shares apply to the span left after gutters (see shots.ts `seg`).
 
 | # | kind | lens | share of issue | framing |
 |---|---|---|---|---|
-| 1 | hold | 24mm | 0.30 | low dutch from street; window upper-third; FG railing, MG rain, BG facade |
-| 2 | whip | 28mm | 0.15 | vertical whip up the facade; speed lines |
-| 3 | dolly | 50mm | 0.35 | slow push to window; cat silhouette enters frame-left on rooftop FG |
+| 1 | hold | 24mm | 0.35 | low dutch from street; window upper-third; FG railing, MG rain, BG facade |
+| 2 | whip | 28mm | 0.23 | vertical whip up the facade; speed lines |
+| 3 | dolly | 50mm | 0.22 | slow push to window; cat silhouette enters frame-left on rooftop FG |
 | 4 | crash | 85->35mm | 0.20 | crash to window; cat leaps frame-right at p~0.8 -- motivated cut |
 
 Notes
@@ -23,3 +23,7 @@ Notes
   3 parapet+cat/rain/window; 4 cat/window/facade wall.
 - Lettering.tsx maps the 3 noir captions onto shots 1-3 automatically.
 - Screen direction: cat exits frame-right; Issue 2 opens on the landing.
+- Shares rebalanced 2026-07-02 (live feedback): wide->close travel was too
+  compressed, so hold/whip grew (0.30/0.15 -> 0.35/0.23) at the dolly's
+  expense (0.35 -> 0.22). Shots 1-3 still sum to 0.80, so shot 4's t-range
+  (0.0962-0.1080) and its NDC-verified leap framing are unchanged.

--- a/issues/01-noir/shots.ts
+++ b/issues/01-noir/shots.ts
@@ -3,9 +3,13 @@ import { issueCenter, RANGES } from "../timeline";
 
 /**
  * Issue 1 -- NOIR authored shot list (S0.8 canonical table, see shots.md):
- * hold 24mm 0.30 / whip 28mm 0.15 / dolly 50mm 0.35 / crash 85->35mm 0.20,
+ * hold 24mm 0.35 / whip 28mm 0.23 / dolly 50mm 0.22 / crash 85->35mm 0.20,
  * chained inside RANGES[1] with three intra-issue whip gutters. Everything
  * here is pure data; Lettering.tsx maps the 3 noir captions onto shots 1-3.
+ * Rebalanced 2026-07-02 (live feedback): the wide->close travel (hold dwell
+ * plus whip arrival) was too compressed; hold+whip grew at the dolly's
+ * expense. First three shares still sum to 0.80, so shot 4's t-range is
+ * bit-identical to the gate-verified leap framing (k-window is in-shot p).
  */
 
 /** vertical fov in degrees for a full-frame lens: 2*atan(12/mm) */
@@ -17,7 +21,7 @@ const easeInCubic: EaseFn = (x) => x * x * x;
 const [S, E] = RANGES[1]!;
 /** intra-issue whip gutters carved from the range (deadband-safe width) */
 const GUTTER = 0.003;
-const SHARES = [0.3, 0.15, 0.35, 0.2];
+const SHARES = [0.35, 0.23, 0.22, 0.2];
 const SPAN = E - S - GUTTER * (SHARES.length - 1);
 
 const seg = (i: number): [number, number] => {

--- a/issues/02-desk/Desk.tsx
+++ b/issues/02-desk/Desk.tsx
@@ -3,7 +3,8 @@
 import { useLayoutEffect, useRef } from "react";
 import { useFrame } from "@react-three/fiber";
 import { PerspectiveCamera, RenderTexture } from "@react-three/drei";
-import { BackSide, Color, Matrix4, Vector3, type Group, type InstancedMesh, type Mesh } from "three";
+import { Color, Matrix4, Vector3, type Group, type InstancedMesh, type Mesh } from "three";
+import CatModel, { type CatPalette } from "@/components/CatModel";
 import { toonRamp } from "@/lib/toon";
 import { stepTime } from "@/lib/steppedClock";
 import { useScrollStore } from "@/lib/scrollStore";
@@ -30,6 +31,9 @@ const WOOD = "#D9A967";
 
 const CENTER = issueCenter(2);
 const CX = CENTER[0];
+
+// mascot identity marks shared with the Cover cat: teal collar, red tag
+const CAT_PALETTE: CatPalette = { ink: INK, paper: PAPER, collar: TEAL, tag: RED, accent: ORANGE };
 
 // -- shared scratch (zero per-frame allocation) ------------------------------
 const MAT = new Matrix4();
@@ -217,7 +221,6 @@ function DeskCat({ say = false }: { say?: boolean }) {
   const paw = useRef<Group>(null);
   const lines = useRef<Group>(null);
   const lastT = useRef<number | null>(null);
-  const ramp = toonRamp();
 
   useFrame(({ clock }) => {
     const g = grp.current;
@@ -292,104 +295,9 @@ function DeskCat({ say = false }: { say?: boolean }) {
 
   return (
     <group ref={grp}>
-      {/* body + paper rim outline (inverted hull) so ink reads against the
-          ink monitor bezel and dark screen, not just the wood */}
-      <mesh position={[0, 0.3, 0]}>
-        <boxGeometry args={[0.95, 0.5, 0.48]} />
-        <meshToonMaterial color={INK} gradientMap={ramp} />
-      </mesh>
-      <mesh position={[0, 0.3, 0]}>
-        <boxGeometry args={[1.01, 0.56, 0.54]} />
-        <meshBasicMaterial color={PAPER} side={BackSide} />
-      </mesh>
-      {/* chest patch */}
-      <mesh position={[0.44, 0.26, 0]}>
-        <boxGeometry args={[0.08, 0.26, 0.2]} />
-        <meshToonMaterial color={PAPER} gradientMap={ramp} />
-      </mesh>
-      {/* collar + tag */}
-      <mesh position={[0.42, 0.5, 0]}>
-        <boxGeometry args={[0.12, 0.07, 0.4]} />
-        <meshToonMaterial color={TEAL} gradientMap={ramp} />
-      </mesh>
-      <mesh position={[0.48, 0.43, 0]}>
-        <boxGeometry args={[0.05, 0.08, 0.08]} />
-        <meshToonMaterial color={RED} gradientMap={ramp} />
-      </mesh>
-      <group ref={head} position={[0.5, 0.62, 0]}>
-        <mesh>
-          <boxGeometry args={[0.44, 0.42, 0.42]} />
-          <meshToonMaterial color={INK} gradientMap={ramp} />
-        </mesh>
-        <mesh>
-          <boxGeometry args={[0.5, 0.48, 0.48]} />
-          <meshBasicMaterial color={PAPER} side={BackSide} />
-        </mesh>
-        {/* ears + orange inner ears */}
-        <mesh position={[0.08, 0.28, 0.12]} rotation={[0, 0, 0.25]}>
-          <coneGeometry args={[0.09, 0.22, 4]} />
-          <meshToonMaterial color={INK} gradientMap={ramp} />
-        </mesh>
-        <mesh position={[0.08, 0.28, -0.12]} rotation={[0, 0, -0.25]}>
-          <coneGeometry args={[0.09, 0.22, 4]} />
-          <meshToonMaterial color={INK} gradientMap={ramp} />
-        </mesh>
-        <mesh position={[0.1, 0.27, 0.12]} rotation={[0, 0, 0.25]}>
-          <coneGeometry args={[0.05, 0.14, 4]} />
-          <meshBasicMaterial color={ORANGE} />
-        </mesh>
-        <mesh position={[0.1, 0.27, -0.12]} rotation={[0, 0, -0.25]}>
-          <coneGeometry args={[0.05, 0.14, 4]} />
-          <meshBasicMaterial color={ORANGE} />
-        </mesh>
-        {/* eyes: flat orange + ink pupils (comic cat stare) */}
-        <mesh position={[0.225, 0.06, 0.11]}>
-          <boxGeometry args={[0.035, 0.11, 0.1]} />
-          <meshBasicMaterial color={ORANGE} />
-        </mesh>
-        <mesh position={[0.225, 0.06, -0.11]}>
-          <boxGeometry args={[0.035, 0.11, 0.1]} />
-          <meshBasicMaterial color={ORANGE} />
-        </mesh>
-        <mesh position={[0.235, 0.04, 0.11]}>
-          <boxGeometry args={[0.03, 0.06, 0.035]} />
-          <meshBasicMaterial color={INK} />
-        </mesh>
-        <mesh position={[0.235, 0.04, -0.11]}>
-          <boxGeometry args={[0.03, 0.06, 0.035]} />
-          <meshBasicMaterial color={INK} />
-        </mesh>
-        {/* paper muzzle + red nose */}
-        <mesh position={[0.225, -0.12, 0]}>
-          <boxGeometry args={[0.05, 0.13, 0.15]} />
-          <meshToonMaterial color={PAPER} gradientMap={ramp} />
-        </mesh>
-        <mesh position={[0.245, -0.05, 0]}>
-          <boxGeometry args={[0.03, 0.04, 0.05]} />
-          <meshBasicMaterial color={RED} />
-        </mesh>
-      </group>
-      <group ref={paw} position={[0.5, 0.42, 0.16]}>
-        <mesh position={[0, -0.18, 0]}>
-          <cylinderGeometry args={[0.055, 0.06, 0.36, 8]} />
-          <meshToonMaterial color={INK} gradientMap={ramp} />
-        </mesh>
-        {/* paper sock on the batting paw */}
-        <mesh position={[0, -0.33, 0]}>
-          <cylinderGeometry args={[0.06, 0.065, 0.1, 8]} />
-          <meshToonMaterial color={PAPER} gradientMap={ramp} />
-        </mesh>
-      </group>
-      <group ref={tail} position={[-0.48, 0.4, 0]}>
-        <mesh position={[-0.18, 0.18, 0]} rotation={[0, 0, 0.9]}>
-          <cylinderGeometry args={[0.05, 0.07, 0.55, 8]} />
-          <meshToonMaterial color={INK} gradientMap={ramp} />
-        </mesh>
-        <mesh position={[-0.37, 0.34, 0]} rotation={[0, 0, 0.9]}>
-          <cylinderGeometry args={[0.042, 0.05, 0.16, 8]} />
-          <meshToonMaterial color={ORANGE} gradientMap={ramp} />
-        </mesh>
-      </group>
+      {/* shared mascot (components/CatModel): lit-toon build, neutral perch;
+          head/paw/tail are driven per frame through the rig refs above */}
+      <CatModel mode="toon" pose="sitting" palette={CAT_PALETTE} rig={{ head, paw, tail }} />
       {/* bat motion lines: speed-line fan at the strike arc, scale = f(p4) */}
       <group ref={lines} position={[1.32, 0.95, 0.2]} scale={0.0001}>
         <mesh position={[0, 0.12, 0]} rotation={[0, 0, 0.5]}>

--- a/issues/registry.ts
+++ b/issues/registry.ts
@@ -28,8 +28,23 @@ export interface IssueEntry {
   outTransition: TransitionKind;
   recipe: PrintRecipe;
   accents: string[];
+  /** this issue's shot list, in timeline order (SHOTS below is derived from these) */
+  shots: Shot[];
   /** scene set rendered by SceneManager (entries 4-11 stay on the placeholder) */
   component: IssueComponent;
+}
+
+/**
+ * Phase 2 gate: a new issue = ONE component file (exporting its component +
+ * printRecipe() + shot list + optional registerJawDrop at module scope) +
+ * ONE row here. Omitted opts fall back to the S0.4 tables / placeholder
+ * shots -- nothing else in the engine changes.
+ */
+interface RowOpts {
+  /** the issue's full look -- one printRecipe() object (lib/recipes.ts) */
+  recipe?: PrintRecipe;
+  shots?: Shot[];
+  accents?: string[];
 }
 
 const row = (
@@ -39,23 +54,25 @@ const row = (
   intensity: number,
   outTransition: TransitionKind,
   component: IssueComponent,
+  opts: RowOpts = {},
 ): IssueEntry => ({
   id,
   title,
   range: [RANGES[index]![0], RANGES[index]![1]],
   intensity,
   outTransition,
-  recipe: RECIPES[index]!,
-  accents: ACCENTS[index]!,
+  recipe: opts.recipe ?? RECIPES[index]!,
+  accents: opts.accents ?? ACCENTS[index]!,
+  shots: opts.shots ?? placeholderShots(id, index),
   component,
 });
 
 /** S0.3 locked timeline -- ranges + gutters chain exactly to 1.000. Do not re-balance. */
 export const ISSUES: IssueEntry[] = [
-  row("cover", "PANEL JUMP", 0, 1, "crash-through", Cover),
-  row("noir", "ISSUE 1 - NOIR", 1, 2, "title-drop", Noir),
-  row("desk", "ISSUE 2 - DESK", 2, 2, "dot-zoom", Desk),
-  row("neon", "ISSUE 3 - NEON INK", 3, 5, "panel-wipe", Neon),
+  row("cover", "PANEL JUMP", 0, 1, "crash-through", Cover, { shots: COVER_SHOTS }),
+  row("noir", "ISSUE 1 - NOIR", 1, 2, "title-drop", Noir, { shots: NOIR_SHOTS }),
+  row("desk", "ISSUE 2 - DESK", 2, 2, "dot-zoom", Desk, { shots: DESK_SHOTS }),
+  row("neon", "ISSUE 3 - NEON INK", 3, 5, "panel-wipe", Neon, { shots: NEON_SHOTS }),
   row("origin", "ISSUE 4 - ORIGIN PAGE", 4, 1, "panel-portal", PlaceholderIssue),
   row("press", "ISSUE 5 - THE PRESS", 5, 3, "stamp", PlaceholderIssue),
   row("newsprint", "ISSUE 6 - NEWSPRINT", 6, 3, "paper-tear", PlaceholderIssue),
@@ -66,14 +83,8 @@ export const ISSUES: IssueEntry[] = [
   row("terminal", "ISSUE 11 - LETTERS PAGE", 11, 1, "cut", PlaceholderIssue),
 ];
 
-// Entries 0-3 own their shot lists (issues/XX-*/shots.ts); 4-11 stay placeholder.
-export const SHOTS: Shot[] = [
-  ...COVER_SHOTS,
-  ...NOIR_SHOTS,
-  ...DESK_SHOTS,
-  ...NEON_SHOTS,
-  ...ISSUES.slice(4).flatMap((issue, i) => placeholderShots(issue.id, i + 4)),
-];
+/** Flat shot list in timeline order, derived from the rows above. */
+export const SHOTS: Shot[] = ISSUES.flatMap((issue) => issue.shots);
 
 export const SEGMENTS: Segment[] = compileSegments(
   SHOTS,

--- a/lib/beats.ts
+++ b/lib/beats.ts
@@ -17,28 +17,26 @@ export interface Beat {
   fire: () => void;
 }
 
-interface BeatState {
-  armed: boolean;
-}
-
 export class BeatRunner {
-  private states = new Map<string, BeatState>();
+  private states = new Map<string, { armed: boolean }>();
   private lastT: number | null = null;
 
-  constructor(private beats: Beat[]) {
-    for (const b of beats) this.states.set(b.id, { armed: true });
-  }
+  /** `beats` is a provider so late registerJawDrop() calls are picked up. */
+  constructor(private beats: () => readonly Beat[]) {}
 
   update(t: number, reducedMotion: boolean) {
     const last = this.lastT;
     this.lastT = t;
-    if (last === null) {
-      // First sample (page may load mid-timeline): disarm anything already passed.
-      for (const b of this.beats) this.states.get(b.id)!.armed = t < b.trigger;
-      return;
-    }
-    for (const b of this.beats) {
-      const st = this.states.get(b.id)!;
+    for (const b of this.beats()) {
+      let st = this.states.get(b.id);
+      if (!st) {
+        // first sighting (page may load mid-timeline; issues may register
+        // their jaw-drop after construction): arm only if not already passed
+        st = { armed: t < b.trigger };
+        this.states.set(b.id, st);
+        continue;
+      }
+      if (last === null) continue;
       if (st.armed && last < b.trigger && t >= b.trigger) {
         st.armed = false;
         if (!reducedMotion) b.fire();
@@ -49,55 +47,94 @@ export class BeatRunner {
   }
 }
 
+/**
+ * S5b jaw-drop helper (Phase 2/3 authoring surface) -- every issue registers
+ * its one designed jaw-drop declaratively; trigger crossing, hysteresis
+ * re-arm and the flash budget are enforced HERE, never per issue. The
+ * scroll-driven part of a jaw-drop stays pure f(t) inside the issue
+ * (scrub-safe); only authored-time motion goes through `animate`.
+ *
+ *   // in the issue's shots.ts or component module scope:
+ *   registerJawDrop({ id: "press-stamp", t: PRESS_STAMP_T, flash: 1,
+ *     animate: () => { myTl?.kill(); myTl = gsap.timeline()... } });
+ */
+export interface JawDropSpec {
+  id: string;
+  /** global t that fires the drop */
+  t: number;
+  /**
+   * impact-frame intensity 0..1: the flash, granted through the central
+   * requestFlash() budget (S2.13). Plays the standard double pop + sub-thump
+   * on fx.impact. Omit (or 0) for quiet-valley jaw-drops (Issues 4, 9).
+   */
+  flash?: number;
+  /**
+   * authored-time hook (own GSAP timeline, 0.4-1.5s per S2.14). Runs even
+   * when the flash is denied; kill your previous timeline before rebuilding
+   * so hysteresis re-fires stay clean.
+   */
+  animate?: () => void;
+  /** re-arm distance below t, default 0.006 */
+  hysteresis?: number;
+}
+
+const jawDrops = new Map<string, Beat>();
+let beatList: Beat[] | null = null;
+
+/** flash-budget-guarded impact double pop + sub-thump, shared by all drops */
+function impactPop(intensity: number) {
+  if (!requestFlash()) return;
+  gsap
+    .timeline()
+    .to(fx, { impact: intensity, duration: 0.05, ease: "none" })
+    .to(fx, { impact: 0, duration: 0.12, ease: "power2.out" })
+    .to(fx, { impact: 0.7 * intensity, duration: 0.04, ease: "none" }, "+=0.06") // sub-thump
+    .to(fx, { impact: 0, duration: 0.18, ease: "power2.out" });
+}
+
+/** Idempotent by id (HMR/StrictMode safe): re-registering replaces the drop. */
+export function registerJawDrop(spec: JawDropSpec): void {
+  jawDrops.set(spec.id, {
+    id: spec.id,
+    trigger: spec.t,
+    hysteresis: spec.hysteresis ?? 0.006,
+    fire: () => {
+      spec.animate?.();
+      if (spec.flash) impactPop(spec.flash);
+    },
+  });
+  beatList = null;
+}
+
+/** Live beat list for BeatRunner -- cached, rebuilt on registration (no per-frame alloc). */
+export function allBeats(): readonly Beat[] {
+  return (beatList ??= [...jawDrops.values()]);
+}
+
 /** Issue 1 -> Issue 2 gutter entry (noir range end, S0.3): the title drop. */
 const TITLE_DROP_T = RANGES[1]![1];
 
 let titleTl: gsap.core.Timeline | null = null;
 
-/**
- * S5b.3 title drop -- the name card slams in as a full-frame comic title at
- * authored speed (the card itself lives in components/Lettering.tsx and reads
- * fx.title), with a flash-budget-guarded impact double pop as the sub-thump.
- * Re-fires cleanly after hysteresis re-arm: the previous timeline is killed.
- */
-export function makeBeats(): Beat[] {
-  return [
-    {
-      id: "title-drop",
-      trigger: TITLE_DROP_T,
-      hysteresis: 0.006,
-      fire: () => {
-        titleTl?.kill();
-        titleTl = gsap
-          .timeline()
-          .set(fx, { title: 0 })
-          .to(fx, { title: 1, duration: 0.22, ease: "back.out(2.5)" })
-          .to(fx, { title: 0, duration: 0.16, ease: "power3.in" }, "+=0.72");
-        if (!requestFlash()) return; // card still plays; only the flashes are budgeted
-        gsap
-          .timeline()
-          .to(fx, { impact: 1, duration: 0.05, ease: "none" })
-          .to(fx, { impact: 0, duration: 0.12, ease: "power2.out" })
-          .to(fx, { impact: 0.7, duration: 0.04, ease: "none" }, "+=0.06") // sub-thump
-          .to(fx, { impact: 0, duration: 0.18, ease: "power2.out" });
-      },
-    },
-    {
-      // Issue 3 jaw-drop: the power-on cascade sub-thump. The cascade itself
-      // is pure f(t) in issues/03-neon (scrub-safe); only this authored-time
-      // impact double pop rides the beat engine. Same trigger t as the wave.
-      id: "neon-cascade",
-      trigger: NEON_CASCADE_T,
-      hysteresis: 0.006,
-      fire: () => {
-        if (!requestFlash()) return; // flash budget (S2.13); wave plays regardless
-        gsap
-          .timeline()
-          .to(fx, { impact: 1, duration: 0.05, ease: "none" })
-          .to(fx, { impact: 0, duration: 0.12, ease: "power2.out" })
-          .to(fx, { impact: 0.7, duration: 0.04, ease: "none" }, "+=0.06") // sub-thump
-          .to(fx, { impact: 0, duration: 0.18, ease: "power2.out" });
-      },
-    },
-  ];
-}
+// S5b.3 title drop -- the name card slams in as a full-frame comic title at
+// authored speed (the card itself lives in components/Lettering.tsx and reads
+// fx.title); the budgeted impact pop is the sub-thump. Re-fires cleanly after
+// hysteresis re-arm: the previous timeline is killed.
+registerJawDrop({
+  id: "title-drop",
+  t: TITLE_DROP_T,
+  flash: 1,
+  animate: () => {
+    titleTl?.kill();
+    titleTl = gsap
+      .timeline()
+      .set(fx, { title: 0 })
+      .to(fx, { title: 1, duration: 0.22, ease: "back.out(2.5)" })
+      .to(fx, { title: 0, duration: 0.16, ease: "power3.in" }, "+=0.72");
+  },
+});
+
+// Issue 3 jaw-drop: the power-on cascade sub-thump. The cascade itself is
+// pure f(t) in issues/03-neon (scrub-safe); only this budgeted impact pop
+// rides the beat engine. Same trigger t as the wave.
+registerJawDrop({ id: "neon-cascade", t: NEON_CASCADE_T, flash: 1 });

--- a/lib/onomatopoeia.ts
+++ b/lib/onomatopoeia.ts
@@ -1,41 +1,21 @@
-import { Vector3 } from "three";
+import type { Vector3 } from "three";
+import { PopPool } from "./pops";
 
 /**
- * Pooled comic onomatopoeia (S5b) -- fixed-size slot pool, zero per-frame
- * allocation. Scenes call sayWord() from useFrame/event code with a word
- * list from content.lettering.onomatopoeia; components/Onomatopoeia.tsx
- * renders the pool as crisp Hud lettering above the post pipeline (S2.16).
+ * Pooled comic onomatopoeia (S5b) -- a PopPool of word sprites. Scenes call
+ * sayWord() from useFrame/event code with a word list from
+ * content.lettering.onomatopoeia; components/Onomatopoeia.tsx renders the
+ * pool as crisp Hud lettering above the post pipeline (S2.16).
  */
-
-export const WORD_POOL_SIZE = 12;
-/** authored pop envelope length, seconds */
-export const WORD_LIFE = 0.9;
-
-export interface WordSlot {
-  active: boolean;
-  /** bumped on (re)spawn so the renderer knows to re-sync glyphs */
-  gen: number;
+export interface WordData {
   word: string;
   color: string;
-  /** world-space anchor, projected to screen each frame */
-  pos: Vector3;
-  /** performance.now() at spawn (ms) */
-  start: number;
-  /** 0..1, drives word pick + rotation jitter */
-  seed: number;
 }
 
-export const wordPool: WordSlot[] = Array.from({ length: WORD_POOL_SIZE }, () => ({
-  active: false,
-  gen: 0,
+export const words = new PopPool<WordData>(12, 0.9, () => ({
   word: "",
   color: "#FFFFFF",
-  pos: new Vector3(),
-  start: 0,
-  seed: 0,
 }));
-
-let cursor = 0;
 
 /**
  * Fire a comic word at a world position. Round-robin over the pool -- the
@@ -48,15 +28,7 @@ export function sayWord(
   color = "#FFFFFF",
 ): void {
   if (list.length === 0) return;
-  const slot = wordPool[cursor]!;
-  cursor = (cursor + 1) % WORD_POOL_SIZE;
-  const s = seed - Math.floor(seed); // wrap into [0,1)
-  slot.word = list[Math.floor(s * list.length) % list.length]!;
-  slot.color = color;
-  if (worldPos instanceof Vector3) slot.pos.copy(worldPos);
-  else slot.pos.set(worldPos[0], worldPos[1], worldPos[2]);
-  slot.seed = s;
-  slot.start = performance.now();
-  slot.gen++;
-  slot.active = true;
+  const slot = words.spawn(worldPos, seed);
+  slot.data.word = list[Math.floor(slot.seed * list.length) % list.length]!;
+  slot.data.color = color;
 }

--- a/lib/pops.ts
+++ b/lib/pops.ts
@@ -1,0 +1,96 @@
+import { Vector3 } from "three";
+import { clamp01 } from "./shots";
+import { stepTime } from "./steppedClock";
+
+/**
+ * Generic fixed-size pop pool (Phase 2 extraction of the S5b onomatopoeia
+ * pool) -- zero per-frame and zero per-spawn allocation. One pool per effect
+ * kind: onomatopoeia words today (lib/onomatopoeia.ts), Issue 8 3D speech
+ * balloons and Issue 11 floating panels later.
+ *
+ * Contract: spawners call pool.spawn() from useFrame/event code and mutate
+ * the returned slot's `data` in place; renderers iterate `pool.slots`, skip
+ * inactive ones, and re-sync expensive state (glyphs, textures) only when
+ * `gen` changes. Readable lettering renderers stay on a post-exempt layer
+ * (DOM overlay or Hud renderPriority 2) per S2.16 -- the pool itself is
+ * layer-agnostic.
+ */
+export interface PopSlot<T> {
+  active: boolean;
+  /** bumped on (re)spawn so renderers know to re-sync expensive state */
+  gen: number;
+  /** world-space anchor */
+  pos: Vector3;
+  /** performance.now() at spawn (ms) */
+  start: number;
+  /** 0..1 jitter/pick seed */
+  seed: number;
+  /** payload -- allocated once at pool construction, mutated on spawn */
+  data: T;
+}
+
+export class PopPool<T> {
+  readonly slots: PopSlot<T>[];
+  private cursor = 0;
+
+  constructor(
+    size: number,
+    /** authored pop envelope length, seconds */
+    readonly life: number,
+    makeData: () => T,
+  ) {
+    this.slots = Array.from({ length: size }, () => ({
+      active: false,
+      gen: 0,
+      pos: new Vector3(),
+      start: 0,
+      seed: 0,
+      data: makeData(),
+    }));
+  }
+
+  /**
+   * Recycle the round-robin oldest slot at a world position and return it so
+   * the caller can fill slot.data. Never allocates.
+   */
+  spawn(
+    worldPos: Vector3 | readonly [number, number, number],
+    seed: number = Math.random(),
+  ): PopSlot<T> {
+    const slot = this.slots[this.cursor]!;
+    this.cursor = (this.cursor + 1) % this.slots.length;
+    if (worldPos instanceof Vector3) slot.pos.copy(worldPos);
+    else slot.pos.set(worldPos[0], worldPos[1], worldPos[2]);
+    slot.seed = seed - Math.floor(seed); // wrap into [0,1)
+    slot.start = performance.now();
+    slot.gen++;
+    slot.active = true;
+    return slot;
+  }
+
+  /** Age in seconds; retires the slot once it outlives the pool's life. */
+  age(slot: PopSlot<T>, nowMs: number): number {
+    const a = (nowMs - slot.start) / 1000;
+    if (a >= this.life) slot.active = false;
+    return a;
+  }
+}
+
+/**
+ * The shared squash-and-stretch pop envelope on stepped time (S2.8): pop-in
+ * with overshoot over `attack` seconds, pop-out over `release`. Returns a
+ * scale factor; <= ~0 means the slot is invisible this frame.
+ */
+export function popScale(
+  ageSec: number,
+  life: number,
+  fps = 12,
+  attack = 0.14,
+  release = 0.18,
+  overshoot = 0.4,
+): number {
+  const a = stepTime(ageSec, fps);
+  const inP = clamp01(a / attack);
+  const outP = clamp01((life - a) / release);
+  return inP * (1 + overshoot * Math.sin(inP * Math.PI)) * outP;
+}

--- a/lib/recipes.ts
+++ b/lib/recipes.ts
@@ -1,8 +1,18 @@
 /**
  * PrintRecipe -- the per-issue knob set for the single shared post pipeline
  * (S2.6). Issues never rebuild the composer; they swap one of these and the
- * pipeline cross-fades its uniforms. All values respect S2.16: no channel
- * offsets exist anywhere in this model.
+ * pipeline cross-fades its uniforms (~0.2s). All values respect S2.16: no
+ * channel offsets exist anywhere in this model.
+ *
+ * Authoring surface (Phase 2 gate): a new issue's full look is ONE
+ * printRecipe() object. Only paper + ink are required; bg defaults to paper
+ * and every other knob to RECIPE_DEFAULTS, so a minimal recipe is one line:
+ *
+ *   printRecipe({ paper: "#F2EAD9", ink: "#201D18" })
+ *   printRecipe({ paper: "#0B0F0C", ink: "#33FF66", mono: 0.85, edge: 0.6 })
+ *
+ * Dark paper flips halftone/hatch polarity automatically inside PrintEffect
+ * (derived from paper luminance) -- no recipe field needed.
  */
 export interface PrintRecipe {
   /** page + ink hexes from the S0.4 palette table */
@@ -29,7 +39,8 @@ export interface PrintRecipe {
   hatchScale: number;
 }
 
-const base: Omit<PrintRecipe, "paper" | "ink" | "bg"> = {
+/** Defaults for every non-color knob; printRecipe() spreads these under your overrides. */
+export const RECIPE_DEFAULTS: Omit<PrintRecipe, "paper" | "ink" | "bg"> = {
   mono: 0,
   edge: 0.7,
   edgeColor: "#201D18",
@@ -43,38 +54,47 @@ const base: Omit<PrintRecipe, "paper" | "ink" | "bg"> = {
   hatchScale: 7,
 };
 
+/**
+ * Build a full PrintRecipe from paper + ink and any overrides. bg defaults
+ * to paper (sets are boxed rooms; bg only shows during cuts).
+ */
+export function printRecipe(
+  spec: Partial<PrintRecipe> & Pick<PrintRecipe, "paper" | "ink">,
+): PrintRecipe {
+  return { ...RECIPE_DEFAULTS, bg: spec.paper, ...spec };
+}
+
 /** One recipe per registry entry, S0.4 palettes. Visibly distinct per S7 Phase 0 gate. */
 export const RECIPES: PrintRecipe[] = [
   // 0 Cover -- printed cover, mid halftone
-  { ...base, paper: "#F2EAD9", ink: "#201D18", bg: "#F2EAD9", halftone: 0.45, halftoneScale: 7 },
-  // 1 Noir -- B&W hatched ink: crosshatch carries the shadow shading now,
-  // halftone drops to a whisper so dots and strokes never fight.
-  // Dark paper flips halftone/hatch polarity inside PrintEffect (derived
-  // from paper luminance): white ink lands on lit forms, deep shadow stays
+  printRecipe({ paper: "#F2EAD9", ink: "#201D18", halftone: 0.45, halftoneScale: 7 }),
+  // 1 Noir -- B&W hatched ink: crosshatch carries the shadow shading,
+  // halftone drops to a whisper so dots and strokes never fight. Dark-paper
+  // polarity flip: white ink lands on lit forms, deep shadow stays
   // paper-black silhouette (ruling 2026-07-02, gate fix attempt 1)
-  { ...base, paper: "#0E0E10", ink: "#F5F1E8", bg: "#0E0E10", mono: 1, edge: 0.95, edgeColor: "#F5F1E8", halftone: 0.12, halftoneScale: 4, vignette: 0.45, hatch: 1, hatchScale: 6 },
+  printRecipe({ paper: "#0E0E10", ink: "#F5F1E8", mono: 1, edge: 0.95, edgeColor: "#F5F1E8", halftone: 0.12, halftoneScale: 4, vignette: 0.45, hatch: 1, hatchScale: 6 }),
   // 2 Desk -- warm full-color halftone
-  { ...base, paper: "#F6EFE3", ink: "#1C1B1A", bg: "#F6EFE3", halftone: 0.6, halftoneScale: 8, grain: 0.08 },
+  printRecipe({ paper: "#F6EFE3", ink: "#1C1B1A", halftone: 0.6, halftoneScale: 8, grain: 0.08 }),
   // 3 Neon Ink -- flat neon on black, razor edges, barely any dots.
   // grain/paperTex lowered: 10Hz grain flicker on a max-contrast black
   // world edged toward strobe territory (S2.16 check, 2026-07-02)
-  { ...base, paper: "#060608", ink: "#EDEDF2", bg: "#060608", edge: 1, edgeColor: "#EDEDF2", halftone: 0.08, halftoneScale: 4, grain: 0.03, paperTex: 0.05, vignette: 0.4, boil: 0.7 },
+  printRecipe({ paper: "#060608", ink: "#EDEDF2", edge: 1, edgeColor: "#EDEDF2", halftone: 0.08, halftoneScale: 4, grain: 0.03, paperTex: 0.05, vignette: 0.4, boil: 0.7 }),
   // 4 Origin -- muted valley
-  { ...base, paper: "#EDE7DB", ink: "#2A2722", bg: "#EDE7DB", halftone: 0.3, edge: 0.5, boil: 0.3 },
+  printRecipe({ paper: "#EDE7DB", ink: "#2A2722", halftone: 0.3, edge: 0.5, boil: 0.3 }),
   // 5 Press -- dark factory, strong ink
-  { ...base, paper: "#23272E", ink: "#E8E4DC", bg: "#23272E", edgeColor: "#E8E4DC", edge: 0.85, halftone: 0.35, halftoneScale: 5 },
+  printRecipe({ paper: "#23272E", ink: "#E8E4DC", edgeColor: "#E8E4DC", edge: 0.85, halftone: 0.35, halftoneScale: 5 }),
   // 6 Newsprint -- heavy coarse halftone, near-mono
-  { ...base, paper: "#EAE3D2", ink: "#221F1A", bg: "#EAE3D2", mono: 0.65, halftone: 0.8, halftoneScale: 11, grain: 0.12, paperTex: 0.18 },
+  printRecipe({ paper: "#EAE3D2", ink: "#221F1A", mono: 0.65, halftone: 0.8, halftoneScale: 11, grain: 0.12, paperTex: 0.18 }),
   // 7 Screentone -- manga B&W, fine dots
-  { ...base, paper: "#101014", ink: "#E8E8E8", bg: "#101014", mono: 1, edge: 0.9, edgeColor: "#E8E8E8", halftone: 0.65, halftoneScale: 4.5 },
+  printRecipe({ paper: "#101014", ink: "#E8E8E8", mono: 1, edge: 0.9, edgeColor: "#E8E8E8", halftone: 0.65, halftoneScale: 4.5 }),
   // 8 Pop Print -- oversaturated webcomic
-  { ...base, paper: "#1B0F2E", ink: "#F4EFFF", bg: "#1B0F2E", halftone: 0.5, halftoneScale: 9, edge: 0.8, edgeColor: "#F4EFFF", boil: 0.65 },
+  printRecipe({ paper: "#1B0F2E", ink: "#F4EFFF", halftone: 0.5, halftoneScale: 9, edge: 0.8, edgeColor: "#F4EFFF", boil: 0.65 }),
   // 9 Sketchbook -- graphite on paper, soft edges
-  { ...base, paper: "#F7F2E7", ink: "#232019", bg: "#F7F2E7", mono: 0.7, edge: 0.45, edgeColor: "#5A564E", halftone: 0.12, paperTex: 0.22, boil: 0.6 },
+  printRecipe({ paper: "#F7F2E7", ink: "#232019", mono: 0.7, edge: 0.45, edgeColor: "#5A564E", halftone: 0.12, paperTex: 0.22, boil: 0.6 }),
   // 10 Spread -- cosmic near-black
-  { ...base, paper: "#05060D", ink: "#EAF2FF", bg: "#05060D", edge: 0.4, edgeColor: "#EAF2FF", halftone: 0.18, halftoneScale: 5, vignette: 0.5 },
+  printRecipe({ paper: "#05060D", ink: "#EAF2FF", edge: 0.4, edgeColor: "#EAF2FF", halftone: 0.18, halftoneScale: 5, vignette: 0.5 }),
   // 11 Terminal -- CRT green on black
-  { ...base, paper: "#0B0F0C", ink: "#33FF66", bg: "#0B0F0C", mono: 0.85, edge: 0.6, edgeColor: "#33FF66", halftone: 0.35, halftoneScale: 3.5, vignette: 0.45 },
+  printRecipe({ paper: "#0B0F0C", ink: "#33FF66", mono: 0.85, edge: 0.6, edgeColor: "#33FF66", halftone: 0.35, halftoneScale: 3.5, vignette: 0.45 }),
 ];
 
 /** Per-issue accent hexes (S0.4), used by placeholder props now, real sets later. */

--- a/lib/scrollStore.ts
+++ b/lib/scrollStore.ts
@@ -16,8 +16,11 @@ interface ScrollState {
   reducedMotion: boolean;
   audioOn: boolean;
   meowCount: number;
+  /** Issue index a deep jump is loading toward (JumpCover fill up); null when idle. */
+  jumpCover: number | null;
   setT: (t: number, velocity: number) => void;
   setActiveIssue: (i: number) => void;
+  setJumpCover: (i: number | null) => void;
   setPointer: (x: number, y: number) => void;
   setQuality: (q: Quality) => void;
   setReducedMotion: (v: boolean) => void;
@@ -34,8 +37,10 @@ export const useScrollStore = create<ScrollState>()((set) => ({
   reducedMotion: false,
   audioOn: false,
   meowCount: 0,
+  jumpCover: null,
   setT: (t, velocity) => set({ t, velocity }),
   setActiveIssue: (activeIssue) => set({ activeIssue }),
+  setJumpCover: (jumpCover) => set({ jumpCover }),
   setPointer: (pointerX, pointerY) => set({ pointerX, pointerY }),
   setQuality: (quality) => set({ quality }),
   setReducedMotion: (reducedMotion) => set({ reducedMotion }),

--- a/lib/shots.ts
+++ b/lib/shots.ts
@@ -25,25 +25,51 @@ export type TransitionKind =
   | "ink-flood"
   | "dot-match";
 
-/** What the TransitionEffect can render (Phase 1: + crash-through). */
-export type TransitionMode = "cut" | "whip" | "dot-zoom" | "crash-through";
+/** What the TransitionEffect can render (Phase 2: full S5 library). */
+export type TransitionMode =
+  | "cut"
+  | "whip"
+  | "dot-zoom"
+  | "crash-through"
+  | "panel-wipe"
+  | "paper-tear"
+  | "page-flip"
+  | "stamp"
+  | "dot-match"
+  | "ink-flood";
 
-// ponytail: unbuilt kinds map to nearest analog (S0.1), swapped for real
-// implementations in Phases 1-2 without touching the registry.
+// Phase 2: every S5 transition is native. Two kinds stay mapped by design:
+// title-drop -> whip (S5b.3: the slam is an authored-time BEAT via
+// lib/beats.ts; the gutter itself only carries the whip into Issue 2), and
+// panel-portal -> panel-wipe (a portal fly-through is scene/camera work,
+// not a post op; "panel grows to full bleed" is the nearest native analog
+// and reads correctly for the Issue 4 quiet-valley exit).
 export const TRANSITION_FALLBACK: Record<TransitionKind, TransitionMode> = {
   cut: "cut",
   whip: "whip",
   "dot-zoom": "dot-zoom",
   "crash-through": "crash-through",
   "title-drop": "whip",
-  "panel-wipe": "cut",
-  "panel-portal": "cut",
-  stamp: "cut",
-  "paper-tear": "cut",
-  "page-flip": "cut",
-  "ink-flood": "cut",
-  "dot-match": "cut",
+  "panel-wipe": "panel-wipe",
+  "panel-portal": "panel-wipe",
+  stamp: "stamp",
+  "paper-tear": "paper-tear",
+  "page-flip": "page-flip",
+  "ink-flood": "ink-flood",
+  "dot-match": "dot-match",
 };
+
+/** Modes that overlay the outgoing issue's snapshot on the incoming live frame. */
+const SNAPSHOT_MODES = new Set<TransitionMode>([
+  "dot-zoom",
+  "crash-through",
+  "panel-wipe",
+  "paper-tear",
+  "page-flip",
+  "stamp",
+  "dot-match",
+]);
+export const usesSnapshot = (mode: TransitionMode) => SNAPSHOT_MODES.has(mode);
 
 export type EaseFn = (x: number) => number;
 
@@ -101,9 +127,10 @@ export function poseAt(shot: Shot, p: number): Pose {
 
 /** Where within a gutter the camera jumps from the outgoing to the incoming shot. */
 function cutPoint(mode: TransitionMode): number {
-  // dot-zoom and crash-through film the incoming issue for the whole
-  // gutter -- the outgoing issue is only present as its snapshot overlay.
-  return mode === "dot-zoom" || mode === "crash-through" ? 0 : 0.5;
+  // snapshot modes film the incoming issue for the whole gutter -- the
+  // outgoing issue is only present as its snapshot overlay. cut, whip and
+  // ink-flood jump mid-gutter (ink-flood's full cover hides the jump).
+  return usesSnapshot(mode) ? 0 : 0.5;
 }
 
 export interface TransitionSample {

--- a/lib/snapshots.ts
+++ b/lib/snapshots.ts
@@ -2,8 +2,17 @@ import { FramebufferTexture, Vector2, type WebGLRenderer } from "three";
 
 /**
  * S2.11 snapshot pool -- frames copied off the canvas when the camera leaves
- * an issue, reused by snapshot-driven transitions (dot-zoom now; tear/flip/
- * spread later). LRU-capped; textures sized in device pixels.
+ * an issue, reused by snapshot-driven transitions (S5 library) and by issues
+ * that quote another issue's frame. LRU-capped; textures sized in device
+ * pixels. Snapshots are CPU-side framebuffer copies, NOT render targets --
+ * the S2.10 budget of 3 live RTs is untouched by this pool.
+ *
+ * Generalized requests (Phase 2): any issue/transition may `retain(issue)` a
+ * key -- retained snapshots are refreshed in that issue's exit tail by
+ * PostPipeline even when the gutter's transition doesn't use one, and are
+ * exempt from LRU eviction until `release(issue)`. Gutter transitions whose
+ * mode passes usesSnapshot() (lib/shots.ts) are served automatically with no
+ * registration.
  *
  * verified 2026-07 (three r185): copyFramebufferToTexture(texture, position,
  * level) -- texture is the FIRST argument (order flipped in r165), and it
@@ -13,7 +22,21 @@ const MAX_SNAPSHOTS = 4;
 
 class SnapshotPool {
   private map = new Map<number, FramebufferTexture>();
+  private retained = new Set<number>();
   private size = new Vector2();
+
+  /** Keep `issue`'s snapshot fresh + evict-proof (e.g. Issue 10 spread pages). */
+  retain(issue: number) {
+    this.retained.add(issue);
+  }
+
+  release(issue: number) {
+    this.retained.delete(issue);
+  }
+
+  isRetained(issue: number): boolean {
+    return this.retained.has(issue);
+  }
 
   capture(renderer: WebGLRenderer, issue: number) {
     renderer.getDrawingBufferSize(this.size);
@@ -27,10 +50,12 @@ class SnapshotPool {
       tex = new FramebufferTexture(this.size.x, this.size.y);
       this.map.set(issue, tex);
       if (this.map.size > MAX_SNAPSHOTS) {
-        const oldest = this.map.keys().next().value;
-        if (oldest !== undefined && oldest !== issue) {
+        // evict the oldest unretained key (retained ones only leave via release)
+        for (const oldest of this.map.keys()) {
+          if (oldest === issue || this.retained.has(oldest)) continue;
           this.map.get(oldest)?.dispose();
           this.map.delete(oldest);
+          break;
         }
       }
     } else {

--- a/shaders/TransitionEffect.ts
+++ b/shaders/TransitionEffect.ts
@@ -4,25 +4,33 @@ import { Color, Uniform, type Texture } from "three";
 /**
  * S5 transition layer as a final fullscreen effect, driven by scrub-safe
  * local p from the gutter evaluator. Modes: 0 none, 1 whip (directional
- * smear along the whip axis + radial speed lines), 2 dot-zoom (outgoing
- * snapshot collapsing into a registered dot screen), 3 cut (paper-color
- * page blink), 4 crash-through (cover tears radially into paper fragments
- * over a settling zoom punch -- Cover -> Issue 1). Everything is a pure
- * function of uP: scrub-deterministic both directions. Velocity speed
- * lines (S2.9) ride the same lines function outside gutters.
+ * smear + radial speed lines), 2 dot-zoom (outgoing snapshot collapsing
+ * into a registered dot screen), 3 cut (paper-color page blink),
+ * 4 crash-through (cover tears radially into paper fragments over a
+ * settling zoom punch), 5 panel-wipe (paper gutter bars sweep in, the
+ * incoming shot grows from a bordered panel to full bleed), 6 paper-tear
+ * (fibered rip left to right), 7 page-flip (whole-viewport cylindrical
+ * page curl, paper backside, incoming underneath), 8 stamp (incoming
+ * slams down: scale-squash, paper-tone impact pop, radial burst, pressed
+ * shadow ring), 9 dot-match (pose-matched iris: incoming inside one
+ * growing inked dot), 10 ink-flood (ink swallows the page at mid-gutter,
+ * hiding the camera cut, then drains). Everything is a pure function of
+ * uP: scrub-deterministic both directions.
  *
  * verified 2026-07 (postprocessing wiki Custom-Effects): sampling the
  * INPUT BUFFER at neighbor texels requires EffectAttribute.CONVOLUTION;
  * one convolution effect per EffectPass -- this is it (DECISIONS
  * 2026-07-02). inputBuffer holds the PRE-print linear frame, so smear /
- * punch taps are re-graded with uSmearMono (the cross-faded recipe mono)
- * to stay consistent with the printed frame they blend into. Canvas
+ * punch / stamp taps are re-graded with pjtPrint (mono + the registered
+ * halftone screen + paper tint from the cross-faded recipe: uSmearMono /
+ * uSmearHalftone / uSmearScale / uSmearPaper) so displaced live samples
+ * match the printed frame they settle into (PR #22 ruling 3). Canvas
  * snapshots are sRGB-encoded and NOT auto-decoded in custom shaders --
  * decode pow(rgb, 2.2) before linear-space mixing (project memory).
  *
- * S2.16: the smear is a single-layer box average (no channel offsets, no
- * ghosting) and only exists inside a whip gutter (whipK == 0 at rest);
- * the crash punch is a single-layer radial resample, zero chromatic ops.
+ * S2.16: every mode is a single-layer color op -- no channel offsets, no
+ * ghosting; page-flip's backside is flat paper (no mirrored content);
+ * stamp's impact frame is one paper-tone pop, same class as cut's blink.
  */
 const fragment = /* glsl */ `
   uniform sampler2D uSnapshot;
@@ -33,6 +41,9 @@ const fragment = /* glsl */ `
   uniform vec3 uFallback;
   uniform vec2 uWhipDir;
   uniform float uSmearMono;
+  uniform float uSmearHalftone;
+  uniform float uSmearScale;
+  uniform vec3 uSmearPaper;
 
   float pjtLuma(const in vec3 c) { return dot(c, vec3(0.299, 0.587, 0.114)); }
 
@@ -40,8 +51,46 @@ const fragment = /* glsl */ `
     return fract(sin(dot(p, vec2(269.5, 183.3))) * 43758.5453);
   }
 
+  float pjtNoise(const in vec2 p) {
+    vec2 i = floor(p);
+    vec2 f = fract(p);
+    vec2 u = f * f * (3.0 - 2.0 * f);
+    return mix(
+      mix(pjtHash(i), pjtHash(i + vec2(1.0, 0.0)), u.x),
+      mix(pjtHash(i + vec2(0.0, 1.0)), pjtHash(i + vec2(1.0, 1.0)), u.x),
+      u.y
+    );
+  }
+
   vec3 pjtGrade(const in vec3 c) {
     return mix(c, vec3(pjtLuma(c)), uSmearMono);
+  }
+
+  // approximate print grade for displaced inputBuffer taps: mono + the
+  // same 45deg screen-registered dot screen as PrintEffect (dots anchored
+  // to SCREEN uv so they never swim with the resample), dark-paper
+  // polarity derived from paper luminance exactly like the print pass.
+  vec3 pjtPrint(const in vec3 c, const in vec2 screenUv) {
+    vec3 g = pjtGrade(c);
+    if (uSmearHalftone < 0.005) return g;
+    float lum = pjtLuma(g);
+    float flip = 1.0 - smoothstep(0.05, 0.25, pjtLuma(uSmearPaper));
+    float shade = mix(lum, 1.0 - lum, flip);
+    mat2 R = mat2(0.70710678, -0.70710678, 0.70710678, 0.70710678);
+    vec2 q = (R * (screenUv * resolution)) / max(uSmearScale, 1.0);
+    vec2 f = fract(q) - 0.5;
+    float r = (1.0 - shade) * 0.75;
+    float d = length(f);
+    float aa = fwidth(d) + 1e-4;
+    float dotMask = 1.0 - smoothstep(r - aa, r + aa, d);
+    return mix(g, mix(uSmearPaper, g * 0.88, dotMask), uSmearHalftone);
+  }
+
+  // outgoing snapshot (sRGB canvas copy -> linear), flat paper fallback
+  vec3 pjtSnap(const in vec2 suv) {
+    return uHasSnapshot > 0.5
+      ? pow(texture2D(uSnapshot, clamp(suv, 0.001, 0.999)).rgb, vec3(2.2))
+      : uFallback;
   }
 
   float pjtSpeedLines(const in vec2 uv, const in float k) {
@@ -93,10 +142,7 @@ const fragment = /* glsl */ `
       float d = length(f);
       float aa = fwidth(d) + 1e-4;
       float cover = 1.0 - smoothstep(r - aa, r + aa, d);
-      vec3 snap = uHasSnapshot > 0.5
-        ? pow(texture2D(uSnapshot, uv).rgb, vec3(2.2))
-        : uFallback;
-      col = mix(col, snap, cover);
+      col = mix(col, pjtSnap(uv), cover);
     } else if (uMode == 3.0) {
       // cut: quick paper-tone page blink centered on the pose jump
       float q = 1.0 - abs(2.0 * p - 1.0);
@@ -106,7 +152,9 @@ const fragment = /* glsl */ `
       // while the printed cover bursts center-out into paper fragments.
       float punch = smoothstep(0.12, 0.5, p) * (1.0 - smoothstep(0.5, 0.92, p));
       vec2 zuv = 0.5 + (uv - 0.5) / (1.0 + punch * 0.35);
-      vec3 live = pjtGrade(texture2D(inputBuffer, zuv).rgb);
+      // pjtPrint re-grades the pre-print tap so the punch frames match the
+      // printed frame they settle into (PR #22 ruling 3 polish, zero RTs)
+      vec3 live = pjtPrint(texture2D(inputBuffer, zuv).rgb, uv);
       col = mix(col, live, clamp(punch * 2.5, 0.0, 1.0));
 
       // polar fragment grid: each cell departs when p passes its threshold
@@ -123,22 +171,152 @@ const fragment = /* glsl */ `
         // carrying their patch of the printed cover with them
         vec2 snapUv = 0.5 + (uv - 0.5) / (1.0 + f * (0.6 + h * 0.8));
         snapUv += vec2(-d.y, d.x) * (h - 0.5) * f * 0.3;
-        vec3 snap = uHasSnapshot > 0.5
-          ? pow(texture2D(uSnapshot, snapUv).rgb, vec3(2.2))
-          : uFallback;
+        vec3 snap = pjtSnap(snapUv);
         // torn paper edge in the cover's page color along fragment borders
         vec2 e2 = min(fract(cell), 1.0 - fract(cell));
         float torn = smoothstep(0.10, 0.02, min(e2.x, e2.y)) * step(0.001, f);
         snap = mix(snap, uFallback, torn * 0.9);
         col = mix(col, snap, 1.0 - smoothstep(0.85, 1.0, f));
       }
+    } else if (uMode == 5.0) {
+      // panel-wipe: paper gutter bars sweep in over the outgoing page,
+      // then the incoming shot enters as an ink-bordered panel that grows
+      // to full bleed (S5).
+      vec3 page = pjtSnap(uv);
+      float ebar = min(min(uv.x, 1.0 - uv.x), min(uv.y, 1.0 - uv.y));
+      float barW = smoothstep(0.0, 0.4, p) * 0.055;
+      float aaE = fwidth(ebar) + 1e-4;
+      vec3 gutter = mix(uFallback, vec3(1.0), 0.25);
+      page = mix(page, gutter, 1.0 - smoothstep(barW - aaE, barW + aaE, ebar));
+      float g = smoothstep(0.12, 0.95, p);
+      vec2 dr = abs(uv - 0.5) - vec2(0.52) * g;
+      float rd = max(dr.x, dr.y);
+      float aaR = fwidth(rd) + 1e-4;
+      float inside = 1.0 - smoothstep(-aaR, aaR, rd);
+      col = mix(page, col, inside);
+      float rim = 1.0 - smoothstep(0.005, 0.005 + aaR * 2.0, abs(rd));
+      rim *= step(0.001, g) * (1.0 - smoothstep(0.8, 0.95, p));
+      col = mix(col, vec3(0.10, 0.09, 0.08), rim);
+    } else if (uMode == 6.0) {
+      // paper-tear: the outgoing page rips left to right with a fibered
+      // white edge, dragged slightly as it goes; the incoming page sits
+      // underneath with a soft shadow along the tear.
+      float front = mix(-0.3, 1.3, p);
+      float jag = (pjtNoise(vec2(uv.y * 9.0, 2.0)) - 0.5) * 0.14
+                + (pjtNoise(vec2(uv.y * 51.0, 7.0)) - 0.5) * 0.04;
+      float dd = uv.x + (uv.y - 0.5) * 0.12 + jag - front;
+      if (dd > 0.0) {
+        vec3 page = pjtSnap(uv - vec2(0.05, 0.012) * p);
+        float fiberN = pjtHash(uv * vec2(240.0, 900.0));
+        float band = 1.0 - smoothstep(0.0, 0.014 + fiberN * 0.02, dd);
+        col = mix(page, mix(uFallback, vec3(1.0), 0.55), band);
+      } else {
+        col *= 1.0 - (1.0 - smoothstep(0.0, 0.06, -dd)) * 0.22;
+      }
+    } else if (uMode == 7.0) {
+      // page-flip: whole-viewport cylindrical curl (radius R), turning
+      // right-to-left like a comic page; flat paper backside (S2.16: no
+      // mirrored ghost), incoming issue underneath. Inverse-mapped per
+      // pixel: pure curl geometry of p, single layer.
+      float R = 0.14;
+      float sweep = p * p * (3.0 - 2.0 * p);
+      float c = mix(1.0 + R, -0.36 - R * 3.14159, sweep);
+      float d = uv.x - c;
+      vec3 back = mix(uFallback, vec3(1.0), 0.4);
+      back *= 1.0 - pjtHash(vec2(floor(uv.y * 160.0), 5.0)) * 0.05;
+      if (d < 0.0) {
+        // paper coord of the turned-over tail lying face-down on top
+        float s3 = 2.0 * c + 3.14159 * R - uv.x;
+        if (s3 <= 1.0) {
+          col = back * (0.88 + 0.12 * smoothstep(0.0, 0.4, -d));
+          col *= 1.0 - (1.0 - smoothstep(0.0, 0.012, 1.0 - s3)) * 0.3;
+        } else {
+          col = pjtSnap(uv);
+          col *= 1.0 - (1.0 - smoothstep(0.0, 0.2, -d)) * 0.15;
+        }
+      } else {
+        // revealed incoming page, shadowed under the roll
+        col *= 1.0 - (1.0 - smoothstep(0.0, 0.24, d - R)) * 0.28;
+        if (d < R) {
+          float theta = asin(clamp(d / R, 0.0, 1.0));
+          float s1 = c + R * theta;                // front face rising
+          float s2 = c + R * (3.14159 - theta);    // backside over the top
+          if (s2 <= 1.0) {
+            col = back * (0.72 + 0.28 * sin(theta));
+            col *= 1.0 - (1.0 - smoothstep(0.0, 0.012, 1.0 - s2)) * 0.3;
+          } else if (s1 <= 1.0) {
+            col = pjtSnap(vec2(s1, uv.y)) * (1.0 - 0.38 * sin(theta));
+          }
+        }
+      }
+    } else if (uMode == 8.0) {
+      // stamp: the incoming shot slams down like a rubber stamp --
+      // scale-squash descent over the outgoing page, one paper-tone impact
+      // pop, radial burst, pressed-paper shadow ring (S5, S2.16-safe).
+      float drop = smoothstep(0.12, 0.55, p);
+      float squash = smoothstep(0.55, 0.60, p) * (1.0 - smoothstep(0.60, 0.78, p));
+      float mx = mix(1.8, 1.0, drop) * (1.0 + squash * 0.05);
+      float my = mix(1.8, 1.0, drop) * (1.0 - squash * 0.07);
+      vec3 face = pjtPrint(texture2D(inputBuffer, 0.5 + (uv - 0.5) / vec2(mx, my)).rgb, uv);
+      vec3 page = pjtSnap(uv);
+      page *= 1.0 - drop * 0.35 * smoothstep(0.9, 0.2, distance(uv, vec2(0.5)));
+      // hand the magnified pre-print face back to the true printed frame
+      // as the scale settles to 1 (same trick as the crash punch)
+      float disp = clamp((abs(mx - 1.0) + abs(my - 1.0)) * 14.0, 0.0, 1.0);
+      float appear = smoothstep(0.15, 0.40, p);
+      col = mix(page, mix(col, face, disp), appear);
+      float hit = smoothstep(0.53, 0.57, p) * (1.0 - smoothstep(0.60, 0.70, p));
+      col = mix(col, uFallback, hit * 0.55);
+      col = mix(col, vec3(1.0), pjtSpeedLines(uv, hit * 0.9) * 0.85);
+      float ed = min(min(uv.x, 1.0 - uv.x), min(uv.y, 1.0 - uv.y));
+      float ring = smoothstep(0.02, 0.05, ed) - smoothstep(0.05, 0.12, ed);
+      col *= 1.0 - ring * smoothstep(0.55, 0.62, p) * (1.0 - smoothstep(0.72, 1.0, p)) * 0.22;
+    } else if (uMode == 9.0) {
+      // dot-match (S5 match-cut): pose-matched iris -- the incoming shot
+      // lives inside one inked dot growing from the matched circular focal
+      // point to full bleed. Shot authoring centers a circle on both sides.
+      vec2 d = uv - 0.5;
+      d.x *= aspect;
+      float rad = length(d);
+      float rEnd = length(vec2(0.5 * aspect, 0.5)) + 0.03;
+      float r = rEnd * p * p * (3.0 - 2.0 * p);
+      float aa = fwidth(rad) + 1e-4;
+      float inside = 1.0 - smoothstep(r - aa, r + aa, rad);
+      col = mix(pjtSnap(uv), col, inside);
+      float rim = 1.0 - smoothstep(0.005, 0.005 + aa * 2.0, abs(rad - r));
+      rim *= smoothstep(0.02, 0.08, p) * (1.0 - smoothstep(0.85, 0.97, p));
+      col = mix(col, vec3(0.10, 0.09, 0.08), rim);
+    } else if (uMode == 10.0) {
+      // ink-flood: ink pours from the top and swallows the page around
+      // mid-gutter (full cover hides the camera cut like cut's blink --
+      // no snapshot needed), then drains to reveal the incoming issue.
+      float q = 1.0 - abs(2.0 * p - 1.0);
+      vec2 d = uv - vec2(0.5, 1.15);
+      d.x *= aspect;
+      float n = 1.0 + (pjtNoise(uv * 6.0) - 0.5) * 0.5 + (pjtNoise(uv * 21.0) - 0.5) * 0.16;
+      float radn = length(d) * n;
+      float front = smoothstep(0.0, 0.82, q) * (length(vec2(0.5 * aspect, 1.15)) * 1.38 + 0.08);
+      float m = 1.0 - smoothstep(front - 0.05, front, radn);
+      col = mix(col, vec3(0.07, 0.06, 0.05), m);
     }
 
     outputColor = vec4(col, inputColor.a);
   }
 `;
 
-const MODE = { none: 0, whip: 1, "dot-zoom": 2, cut: 3, "crash-through": 4 } as const;
+const MODE = {
+  none: 0,
+  whip: 1,
+  "dot-zoom": 2,
+  cut: 3,
+  "crash-through": 4,
+  "panel-wipe": 5,
+  "paper-tear": 6,
+  "page-flip": 7,
+  stamp: 8,
+  "dot-match": 9,
+  "ink-flood": 10,
+} as const;
 export type EffectModeName = keyof typeof MODE;
 
 export class TransitionEffect extends Effect {
@@ -154,6 +332,9 @@ export class TransitionEffect extends Effect {
         ["uFallback", new Uniform(new Color("#F2EAD9"))],
         ["uWhipDir", new Uniform({ x: 1, y: 0 })],
         ["uSmearMono", new Uniform(0)],
+        ["uSmearHalftone", new Uniform(0.4)],
+        ["uSmearScale", new Uniform(6)],
+        ["uSmearPaper", new Uniform(new Color("#F2EAD9"))],
       ]),
     });
   }


### PR DESCRIPTION
## Summary
- Transition library complete (SPEC S5): native panel-wipe, paper-tear, page-flip, stamp, dot-match, ink-flood (TransitionEffect modes 5-10), all pure f(p) and scrub-deterministic; in-shader pjtPrint() pre-print approximation polishes crash-through and stamp handoffs (closes PR #22 advisory ruling 3) at zero RT cost. Remaining fallbacks are by design and logged in lib/shots.ts: title-drop->whip (slam is an authored-time beat), panel-portal->panel-wipe (portal fly-through is scene work).
- Framework APIs for Phase 3: printRecipe() one-object issue look, PopPool<T> pooled lettering/balloons, snapshots.retain/release, declarative registerJawDrop() with centralized hysteresis + flash budget (title-drop and neon-cascade migrated, identical envelopes), self-contained registry row(). Phase 2 gate criterion proven live: a throwaway issue rendered with full print treatment + transitions from exactly one component file, one registry row, one recipe - then deleted.
- Scroll pacing (user feedback): spacer 1200vh -> 2400vh, wheelMultiplier 0.7; measured 0.478x t per wheel notch. Both are named constants for feel-tuning.
- Deep-jump mount blank fixed: JumpCover paints an opaque paper-color dot screen synchronously on large t jumps, reveals after the target trio premounts (double-rAF); mid-fade re-jumps idempotent.
- Shared CatModel (pose x mode x palette x rig refs); cover and desk cats migrated numeric-constant-identical; noir leaping cat deliberately untouched (dimensional prop verified against approved shot-4 framing).
- Live user fixes: noir shot shares 0.35/0.23/0.22/0.20 (wide->close travel +40% t, shot-4 range bit-identical), caption fades 0.18 -> 0.30 in/out.

## Gate (Chrome DevTools MCP, formal)
10/10 PASS, zero fix loops - full table in DECISIONS.md. Highlights: all 7 new/polished transitions styled + scrub-deterministic both directions; S2.16 comfort clean; perf median 2.1ms, 99.8% frames under 16.7ms; flash budget sole-path verified. One non-blocking advisory: reproducible single-frame ~58ms scene-mount hitch at t~0.172 (0.2% of frames), queued for perf-profiler if it worsens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)