### PR TITLE
Phase 4: Sound + polish - full synthesized soundscape

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -417,3 +417,24 @@ pinned 5.9.3, an external edit bumped it - kept, builds clean),
   360 exposed the detached root), ruff clamped inside the barrel (the
   top-view flank smear). Feet bottom at exactly y=0: zero scene seat
   changes. ~9-13 low-poly meshes per toon cat.
+
+## Phase 4 - Sound + polish (2026-07-03)
+- Tone.js pinned tone@15.1.22 (npm latest, verified 2026-07-03 via
+  Context7 + registry; SPEC pre-approved dep for this phase). Lazy
+  import("tone") on first enable only - audio never in initial bundle.
+- Latency ruling: keep default latencyHint "interactive" but set
+  context.lookAhead = 0.02 after Tone.start(). Rationale: docs suggest
+  "playback" for sustained ambience CPU, but beat one-shots must land
+  inside their ~60ms visual impact frame; default 100ms lookAhead would
+  audibly lag every thump. CPU cost goes to the perf ladder if the gate
+  trace objects.
+- fx.audioPulse channel added (0..1 smoothed music envelope, 0 whenever
+  audio off): the ONE contract between audio director (writer) and
+  PrintEffect halftone breathe (reader). Bit-exact print output when 0 -
+  settle-determinism gates unaffected.
+- Beat sounds: single hook in beats.ts fire() (setBeatSound) - "every
+  beat has a synced sound" enforced at the same choke point that already
+  enforces hysteresis + flash budget. Quiet-valley drops (flash 0) get a
+  soft page-turn, never a thump.
+- Meow synth = the Phase-3-queued meowCount consumer: store subscription,
+  deterministic per-count pitch hash (no Math.random - standing law).

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -446,3 +446,16 @@ pinned 5.9.3, an external edit bumped it - kept, builds clean),
   with screentone gold +10% if it ever muddies) and Noir->Desk the
   weakest energy beat (title-drop gutter carries it). Audit via
   agent-browser CLI (chrome-devtools MCP absent this session too).
+- Phase 4 gate: 10/10. Checks 1-8,10 via agent-browser CLI (no autoplay:
+  AudioContext count 0 pre-gesture; audio-on full journey 102 steps clean;
+  beat/meow paths verified via AudioParam-op counting; breathe ON==OFF at
+  the 2.5% boil floor; settle determinism <1%; toggle off quiesces to 0
+  param ops). Check 9 formally re-traced under chrome-devtools MCP
+  (reconnected mid-session): Desk + Pop spans audio-on, no sustained
+  jank, audio main-thread cost negligible (Pop ON 2.11ms mean vs OFF
+  2.36ms; zero Tone long tasks - Web Audio renders off-main-thread).
+  This also closes the Phase 3 queued formal re-trace.
+- Advisory carried forward: single-frame cold-mount stalls (desk ~90-108ms,
+  pop ~143ms IN DEV - unminified + StrictMode double-invoke inflate the
+  58ms Phase 2 baseline) are audio-neutral and pre-date Phase 4.
+  Re-measure on a production build; goes in REPORT.md if it survives.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -438,3 +438,11 @@ pinned 5.9.3, an external edit bumped it - kept, builds clean),
   soft page-turn, never a thump.
 - Meow synth = the Phase-3-queued meowCount consumer: store subscription,
   deterministic per-count pitch hash (no Math.random - standing law).
+- Global color-script pass (SPEC Phase 4): 23 screenshots (12 centers +
+  11 gutters), 11/11 adjacent pairs OK - 0 clash, 0 flat. No recipe
+  changes made (pass criterion was "tweak only on clash"). Advisory
+  watch-links if a future phase touches these recipes: Newsprint->
+  Screentone is the softest palette gap (both desaturated print; widen
+  with screentone gold +10% if it ever muddies) and Noir->Desk the
+  weakest energy beat (title-drop gutter carries it). Audit via
+  agent-browser CLI (chrome-devtools MCP absent this session too).

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -459,3 +459,14 @@ pinned 5.9.3, an external edit bumped it - kept, builds clean),
   pop ~143ms IN DEV - unminified + StrictMode double-invoke inflate the
   58ms Phase 2 baseline) are audio-neutral and pre-date Phase 4.
   Re-measure on a production build; goes in REPORT.md if it survives.
+- Soundscape enrichment focused re-gate: 6/6 PASS (DevTools MCP): 0
+  AudioContexts pre-gesture across all 10 new call sites, full journey
+  clean both directions, gutter-jitter hysteresis holds (paramOps delta 0
+  across 40 rapid crossings), terminal cmdOk/cmdErr paths live, deep-jump
+  landing bounded (no catch-up cascade).
+- Toggle-off semantics ruling: post-disable, event-driven sounds still
+  schedule into the master out-gain ramped to 0 (silence guarantee holds;
+  context kept live for instant re-enable). Differs from the pre-enrichment
+  "0 param ops when off" observation BY DESIGN (ui.ts contract lines
+  15-20); cost negligible per the formal trace. Revisit only if a future
+  trace disagrees.

--- a/PLAN.md
+++ b/PLAN.md
@@ -89,7 +89,36 @@ Session protocol (S0.9): one phase per session. Kickoff every session with
   press CTA is DOM already) need DOM/a11y exposure; terminal panels
   spawn partly off-frame at play camera (legible, polish)
 
-## Phase 4 - Sound (all synthesized; Tone.js pre-approved) + polish
+## Phase 4 - Sound (all synthesized; Tone.js pre-approved) + polish -- DONE (2026-07-03)
+- [x] tone@15.1.22 pinned (verified via Context7 before any code); lazy
+      import, never in the initial bundle; lookAhead 0.02 latency ruling
+- [x] Audio engine core: director singleton (music/sfx buses -> Compressor
+      -> Limiter, -9dB ceiling), AudioToggle DOM overlay (off by default,
+      aria-pressed, never autoplays), setBeatSound hook at the beats.ts
+      fire() choke point, fx.audioPulse contract channel
+- [x] meowCount consumer shipped (Phase 3 queue): synth meow on cat click,
+      hash-seeded, later upgraded to contour families (question/trill/chirp)
+- [x] 12 per-issue ambiences per SPEC list (Cover/Origin/Press nearest-
+      analog rulings); screentone rail synced to the 10Hz boil grid;
+      sketchbook pencil scratch follows |velocity|
+- [x] Halftone dot-scale breathe: uAudioPulse, +5% radius cap, cell pitch
+      fixed (no crawl), bit-exact at 0 - settle gates unaffected
+- [x] Global color-script pass: 23 shots, 11/11 boundaries OK, advisory-only
+- [x] User-directed soundscape enrichment (multi-agent design sweep, 44
+      candidates -> 35 shipped): ALL 11 gutter transitions carry signature
+      sounds + velocity page-riffle; 15 scroll-window scene reactions
+      (moments.ts); 10 input reactions (ui.ts) across 10 approved scene
+      call sites; adversarial law review PASS 10/10
+- [x] Gate 10/10 (agent-browser CLI + chrome-devtools MCP after mid-session
+      reconnect); formal DevTools re-trace closes the Phase 3 queue: audio
+      adds zero main-thread cost (Web Audio off-main-thread), no new jank
+- [x] Focused audio re-gate over the enrichment (autoplay guard at new
+      call sites, gutter-jitter hysteresis, terminal interactions,
+      toggle-off quiesce, deep-jump safety)
+- Advisory to REPORT.md: pre-existing single-frame cold-mount stalls
+  (desk/pop) read 90-143ms in dev (StrictMode-inflated vs 58ms Phase 2
+  baseline) - audio-neutral; re-measure on a production build
+- Ships as PR: branch phase-4-sound-polish
 
 ## Phase 5 - Print Edition + accessibility (do NOT skip)
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,4 @@
+import AudioToggle from "@/components/AudioToggle";
 import Experience from "@/components/Experience";
 import JumpCover from "@/components/JumpCover";
 import Lettering from "@/components/Lettering";
@@ -16,6 +17,7 @@ export default function Home() {
       <Experience />
       <Lettering />
       <PressCta />
+      <AudioToggle />
       <JumpCover />
       <ScrollProxy />
     </main>

--- a/components/AudioToggle.tsx
+++ b/components/AudioToggle.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useScrollStore } from "@/lib/scrollStore";
+import { disableAudio, enableAudio } from "@/lib/audio/director";
+
+/**
+ * Sound on/off toggle on the post-exempt DOM layer (S2.16 -- crisp single
+ * layer, printed-comic idiom: paper fill, ink border, hard offset shadow).
+ * Bottom-right corner: clear of the attract prompt + Press CTA (bottom
+ * center), noir caption spots, and the ?debug PerfHUD (top-left). OFF by
+ * default, never autoplays -- enableAudio() runs synchronously inside the
+ * click so Tone.start() gets its user-gesture unlock. Native button =
+ * keyboard operable.
+ */
+
+const PAPER = "#F2EAD9";
+const INK = "#14110E";
+const RED = "#E2574C";
+
+export default function AudioToggle() {
+  const on = useScrollStore((s) => s.audioOn);
+  return (
+    <button
+      type="button"
+      aria-pressed={on}
+      aria-label="Sound"
+      onClick={() => (useScrollStore.getState().audioOn ? disableAudio() : enableAudio())}
+      className="fixed bottom-4 right-4 z-30"
+      style={{
+        fontFamily: "var(--font-bangers)",
+        fontSize: "clamp(13px, 1.8vh, 17px)",
+        letterSpacing: "0.08em",
+        padding: "0.35em 0.9em",
+        background: on ? INK : PAPER,
+        color: on ? PAPER : INK,
+        border: `3px solid ${INK}`,
+        borderRadius: "10px",
+        boxShadow: `4px 4px 0 ${on ? RED : INK}`,
+        cursor: "pointer",
+        whiteSpace: "nowrap",
+      }}
+    >
+      SOUND {on ? "ON" : "OFF"}
+    </button>
+  );
+}

--- a/components/PostPipeline.tsx
+++ b/components/PostPipeline.tsx
@@ -135,6 +135,9 @@ export default function PostPipeline() {
     print.u<number>("uPaperTex").value = c.paperTex;
     print.u<number>("uVignette").value = c.vignette;
     print.u<number>("uImpact").value = fx.impact;
+    // Phase 4: halftone dot-scale breathe -- envelope is smoothed by the
+    // audio director and is exactly 0 whenever audio is off (no fallback)
+    print.u<number>("uAudioPulse").value = Math.min(1, Math.max(0, fx.audioPulse));
     print.u<number>("uHatch").value = c.hatch;
     print.u<number>("uHatchScale").value = c.hatchScale;
 

--- a/components/PressCta.tsx
+++ b/components/PressCta.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from "react";
 import { useScrollStore } from "@/lib/scrollStore";
+import { uiSound } from "@/lib/audio/ui";
 import { issueCopy } from "@/lib/content";
 import { clamp01 } from "@/lib/shots";
 import { scrollToT } from "./ScrollProxy";
@@ -53,7 +54,10 @@ export default function PressCta() {
     <button
       ref={btn}
       type="button"
-      onClick={() => scrollToT(PRESS_PROJECTS_T)}
+      onClick={() => {
+        uiSound("ctaPress");
+        scrollToT(PRESS_PROJECTS_T);
+      }}
       className="fixed left-1/2 z-30"
       style={{
         bottom: "9vh",

--- a/issues/06-newsprint/Newsprint.tsx
+++ b/issues/06-newsprint/Newsprint.tsx
@@ -11,6 +11,7 @@ import { toonRamp } from "@/lib/toon";
 import { stepTime } from "@/lib/steppedClock";
 import { useScrollStore } from "@/lib/scrollStore";
 import { sayWord } from "@/lib/onomatopoeia";
+import { uiSound } from "@/lib/audio/ui";
 import { issueCopy, lettering, links } from "@/lib/content";
 import { colorWindow } from "@/shaders/colorWindow";
 import { issueCenter } from "../timeline";
@@ -390,6 +391,7 @@ function PanelButton({ x, label, url }: { x: number; label: string; url: string 
       position={[x, -3.5, 0.45]}
       onClick={(e) => {
         e.stopPropagation();
+        uiSound("linkPress"); // both GITHUB and WEBSITE plates
         window.open(url, "_blank", "noopener,noreferrer");
       }}
       onPointerOver={(e) => {

--- a/issues/11-terminal/Terminal.tsx
+++ b/issues/11-terminal/Terminal.tsx
@@ -21,6 +21,7 @@ import { useScrollStore } from "@/lib/scrollStore";
 import { snapshots } from "@/lib/snapshots";
 import { popScale } from "@/lib/pops";
 import { clamp01, lerp } from "@/lib/shots";
+import { uiSound } from "@/lib/audio/ui";
 import { issueCopy, projects } from "@/lib/content";
 import {
   AMBER,
@@ -91,16 +92,19 @@ function onKey(e: KeyboardEvent) {
     e.preventDefault();
     term.buf = term.buf.slice(0, -1);
     term.gen++;
+    uiSound("keyBack");
     return;
   }
   if (e.key === "Escape") {
     term.buf = "";
     term.gen++;
+    uiSound("keyEsc");
     return;
   }
   if (e.key.length === 1 && /[a-z0-9-]/i.test(e.key) && term.buf.length < 14) {
     term.buf += e.key.toLowerCase();
     term.gen++;
+    uiSound("key", term.buf.length);
   }
 }
 
@@ -494,6 +498,7 @@ function ResponsePanels() {
                   onClick={(e) => {
                     if (!openLive(i)) return; // dead tab: let the ray pass
                     e.stopPropagation();
+                    uiSound("openTab", r); // per-row pitch step
                     // synchronous with the click gesture -- popup-blocker safe
                     window.open(p.url, "_blank", "noopener");
                   }}

--- a/issues/11-terminal/shots.ts
+++ b/issues/11-terminal/shots.ts
@@ -5,6 +5,7 @@ import { registerJawDrop } from "@/lib/beats";
 import { PopPool } from "@/lib/pops";
 import { snapshots } from "@/lib/snapshots";
 import { content, issueCopy, links } from "@/lib/content";
+import { uiSound } from "@/lib/audio/ui";
 import { issueCenter, RANGES } from "../timeline";
 
 /**
@@ -195,13 +196,22 @@ export function runCommand(cmd: string): boolean {
   const locked = RESPONSES[cmd];
   if (locked === undefined) {
     spawnPanel(cmd, issueCopy.lettersPage.unknownCommand.replace("{cmd}", cmd));
+    uiSound("cmdErr"); // lockstep with the errAt screen flinch
     return false;
   }
   spawnPanel(cmd, cmd === "contact" ? locked + "\n" + assembleEmail() : locked);
   if (cmd === "resume") dropPool.spawn(RESUME_DROP_POS);
   if (cmd === "github" && links.githubUrl !== "") window.open(links.githubUrl, "_blank", "noopener");
   if (cmd === "linkedin" && links.linkedinUrl !== "") window.open(links.linkedinUrl, "_blank", "noopener");
+  uiSound("cmdOk", charSum(cmd)); // per-command pitch identity (Enter + card click)
   return true;
+}
+
+/** Deterministic per-command seed (sum of char codes) for the cmdOk pitch. */
+function charSum(s: string): number {
+  let n = 0;
+  for (let i = 0; i < s.length; i++) n += s.charCodeAt(i);
+  return n;
 }
 
 // ---- jaw-drop: the back-cover reveal (gentle BY DESIGN, intensity 1) --------

--- a/lib/audio/director.ts
+++ b/lib/audio/director.ts
@@ -5,6 +5,8 @@ import { setBeatSound } from "@/lib/beats";
 import { clamp01 } from "@/lib/shots";
 import { RANGES } from "@/issues/timeline";
 import { audioRecipes, type AudioRecipe, type ToneModule } from "./types";
+import { scoreTransitions, stopTransitions } from "./transitions";
+import "./recipes"; // Wave B: fills the audioRecipes slots (side effect)
 
 /**
  * Audio director -- plain module singleton, React-free (lib/fx.ts pattern).
@@ -113,6 +115,11 @@ export function disableAudio(): void {
           warn(e);
         }
         ch.started = false;
+      }
+      try {
+        stopTransitions();
+      } catch (e) {
+        warn(e);
       }
     }, 250);
   } catch (e) {
@@ -243,6 +250,8 @@ function loop(now: number): void {
         ch.started = false;
       }
     }
+    // scored transitions: pure f(t, velocity) on the sfx bus (single call site)
+    scoreTransitions(m.T, m.sfx, t, dt, velocity);
     // music-bus envelope for the halftone breathe (consumers scale it down)
     const v = m.meter.getValue();
     fx.audioPulse = Math.min(1, Math.max(0, typeof v === "number" ? v : (v[0] ?? 0)));

--- a/lib/audio/director.ts
+++ b/lib/audio/director.ts
@@ -1,0 +1,253 @@
+import type { FMSynth, Gain, MembraneSynth, Meter, Synth } from "tone";
+import { useScrollStore } from "@/lib/scrollStore";
+import { fx } from "@/lib/fx";
+import { setBeatSound } from "@/lib/beats";
+import { clamp01 } from "@/lib/shots";
+import { RANGES } from "@/issues/timeline";
+import { audioRecipes, type AudioRecipe, type ToneModule } from "./types";
+
+/**
+ * Audio director -- plain module singleton, React-free (lib/fx.ts pattern).
+ * OFF by default; enableAudio() must be called synchronously from a user
+ * gesture handler (Tone.start() unlock). Tone.js is lazy-imported here on
+ * first enable so it never rides the server/initial bundle. Every Tone call
+ * is wrapped: failure degrades to silence with a single console.warn.
+ *
+ * Chain: per-issue crossfade gains -> music bus \
+ *                                                out gain -> Compressor ->
+ *        one-shots (thump/chime/meow) -> sfx bus /  Limiter(-1) -> destination
+ *        (destination volume ceiling -9 dB).
+ *
+ * Beat sounds ride lib/beats.ts setBeatSound, which only fires from
+ * BeatRunner crossings -- reduced motion already suppresses those, so the
+ * sounds inherit the suppression for free.
+ */
+
+interface Master {
+  T: ToneModule;
+  out: Gain;
+  music: Gain;
+  sfx: Gain;
+  meter: Meter;
+  thump: MembraneSynth;
+  chime: Synth;
+  meowSynth: FMSynth;
+}
+
+interface Channel {
+  recipe: AudioRecipe;
+  gain: Gain;
+  started: boolean;
+  lastG: number;
+}
+
+const CROSSFADE_S = 0.15;
+/** t distance past an issue's range over which its bed fades to silence */
+const FALLOFF = 0.02;
+
+let master: Master | null = null;
+let channels: (Channel | null)[] = [];
+let enabled = false;
+let pending = false;
+let wired = false;
+let session = 0;
+let raf = 0;
+let lastNow = 0;
+let warned = false;
+
+function warn(e: unknown): void {
+  if (warned) return;
+  warned = true;
+  console.warn("[audio] degraded to silent:", e);
+}
+
+/** Idempotent; call synchronously inside the user gesture (click) handler. */
+export function enableAudio(): void {
+  if (enabled || pending) return;
+  pending = true;
+  const mySession = ++session;
+  // optimistic mirror (reverted on failure) so the toggle flips instantly
+  useScrollStore.getState().setAudioOn(true);
+  void (async () => {
+    const T = master ? master.T : await import("tone");
+    await T.start(); // unlock -- initiated from the gesture's task
+    if (session !== mySession) return; // disabled mid-flight
+    // default lookAhead (100ms) makes beat hits lag their visual flash
+    T.getContext().lookAhead = 0.02;
+    if (!master) master = buildMaster(T);
+    wire();
+    master.out.gain.rampTo(1, 0.1);
+    enabled = true;
+    pending = false;
+    lastNow = performance.now();
+    cancelAnimationFrame(raf);
+    raf = requestAnimationFrame(loop);
+  })().catch((e) => {
+    pending = false;
+    enabled = false;
+    useScrollStore.getState().setAudioOn(false);
+    warn(e);
+  });
+}
+
+/** Ramp to silence, stop sources, KEEP instances for cheap re-enable. */
+export function disableAudio(): void {
+  session++;
+  useScrollStore.getState().setAudioOn(false);
+  if (!enabled && !pending) return;
+  enabled = false;
+  pending = false;
+  cancelAnimationFrame(raf);
+  fx.audioPulse = 0; // written once here so it never sticks
+  const m = master;
+  if (!m) return;
+  try {
+    m.out.gain.rampTo(0, 0.2);
+    setTimeout(() => {
+      if (enabled) return; // re-enabled during the fade
+      for (const ch of channels) {
+        if (!ch || !ch.started) continue;
+        try {
+          ch.recipe.stop();
+        } catch (e) {
+          warn(e);
+        }
+        ch.started = false;
+      }
+    }, 250);
+  } catch (e) {
+    warn(e);
+  }
+}
+
+function buildMaster(T: ToneModule): Master {
+  const comp = new T.Compressor({ threshold: -18, ratio: 3 });
+  const limiter = new T.Limiter(-1);
+  const out = new T.Gain(0);
+  out.chain(comp, limiter, T.getDestination());
+  T.getDestination().volume.value = -9; // master ceiling
+
+  const music = new T.Gain(1).connect(out);
+  const sfx = new T.Gain(1).connect(out);
+  const meter = new T.Meter({ smoothing: 0.9, normalRange: true });
+  music.connect(meter);
+
+  const thump = new T.MembraneSynth({
+    pitchDecay: 0.08,
+    octaves: 5,
+    envelope: { attack: 0.002, decay: 0.4, sustain: 0, release: 0.1 },
+    volume: -6,
+  }).connect(sfx);
+  const chime = new T.Synth({
+    oscillator: { type: "triangle" },
+    envelope: { attack: 0.02, decay: 0.25, sustain: 0, release: 0.3 },
+    volume: -18,
+  }).connect(sfx);
+  const meowSynth = new T.FMSynth({
+    harmonicity: 1.5,
+    modulationIndex: 4,
+    envelope: { attack: 0.03, decay: 0.2, sustain: 0.5, release: 0.12 },
+    modulationEnvelope: { attack: 0.05, decay: 0.2, sustain: 0.3, release: 0.1 },
+    volume: -12,
+  }).connect(sfx);
+
+  channels = audioRecipes.map(() => null);
+  return { T, out, music, sfx, meter, thump, chime, meowSynth };
+}
+
+/** One-time subscriptions (survive disable; guarded by `enabled`). */
+function wire(): void {
+  if (wired) return;
+  wired = true;
+  // beat one-shots: sub-thump scaled by flash; quiet-valley drops (flash 0)
+  // get a soft chime instead. All on the sfx bus.
+  setBeatSound((_id, flash) => {
+    const m = master;
+    if (!enabled || !m) return;
+    try {
+      const now = m.T.now();
+      if (flash > 0) m.thump.triggerAttackRelease("A1", 0.3, now, 0.4 + 0.6 * Math.min(flash, 1));
+      else m.chime.triggerAttackRelease("D6", 0.2, now, 0.7);
+    } catch (e) {
+      warn(e);
+    }
+  });
+  // meow: deterministic per-count variation (multiplicative hash, repo law:
+  // no Math.random)
+  useScrollStore.subscribe((s, prev) => {
+    const m = master;
+    if (s.meowCount === prev.meowCount || !enabled || !m) return;
+    try {
+      const h = (s.meowCount * 2654435761) >>> 0;
+      const base = 480 + (h % 200); // Hz
+      const peak = base * (1.3 + ((h >>> 8) % 35) / 100);
+      const now = m.T.now();
+      m.meowSynth.triggerAttack(base, now, 0.8);
+      m.meowSynth.frequency.rampTo(peak, 0.1, now + 0.02); // "me-"
+      m.meowSynth.frequency.rampTo(base * 0.82, 0.2, now + 0.14); // "-ow"
+      m.meowSynth.triggerRelease(now + 0.38);
+    } catch (e) {
+      warn(e);
+    }
+  });
+}
+
+/** 1 inside the issue's range, linear falloff to 0 across FALLOFF outside. */
+function proximity(t: number, i: number): number {
+  const r = RANGES[i];
+  if (!r) return 0;
+  const d = t < r[0] ? r[0] - t : t > r[1] ? t - r[1] : 0;
+  return Math.max(0, 1 - d / FALLOFF);
+}
+
+/** rampTo only on real target moves -- per-frame automation writes are banned. */
+function setGain(ch: Channel, target: number): void {
+  const moved = Math.abs(target - ch.lastG);
+  if (moved === 0) return;
+  if (moved < 0.02 && target > 0 && target < 1) return;
+  ch.lastG = target;
+  ch.gain.gain.rampTo(target, CROSSFADE_S);
+}
+
+function loop(now: number): void {
+  raf = requestAnimationFrame(loop);
+  const m = master;
+  if (!enabled || !m) return;
+  const dt = Math.min((now - lastNow) / 1000, 0.1);
+  lastNow = now;
+  try {
+    const { t, velocity, activeIssue } = useScrollStore.getState();
+    for (let i = 0; i < audioRecipes.length; i++) {
+      const recipe = audioRecipes[i];
+      if (!recipe) continue;
+      let ch = channels[i] ?? null;
+      if (Math.abs(i - activeIssue) <= 1) {
+        if (!ch) {
+          // lazy build on first entry into the active window
+          const gain = new m.T.Gain(0).connect(m.music);
+          recipe.build(m.T).connect(gain);
+          ch = { recipe, gain, started: false, lastG: 0 };
+          channels[i] = ch;
+        }
+        if (!ch.started) {
+          recipe.start();
+          ch.started = true;
+        }
+        const r = RANGES[i]!;
+        recipe.update(clamp01((t - r[0]) / (r[1] - r[0])), dt, velocity);
+        setGain(ch, proximity(t, i));
+      } else if (ch && ch.started) {
+        // a full issue away: bed already at 0 gain, hard stop is silent
+        setGain(ch, 0);
+        ch.recipe.stop();
+        ch.started = false;
+      }
+    }
+    // music-bus envelope for the halftone breathe (consumers scale it down)
+    const v = m.meter.getValue();
+    fx.audioPulse = Math.min(1, Math.max(0, typeof v === "number" ? v : (v[0] ?? 0)));
+  } catch (e) {
+    warn(e);
+    disableAudio();
+  }
+}

--- a/lib/audio/director.ts
+++ b/lib/audio/director.ts
@@ -1,4 +1,4 @@
-import type { FMSynth, Gain, MembraneSynth, Meter, Synth } from "tone";
+import type { Gain, MembraneSynth, Meter, Synth } from "tone";
 import { useScrollStore } from "@/lib/scrollStore";
 import { fx } from "@/lib/fx";
 import { setBeatSound } from "@/lib/beats";
@@ -6,6 +6,8 @@ import { clamp01 } from "@/lib/shots";
 import { RANGES } from "@/issues/timeline";
 import { audioRecipes, type AudioRecipe, type ToneModule } from "./types";
 import { scoreTransitions, stopTransitions } from "./transitions";
+import { scoreMoments, beatMoment, stopMoments } from "./moments";
+import { wireUi, uiSound } from "./ui";
 import "./recipes"; // Wave B: fills the audioRecipes slots (side effect)
 
 /**
@@ -33,7 +35,6 @@ interface Master {
   meter: Meter;
   thump: MembraneSynth;
   chime: Synth;
-  meowSynth: FMSynth;
 }
 
 interface Channel {
@@ -79,6 +80,7 @@ export function enableAudio(): void {
     if (!master) master = buildMaster(T);
     wire();
     master.out.gain.rampTo(1, 0.1);
+    uiSound("toggleOn"); // first thing the user hears (package C)
     enabled = true;
     pending = false;
     lastNow = performance.now();
@@ -104,6 +106,7 @@ export function disableAudio(): void {
   const m = master;
   if (!m) return;
   try {
+    uiSound("toggleOff"); // print-press chime while the master still rings (package C)
     m.out.gain.rampTo(0, 0.2);
     setTimeout(() => {
       if (enabled) return; // re-enabled during the fade
@@ -118,6 +121,7 @@ export function disableAudio(): void {
       }
       try {
         stopTransitions();
+        stopMoments();
       } catch (e) {
         warn(e);
       }
@@ -150,28 +154,24 @@ function buildMaster(T: ToneModule): Master {
     envelope: { attack: 0.02, decay: 0.25, sustain: 0, release: 0.3 },
     volume: -18,
   }).connect(sfx);
-  const meowSynth = new T.FMSynth({
-    harmonicity: 1.5,
-    modulationIndex: 4,
-    envelope: { attack: 0.03, decay: 0.2, sustain: 0.5, release: 0.12 },
-    modulationEnvelope: { attack: 0.05, decay: 0.2, sustain: 0.3, release: 0.1 },
-    volume: -12,
-  }).connect(sfx);
-
   channels = audioRecipes.map(() => null);
-  return { T, out, music, sfx, meter, thump, chime, meowSynth };
+  return { T, out, music, sfx, meter, thump, chime };
 }
 
 /** One-time subscriptions (survive disable; guarded by `enabled`). */
 function wire(): void {
   if (wired) return;
+  const m0 = master;
+  if (!m0) return;
   wired = true;
-  // beat one-shots: sub-thump scaled by flash; quiet-valley drops (flash 0)
-  // get a soft chime instead. All on the sfx bus.
-  setBeatSound((_id, flash) => {
+  // beat one-shots: package B (moments) claims scored beats first; anything it
+  // does not own falls through to the sub-thump (flash>0) / soft chime (flash 0)
+  // default. All on the sfx bus.
+  setBeatSound((id, flash) => {
     const m = master;
     if (!enabled || !m) return;
     try {
+      if (beatMoment(id, flash)) return; // moment owns the hit (sound or silence)
       const now = m.T.now();
       if (flash > 0) m.thump.triggerAttackRelease("A1", 0.3, now, 0.4 + 0.6 * Math.min(flash, 1));
       else m.chime.triggerAttackRelease("D6", 0.2, now, 0.7);
@@ -179,24 +179,9 @@ function wire(): void {
       warn(e);
     }
   });
-  // meow: deterministic per-count variation (multiplicative hash, repo law:
-  // no Math.random)
-  useScrollStore.subscribe((s, prev) => {
-    const m = master;
-    if (s.meowCount === prev.meowCount || !enabled || !m) return;
-    try {
-      const h = (s.meowCount * 2654435761) >>> 0;
-      const base = 480 + (h % 200); // Hz
-      const peak = base * (1.3 + ((h >>> 8) % 35) / 100);
-      const now = m.T.now();
-      m.meowSynth.triggerAttack(base, now, 0.8);
-      m.meowSynth.frequency.rampTo(peak, 0.1, now + 0.02); // "me-"
-      m.meowSynth.frequency.rampTo(base * 0.82, 0.2, now + 0.14); // "-ow"
-      m.meowSynth.triggerRelease(now + 0.38);
-    } catch (e) {
-      warn(e);
-    }
-  });
+  // package C (ui) installs the meow-variety + jump-land subscriptions on the
+  // sfx bus; both inherit the gesture gate (mod set here, post-enable).
+  wireUi(m0.T, m0.sfx);
 }
 
 /** 1 inside the issue's range, linear falloff to 0 across FALLOFF outside. */
@@ -252,6 +237,8 @@ function loop(now: number): void {
     }
     // scored transitions: pure f(t, velocity) on the sfx bus (single call site)
     scoreTransitions(m.T, m.sfx, t, dt, velocity);
+    // scene reactions (package B): diegetic moments, single call site
+    scoreMoments(m.T, m.sfx, t, dt, velocity);
     // music-bus envelope for the halftone breathe (consumers scale it down)
     const v = m.meter.getValue();
     fx.audioPulse = Math.min(1, Math.max(0, typeof v === "number" ? v : (v[0] ?? 0)));

--- a/lib/audio/moments.ts
+++ b/lib/audio/moments.ts
@@ -1,0 +1,774 @@
+import type {
+  FeedbackDelay,
+  Filter,
+  FMSynth,
+  Gain,
+  MembraneSynth,
+  MetalSynth,
+  Noise,
+  NoiseSynth,
+  Oscillator,
+  Synth,
+} from "tone";
+import { clamp01 } from "@/lib/shots";
+import { RANGES } from "@/issues/timeline";
+import type { ToneModule } from "./types";
+import { h01, hash, moveTo } from "./util";
+// Read-only scene constants (all already exported). These are pure numbers /
+// pure f(t) helpers -- importing them adds NO Tone at module scope and no new
+// autoplay path (Tone stays lazy, handed in via scoreMoments' T argument).
+import { KEYS_R } from "@/issues/02-desk/shots";
+import { NEON_CASCADE_END, NEON_CASCADE_T } from "@/issues/03-neon/shots";
+import { PRESS_PART_T } from "@/issues/05-press/shots";
+import { STATION_X, trainSpeed, trainX } from "@/issues/07-screentone/shots";
+import { ORBIT_START_T } from "@/issues/08-pop/shots";
+import { FLOOD_T, inkAt } from "@/issues/09-sketchbook/shots";
+import { UNFOLD_RANGE } from "@/issues/10-spread/shots";
+
+/**
+ * Wave C: the reactive "moments" layer -- a self-contained sibling of
+ * transitions.ts. Two surfaces, both on the sfx bus (master Compressor ->
+ * Limiter), mixed low, texture only:
+ *
+ *   scoreMoments(T, sfx, t, dtSec, velocity) -- one director call site per
+ *     tick. Diegetic scene reactions re-homed off recipes.ts: each windows on
+ *     imported scene constants, reconstructs global t, and fires through an
+ *     OWN pooled synth kit built once. Scrub/deep-jump-safe crossings use the
+ *     Edge helper (BeatRunner semantics: prime on first tick, fire forward
+ *     cross, re-arm below trigger-hysteresis, NO catch-up burst). The pop-360
+ *     whoosh/crowd bed is a continuous pure f(t) swell (no event arming).
+ *
+ *   beatMoment(id, flash) -- the setBeatSound handler. Returns true when a
+ *     moment owns the hit (custom sound OR a deliberate silence), false to let
+ *     the caller fall through to its default thump/chime. Reuses the same
+ *     pooled kit -- no new synths. Gesture-gated for free: the kit only exists
+ *     once scoreMoments has run under an enabled director.
+ *
+ * Determinism law: variation is Knuth hash(i)/h01(i) of integer indices only,
+ * never Math.random. Param moves via moveTo (rampTo on real changes); shaped
+ * one-shot sweeps via scheduled setValueAtTime/linearRampToValueAtTime. No
+ * per-frame allocation in the update path.
+ */
+
+/* ------------------------------------------------------------------ Edge --- */
+/**
+ * Forward-crossing latch, scrub- and deep-jump-safe (BeatRunner pattern). The
+ * first crossed() call only primes (arms iff below the threshold) so a jump
+ * INTO the middle of a window replays nothing. Thereafter it fires once on a
+ * forward cross and re-arms only after retreating past trigger - hysteresis.
+ */
+class Edge {
+  private primed = false;
+  private armed = true;
+  crossed(x: number, at: number, hyst: number): boolean {
+    if (!this.primed) {
+      this.primed = true;
+      this.armed = x < at;
+      return false;
+    }
+    if (this.armed) {
+      if (x >= at) {
+        this.armed = false;
+        return true;
+      }
+    } else if (x < at - hyst) {
+      this.armed = true;
+    }
+    return false;
+  }
+  reset(): void {
+    this.primed = false;
+    this.armed = true;
+  }
+}
+
+/* -------------------------------------------------- windows + note tables --- */
+const CLACK_FRACS = [0.12, 0.3, 0.46, 0.62, 0.76, 0.9] as const;
+const CLACK_HYST = 0.0008;
+const PART_HYST = 0.003;
+const STATION_HYST = 4; // world units (stations ~24 apart)
+const INK_HYST = 0.02;
+const STAR_HYST = 0.015;
+
+const POP_RANGE = RANGES[8]!;
+/** ORBIT_F is not exported by 08-pop; derive it from ORBIT_START_T. */
+const ORBIT_F = (ORBIT_START_T - POP_RANGE[0]) / (POP_RANGE[1] - POP_RANGE[0]);
+/** wash-flood onset expressed in sketch ink-u (== inkAt(FLOOD_T) == 0.65). */
+const FLOOD_U = inkAt(FLOOD_T);
+
+/** ascending pentatonic C5..A6, one shimmer per spread page (0..9). */
+const PENTA = [523.25, 587.33, 659.25, 783.99, 880, 1046.5, 1174.66, 1318.51, 1567.98, 1760] as const;
+
+/* --------------------------------------------------------------- the kit --- */
+interface Kit {
+  // desk keycap clacks
+  clackNoise: NoiseSynth;
+  clackBp: Filter;
+  clackThock: Synth;
+  // neon ring zaps
+  ringSyn: Synth;
+  ringBp: Filter;
+  ringDelay: FeedbackDelay;
+  ringSnap: NoiseSynth;
+  ringSnapHp: Filter;
+  // press part-add thumps
+  partMembrane: MembraneSynth;
+  partReact: Synth;
+  partTs: Synth;
+  partTsBp: Filter;
+  partRust: MetalSynth;
+  partAiA: Synth;
+  partAiB: Synth;
+  // screentone far-off horn
+  hornA: Synth;
+  hornB: Synth;
+  hornLp: Filter;
+  hornDelay: FeedbackDelay;
+  // pop 360 whoosh + crowd (continuous)
+  popWhoosh: Noise;
+  popWhooshBp: Filter;
+  popWhooshGain: Gain;
+  crowdA: Oscillator;
+  crowdB: Oscillator;
+  crowdC: Oscillator;
+  crowdLp: Filter;
+  crowdGain: Gain;
+  hushNoise: Noise;
+  hushLp: Filter;
+  // sketch ink ticks + wash flood
+  inkTick: NoiseSynth;
+  inkTickHp: Filter;
+  washNoise: NoiseSynth;
+  washLp: Filter;
+  washSine: Synth;
+  // spread star-chart arp
+  starBell: FMSynth;
+  starDelay: FeedbackDelay;
+  // kaching donation
+  kachA: FMSynth;
+  kachB: FMSynth;
+  kachDrawer: NoiseSynth;
+  kachDrawerBp: Filter;
+  kachPop: NoiseSynth;
+  kachPopLp: Filter;
+  coin: Synth;
+  // press die-slam
+  stampMembrane: MembraneSynth;
+  stampMetal: MetalSynth;
+  stampPaper: NoiseSynth;
+  stampPaperLp: Filter;
+  // press clank KRUNCH
+  clankNoise: NoiseSynth;
+  clankBp: Filter;
+  clankThock: Synth;
+  // newsprint KRAKA-THOOM
+  newsMembrane: MembraneSynth;
+  newsBody: FMSynth;
+  newsTele: NoiseSynth;
+  newsTeleHp: Filter;
+  // title drop stamp
+  titleMembrane: MembraneSynth;
+  titleClang: Synth;
+  titleCrack: NoiseSynth;
+  // screentone edge-run launch
+  edgeMembrane: MembraneSynth;
+  edgeScreech: Synth;
+  edgeScreechBp: Filter;
+  edgeWhoosh: NoiseSynth;
+  edgeWhooshBp: Filter;
+  edgeHorn: FMSynth;
+}
+
+function buildKit(T: ToneModule, sfx: Gain): Kit {
+  // -- desk keycap clacks
+  const clackNoise = new T.NoiseSynth({
+    noise: { type: "white" },
+    envelope: { attack: 0.001, decay: 0.018, sustain: 0 },
+    volume: -12,
+  });
+  const clackBp = new T.Filter(3400, "bandpass");
+  clackNoise.chain(clackBp, sfx);
+  const clackThock = new T.Synth({
+    oscillator: { type: "triangle" },
+    envelope: { attack: 0.001, decay: 0.04, sustain: 0, release: 0.02 },
+    volume: -14,
+  });
+  clackThock.connect(sfx);
+
+  // -- neon ring zaps
+  const ringSyn = new T.Synth({
+    oscillator: { type: "square" },
+    envelope: { attack: 0.001, decay: 0.05, sustain: 0, release: 0.02 },
+    volume: -16,
+  });
+  const ringBp = new T.Filter(1500, "bandpass");
+  const ringDelay = new T.FeedbackDelay(0.03, 0.15);
+  ringDelay.wet.value = 0.25;
+  ringSyn.chain(ringBp, ringDelay, sfx);
+  const ringSnap = new T.NoiseSynth({
+    noise: { type: "white" },
+    envelope: { attack: 0.001, decay: 0.015, sustain: 0 },
+    volume: -18,
+  });
+  const ringSnapHp = new T.Filter(4000, "highpass");
+  ringSnap.chain(ringSnapHp, sfx);
+
+  // -- press part-add thumps
+  const partMembrane = new T.MembraneSynth({
+    pitchDecay: 0.05,
+    octaves: 4,
+    envelope: { attack: 0.001, decay: 0.35, sustain: 0, release: 0.08 },
+    volume: -8,
+  });
+  partMembrane.connect(sfx);
+  const partReact = new T.Synth({
+    oscillator: { type: "triangle" },
+    envelope: { attack: 0.001, decay: 0.08, sustain: 0, release: 0.03 },
+    volume: -14,
+  });
+  partReact.connect(sfx);
+  const partTs = new T.Synth({
+    oscillator: { type: "square" },
+    envelope: { attack: 0.001, decay: 0.09, sustain: 0, release: 0.03 },
+    volume: -16,
+  });
+  const partTsBp = new T.Filter(900, "bandpass");
+  partTs.chain(partTsBp, sfx);
+  const partRust = new T.MetalSynth({
+    harmonicity: 3.1,
+    resonance: 300,
+    modulationIndex: 16,
+    octaves: 1.2,
+    envelope: { attack: 0.001, decay: 0.1, release: 0.05 },
+    volume: -20,
+  });
+  partRust.connect(sfx);
+  const partAiA = new T.Synth({
+    oscillator: { type: "sine" },
+    envelope: { attack: 0.002, decay: 0.16, sustain: 0, release: 0.06 },
+    volume: -16,
+  });
+  partAiA.connect(sfx);
+  const partAiB = new T.Synth({
+    oscillator: { type: "sine" },
+    envelope: { attack: 0.002, decay: 0.16, sustain: 0, release: 0.06 },
+    volume: -18,
+  });
+  partAiB.connect(sfx);
+
+  // -- screentone far-off horn (two detuned voices a fifth apart)
+  const hornDelay = new T.FeedbackDelay(0.3, 0.3);
+  hornDelay.wet.value = 0.25;
+  const hornLp = new T.Filter(500, "lowpass");
+  hornLp.connect(hornDelay);
+  hornDelay.connect(sfx);
+  const hornEnv = { attack: 0.08, decay: 0.4, sustain: 0.2, release: 0.5 };
+  const hornA = new T.Synth({ oscillator: { type: "sine" }, envelope: hornEnv, volume: -20 });
+  const hornB = new T.Synth({ oscillator: { type: "triangle" }, envelope: hornEnv, volume: -22 });
+  hornA.connect(hornLp);
+  hornB.connect(hornLp);
+
+  // -- pop 360 whoosh + crowd (continuous, started on demand)
+  const popWhooshGain = new T.Gain(0);
+  const popWhooshBp = new T.Filter(300, "bandpass");
+  const popWhoosh = new T.Noise({ type: "pink", volume: -18 });
+  popWhoosh.chain(popWhooshBp, popWhooshGain, sfx);
+  const crowdGain = new T.Gain(0);
+  const crowdLp = new T.Filter(600, "lowpass");
+  crowdLp.connect(crowdGain);
+  crowdGain.connect(sfx);
+  const crowdA = new T.Oscillator({ frequency: 110, type: "sawtooth", volume: -18 });
+  const crowdB = new T.Oscillator({ frequency: 165, type: "sawtooth", volume: -20 });
+  const crowdC = new T.Oscillator({ frequency: 220, type: "sawtooth", volume: -22 });
+  crowdA.connect(crowdLp);
+  crowdB.connect(crowdLp);
+  crowdC.connect(crowdLp);
+  const hushLp = new T.Filter(1200, "lowpass");
+  const hushNoise = new T.Noise({ type: "white", volume: -26 });
+  hushNoise.chain(hushLp, crowdGain);
+
+  // -- sketch ink ticks + wash flood
+  const inkTick = new T.NoiseSynth({
+    noise: { type: "white" },
+    envelope: { attack: 0.001, decay: 0.01, sustain: 0 },
+    volume: -16,
+  });
+  const inkTickHp = new T.Filter(3800, "highpass");
+  inkTick.chain(inkTickHp, sfx);
+  const washNoise = new T.NoiseSynth({
+    noise: { type: "pink" },
+    envelope: { attack: 0.3, decay: 0.4, sustain: 0 },
+    volume: -18,
+  });
+  const washLp = new T.Filter(400, "lowpass");
+  washNoise.chain(washLp, sfx);
+  const washSine = new T.Synth({
+    oscillator: { type: "sine" },
+    envelope: { attack: 0.02, decay: 0.5, sustain: 0, release: 0.3 },
+    volume: -18,
+  });
+  washSine.connect(sfx);
+
+  // -- spread star-chart arp (also reused by origin-portal)
+  const starDelay = new T.FeedbackDelay(0.28, 0.4);
+  starDelay.wet.value = 0.35;
+  starDelay.connect(sfx);
+  const starBell = new T.FMSynth({
+    harmonicity: 2,
+    modulationIndex: 3,
+    oscillator: { type: "sine" },
+    modulation: { type: "triangle" },
+    envelope: { attack: 0.005, decay: 0.5, sustain: 0, release: 0.6 },
+    modulationEnvelope: { attack: 0.005, decay: 0.4, sustain: 0, release: 0.4 },
+    volume: -18,
+  });
+  starBell.connect(starDelay);
+
+  // -- kaching donation (kachPop reused by sketch-print-run + back-cover)
+  const kachEnv = { attack: 0.001, decay: 0.35, sustain: 0, release: 0.2 };
+  const kachA = new T.FMSynth({ harmonicity: 5.1, modulationIndex: 28, envelope: kachEnv, volume: -12 });
+  const kachB = new T.FMSynth({ harmonicity: 5.1, modulationIndex: 28, envelope: kachEnv, volume: -13 });
+  kachA.connect(sfx);
+  kachB.connect(sfx);
+  const kachDrawer = new T.NoiseSynth({
+    noise: { type: "white" },
+    envelope: { attack: 0.001, decay: 0.07, sustain: 0 },
+    volume: -20,
+  });
+  const kachDrawerBp = new T.Filter(2200, "bandpass");
+  kachDrawer.chain(kachDrawerBp, sfx);
+  const kachPop = new T.NoiseSynth({
+    noise: { type: "pink" },
+    envelope: { attack: 0.05, decay: 0.4, sustain: 0 },
+    volume: -22,
+  });
+  const kachPopLp = new T.Filter(800, "lowpass");
+  kachPop.chain(kachPopLp, sfx);
+  const coin = new T.Synth({
+    oscillator: { type: "triangle" },
+    envelope: { attack: 0.001, decay: 0.06, sustain: 0, release: 0.03 },
+    volume: -18,
+  });
+  coin.connect(sfx);
+
+  // -- press die-slam (stampMembrane reused by terminal-back-cover)
+  const stampMembrane = new T.MembraneSynth({
+    pitchDecay: 0.05,
+    octaves: 4,
+    envelope: { attack: 0.001, decay: 0.5, sustain: 0, release: 0.1 },
+    volume: -6,
+  });
+  stampMembrane.connect(sfx);
+  const stampMetal = new T.MetalSynth({
+    harmonicity: 3.2,
+    resonance: 400,
+    modulationIndex: 20,
+    octaves: 1.4,
+    envelope: { attack: 0.001, decay: 0.12, release: 0.05 },
+    volume: -16,
+  });
+  stampMetal.connect(sfx);
+  const stampPaper = new T.NoiseSynth({
+    noise: { type: "pink" },
+    envelope: { attack: 0.001, decay: 0.12, sustain: 0 },
+    volume: -16,
+  });
+  const stampPaperLp = new T.Filter(1200, "lowpass");
+  stampPaper.chain(stampPaperLp, sfx);
+
+  // -- press clank KRUNCH
+  const clankNoise = new T.NoiseSynth({
+    noise: { type: "white" },
+    envelope: { attack: 0.001, decay: 0.12, sustain: 0 },
+    volume: -10,
+  });
+  const clankBp = new T.Filter({ frequency: 600, type: "bandpass", Q: 3 });
+  clankNoise.chain(clankBp, sfx);
+  const clankThock = new T.Synth({
+    oscillator: { type: "square" },
+    envelope: { attack: 0.001, decay: 0.15, sustain: 0, release: 0.04 },
+    volume: -12,
+  });
+  clankThock.connect(sfx);
+
+  // -- newsprint KRAKA-THOOM (no bright transient by design; bright world)
+  const newsMembrane = new T.MembraneSynth({
+    pitchDecay: 0.1,
+    octaves: 4,
+    envelope: { attack: 0.002, decay: 0.6, sustain: 0, release: 0.1 },
+    volume: -7,
+  });
+  newsMembrane.connect(sfx);
+  const newsBody = new T.FMSynth({
+    harmonicity: 1.5,
+    modulationIndex: 6,
+    envelope: { attack: 0.002, decay: 0.25, sustain: 0, release: 0.1 },
+    volume: -12,
+  });
+  newsBody.connect(sfx);
+  const newsTele = new T.NoiseSynth({
+    noise: { type: "white" },
+    envelope: { attack: 0.001, decay: 0.01, sustain: 0 },
+    volume: -14,
+  });
+  const newsTeleHp = new T.Filter(3200, "highpass");
+  newsTele.chain(newsTeleHp, sfx);
+
+  // -- title drop stamp
+  const titleMembrane = new T.MembraneSynth({
+    pitchDecay: 0.06,
+    octaves: 5,
+    envelope: { attack: 0.001, decay: 0.45, sustain: 0, release: 0.1 },
+    volume: -6,
+  });
+  titleMembrane.connect(sfx);
+  const titleClang = new T.Synth({
+    oscillator: { type: "square" },
+    envelope: { attack: 0.001, decay: 0.12, sustain: 0, release: 0.05 },
+    volume: -16,
+  });
+  titleClang.connect(sfx);
+  const titleCrack = new T.NoiseSynth({
+    noise: { type: "white" },
+    envelope: { attack: 0.001, decay: 0.03, sustain: 0 },
+    volume: -14,
+  });
+  titleCrack.connect(sfx);
+
+  // -- screentone edge-run launch (edgeWhoosh reused by pop-orbit-360)
+  const edgeMembrane = new T.MembraneSynth({
+    pitchDecay: 0.04,
+    octaves: 3,
+    envelope: { attack: 0.001, decay: 0.12, sustain: 0, release: 0.04 },
+    volume: -10,
+  });
+  edgeMembrane.connect(sfx);
+  const edgeScreech = new T.Synth({
+    oscillator: { type: "sawtooth" },
+    envelope: { attack: 0.01, decay: 0.3, sustain: 0, release: 0.05 },
+    volume: -20,
+  });
+  const edgeScreechBp = new T.Filter({ frequency: 1200, type: "bandpass", Q: 2 });
+  edgeScreech.chain(edgeScreechBp, sfx);
+  const edgeWhoosh = new T.NoiseSynth({
+    noise: { type: "pink" },
+    envelope: { attack: 0.05, decay: 0.3, sustain: 0 },
+    volume: -16,
+  });
+  const edgeWhooshBp = new T.Filter(400, "bandpass");
+  edgeWhoosh.chain(edgeWhooshBp, sfx);
+  const edgeHorn = new T.FMSynth({
+    harmonicity: 1.5,
+    modulationIndex: 8,
+    envelope: { attack: 0.02, decay: 0.3, sustain: 0, release: 0.1 },
+    volume: -16,
+  });
+  edgeHorn.connect(sfx);
+
+  return {
+    clackNoise, clackBp, clackThock,
+    ringSyn, ringBp, ringDelay, ringSnap, ringSnapHp,
+    partMembrane, partReact, partTs, partTsBp, partRust, partAiA, partAiB,
+    hornA, hornB, hornLp, hornDelay,
+    popWhoosh, popWhooshBp, popWhooshGain, crowdA, crowdB, crowdC, crowdLp, crowdGain, hushNoise, hushLp,
+    inkTick, inkTickHp, washNoise, washLp, washSine,
+    starBell, starDelay,
+    kachA, kachB, kachDrawer, kachDrawerBp, kachPop, kachPopLp, coin,
+    stampMembrane, stampMetal, stampPaper, stampPaperLp,
+    clankNoise, clankBp, clankThock,
+    newsMembrane, newsBody, newsTele, newsTeleHp,
+    titleMembrane, titleClang, titleCrack,
+    edgeMembrane, edgeScreech, edgeScreechBp, edgeWhoosh, edgeWhooshBp, edgeHorn,
+  };
+}
+
+/* ---------------------------------------------------------- module state --- */
+let kit: Kit | null = null;
+let TM: ToneModule | null = null;
+
+const clackEdges = Array.from({ length: 6 }, () => new Edge());
+const partEdges = Array.from({ length: 4 }, () => new Edge());
+const stationEdges = Array.from({ length: 8 }, () => new Edge());
+const inkEdges = Array.from({ length: 6 }, () => new Edge());
+const washEdge = new Edge();
+const starEdges = Array.from({ length: 10 }, () => new Edge());
+const allEdges: Edge[] = [...clackEdges, ...partEdges, ...stationEdges, ...inkEdges, washEdge, ...starEdges];
+
+// neon cascade: step-increment latch (own priming; scrub-back re-arms silent)
+let neonPrimed = false;
+let neonLast = -1;
+
+// pop 360 continuous bed
+let popOn = false;
+let popQuiet = 0;
+const gWhoosh = { v: 0 };
+const gCrowd = { v: 0 };
+const fWhooshC = { v: 300 };
+
+/* --------------------------------------------- score-reaction one-shots --- */
+function fireClack(k: Kit, now: number, i: number): void {
+  k.clackNoise.triggerAttackRelease(0.018, now, 0.6 + 0.2 * h01(i * 7 + 1));
+  const f = 180 + ((hash(i * 5 + 2) % 61) - 30); // 180 +/- 30 Hz, hashed
+  k.clackThock.triggerAttackRelease(f, 0.04, now, 0.7 + 0.2 * h01(i + 3));
+}
+
+function fireRing(k: Kit, now: number, ring: number): void {
+  const note = 196 * Math.pow(2, ring / 12); // climb the cascade
+  k.ringBp.frequency.rampTo(1500 + 1700 * (ring / 10), 0.02, now);
+  let vel = 0.4 + 0.3 * h01(ring * 3 + 1);
+  if (ring === 10) vel = Math.min(1, vel * 2); // hero tower +6 dB
+  k.ringSyn.triggerAttackRelease(note, 0.05, now, vel);
+  if (ring % 2 === 1) k.ringSnap.triggerAttackRelease(0.015, now, 0.4);
+}
+
+function firePart(k: Kit, now: number, i: number): void {
+  k.partMembrane.triggerAttackRelease("F1", 0.12, now, 0.9);
+  if (i === 0) k.partReact.triggerAttackRelease(660, 0.08, now, 0.6);
+  else if (i === 1) k.partTs.triggerAttackRelease(440, 0.09, now, 0.6);
+  else if (i === 2) k.partRust.triggerAttackRelease(0.1, now, 0.6);
+  else {
+    k.partAiA.triggerAttackRelease(523.25, 0.12, now, 0.4);
+    k.partAiB.triggerAttackRelease(783.99, 0.12, now, 0.4);
+  }
+}
+
+function fireHorn(k: Kit, now: number): void {
+  k.hornA.triggerAttackRelease(155, 0.6, now, 0.7);
+  k.hornB.triggerAttackRelease(233, 0.6, now, 0.6);
+}
+
+function fireInk(k: Kit, now: number, i: number): void {
+  k.inkTick.triggerAttackRelease(0.01, now, 0.4 + 0.3 * h01(i * 9 + 1));
+}
+
+function fireWash(k: Kit, now: number): void {
+  k.washLp.frequency.cancelScheduledValues(now);
+  k.washLp.frequency.setValueAtTime(400, now);
+  k.washLp.frequency.linearRampToValueAtTime(2000, now + 0.3);
+  k.washNoise.triggerAttackRelease(0.5, now, 0.5);
+  k.washSine.triggerAttackRelease(110, 0.5, now, 0.4);
+}
+
+function fireStar(k: Kit, now: number, page: number): void {
+  k.starBell.triggerAttackRelease(PENTA[page]!, 0.5, now, 0.4 + 0.2 * h01(page + 1));
+}
+
+/* --------------------------------------------------------- scoreMoments --- */
+/** Called once per director rAF tick while audio is enabled. */
+export function scoreMoments(
+  T: ToneModule,
+  sfx: Gain,
+  t: number,
+  dtSec: number,
+  velocity: number,
+): void {
+  void velocity; // reactions are pure f(t); velocity is unused here by design
+  const k = kit ?? (kit = buildKit(T, sfx));
+  if (!TM) TM = T;
+  const now = T.now();
+
+  // -- desk keycap clacks (issue 2): 6 CLACKs on the visible keycap dips
+  const kw = KEYS_R[1] - KEYS_R[0];
+  for (let i = 0; i < 6; i++) {
+    if (clackEdges[i]!.crossed(t, KEYS_R[0] + CLACK_FRACS[i]! * kw, CLACK_HYST)) fireClack(k, now, i);
+  }
+
+  // -- neon ring zaps (issue 3): same 0..10 quantization as the visual boot.
+  // step -1 below the cascade so ring 0 (the boom) is a real forward increment.
+  const step =
+    t < NEON_CASCADE_T
+      ? -1
+      : Math.min(10, Math.floor(clamp01((t - NEON_CASCADE_T) / (NEON_CASCADE_END - NEON_CASCADE_T)) * 11));
+  if (!neonPrimed) {
+    neonPrimed = true;
+    neonLast = step;
+  } else if (step > neonLast) {
+    fireRing(k, now, step); // fire the newly reached ring only -- no burst
+    neonLast = step;
+  } else if (step < neonLast) {
+    neonLast = step; // scrub-back re-arms silently
+  }
+
+  // -- press part-add thumps (issue 5): 4 departments welding on
+  for (let i = 0; i < 4; i++) {
+    if (partEdges[i]!.crossed(t, PRESS_PART_T[i]!, PART_HYST)) firePart(k, now, i);
+  }
+
+  // -- screentone far-off horn (issue 7): arrival at each station, moving only
+  const tx = trainX(t);
+  for (let i = 0; i < 8; i++) {
+    if (stationEdges[i]!.crossed(tx, STATION_X[i]!, STATION_HYST) && trainSpeed(t) > 0.2) fireHorn(k, now);
+  }
+
+  // -- pop 360 whoosh + crowd (issue 8): continuous, pure f(t) both directions
+  const tLocal8 = clamp01((t - POP_RANGE[0]) / (POP_RANGE[1] - POP_RANGE[0]));
+  const pp = clamp01((tLocal8 - ORBIT_F) / (1 - ORBIT_F));
+  const spd = Math.min(1, 6 * pp * (1 - pp)); // d/dp easeInOut, peaks mid-spin
+  const swell = Math.sin(Math.PI * pp);
+  const popActive = pp > 0.0001 && pp < 0.9999 && (spd > 0.002 || swell > 0.002);
+  if (popActive) {
+    if (!popOn) {
+      k.popWhoosh.start();
+      k.crowdA.start();
+      k.crowdB.start();
+      k.crowdC.start();
+      k.hushNoise.start();
+      popOn = true;
+    }
+    popQuiet = 0;
+    moveTo(k.popWhooshBp.frequency, fWhooshC, 300 + 900 * swell, 0.05, 20);
+  } else if (popOn) {
+    popQuiet += dtSec;
+    if (popQuiet > 0.3) {
+      k.popWhoosh.stop();
+      k.crowdA.stop();
+      k.crowdB.stop();
+      k.crowdC.stop();
+      k.hushNoise.stop();
+      popOn = false;
+    }
+  }
+  moveTo(k.popWhooshGain.gain, gWhoosh, popActive ? spd : 0, 0.05, 0.01);
+  moveTo(k.crowdGain.gain, gCrowd, popActive ? swell * 0.7 : 0, 0.06, 0.01);
+
+  // -- sketch ink ticks + wash flood (issue 9)
+  const u9 = inkAt(t);
+  for (let i = 0; i < 6; i++) {
+    if (inkEdges[i]!.crossed(u9, 0.16 + i * 0.075, INK_HYST)) fireInk(k, now, i);
+  }
+  if (washEdge.crossed(u9, FLOOD_U, INK_HYST)) fireWash(k, now);
+
+  // -- spread star-chart arp (issue 10): one shimmer per page reveal, stops at 10
+  const u10 = clamp01((t - UNFOLD_RANGE[0]) / (UNFOLD_RANGE[1] - UNFOLD_RANGE[0]));
+  for (let i = 0; i < 10; i++) {
+    if (starEdges[i]!.crossed(u10, i * 0.055, STAR_HYST)) fireStar(k, now, i);
+  }
+}
+
+/* ----------------------------------------------------------- beatMoment --- */
+/**
+ * setBeatSound handler. Returns true when a moment owns the hit (a custom
+ * sound OR a deliberate silence), false to fall through to the caller's
+ * default thump/chime. Silent until scoreMoments has built the kit under an
+ * enabled director -- the gesture gate is inherited.
+ */
+export function beatMoment(id: string, flash: number): boolean {
+  const T = TM;
+  const k = kit;
+  if (!T || !k) return false;
+  const now = T.now();
+  const v = Math.min(Math.max(flash, 0), 1);
+
+  switch (id) {
+    case "pop-donation": {
+      const vel = 0.5 + 0.5 * v;
+      k.kachA.triggerAttackRelease("E6", 0.35, now, vel);
+      k.kachB.triggerAttackRelease("G#6", 0.35, now + 0.06, vel);
+      k.kachDrawer.triggerAttackRelease(0.07, now, 0.5);
+      k.kachPopLp.frequency.rampTo(800, 0.02, now);
+      k.kachPop.triggerAttackRelease(0.4, now, 0.5);
+      k.coin.triggerAttackRelease("B6", 0.05, now + 0.12, 0.4);
+      k.coin.triggerAttackRelease("D7", 0.05, now + 0.18, 0.4);
+      k.coin.triggerAttackRelease("G7", 0.05, now + 0.24, 0.4);
+      return true;
+    }
+    case "press-stamp": {
+      k.stampMembrane.triggerAttackRelease("G0", 0.5, now, v);
+      k.stampMetal.triggerAttackRelease(0.12, now, 0.8 * v);
+      k.stampPaperLp.frequency.rampTo(1200, 0.02, now);
+      k.stampPaper.triggerAttackRelease(0.12, now, 0.6);
+      k.stampMetal.triggerAttackRelease(0.1, now + 0.07, 0.4); // rebound tick
+      return true;
+    }
+    case "press-clank": {
+      k.clankNoise.triggerAttackRelease(0.12, now, 0.7);
+      k.clankThock.triggerAttackRelease(90, 0.15, now, 0.7);
+      return true;
+    }
+    case "newsprint-flood": {
+      k.newsMembrane.triggerAttackRelease("E1", 0.6, now, 0.6);
+      k.newsBody.triggerAttackRelease(55, 0.4, now, 0.5);
+      const seed = 101;
+      const count = 8 + Math.floor(h01(seed) * 5); // 8..12 teletype clicks
+      let ti = now + 0.02;
+      let gap = 0.05;
+      for (let i = 0; i < count; i++) {
+        k.newsTele.triggerAttackRelease(0.01, ti, 0.3 + 0.25 * h01(seed + i * 3));
+        gap = gap * 0.82 + 0.003 * h01(seed * 7 + i); // accelerating + jitter
+        ti += Math.max(gap, 0.012);
+      }
+      return true;
+    }
+    case "title-drop": {
+      k.titleMembrane.triggerAttackRelease("A1", 0.3, now, v);
+      k.titleClang.triggerAttackRelease(660, 0.12, now, 0.5 * v);
+      k.titleCrack.triggerAttackRelease(0.03, now, 0.5 * v);
+      return true;
+    }
+    case "screentone-edge-run": {
+      let ti = now; // accelerating wheel clatter 8 -> 16 Hz
+      const hits = 7;
+      for (let i = 0; i < hits; i++) {
+        k.edgeMembrane.triggerAttackRelease("A1", 0.08, ti, (0.5 + 0.2 * h01(i + 1)) * v);
+        ti += 1 / (8 + 8 * (i / (hits - 1)));
+      }
+      k.edgeScreech.triggerAttackRelease(300, 0.3, now, 0.5 * v); // wheel screech
+      k.edgeScreech.frequency.rampTo(700, 0.28, now + 0.01);
+      k.edgeWhooshBp.frequency.cancelScheduledValues(now); // rising doppler
+      k.edgeWhooshBp.frequency.setValueAtTime(400, now);
+      k.edgeWhooshBp.frequency.linearRampToValueAtTime(3000, now + 0.3);
+      k.edgeWhoosh.triggerAttackRelease(0.35, now, 0.6 * v);
+      k.edgeHorn.triggerAttackRelease(110, 0.3, now, 0.5 * v); // low horn
+      return true;
+    }
+    case "origin-portal": {
+      k.starBell.triggerAttackRelease(440, 0.9, now, 0.35); // airy pad into the tail
+      return true;
+    }
+    case "sketch-print-run": {
+      k.kachPopLp.frequency.rampTo(500, 0.02, now);
+      k.kachPop.triggerAttackRelease(0.4, now, 0.35); // near-silent roller finish
+      return true;
+    }
+    case "terminal-back-cover": {
+      k.stampMembrane.triggerAttackRelease("C2", 0.3, now, 0.4); // soft book close
+      k.kachPopLp.frequency.rampTo(300, 0.02, now);
+      k.kachPop.triggerAttackRelease(0.3, now, 0.4); // "fwump"
+      return true;
+    }
+    case "pop-orbit-360": {
+      k.edgeWhooshBp.frequency.cancelScheduledValues(now); // doppler swoop 500->2500->500
+      k.edgeWhooshBp.frequency.setValueAtTime(500, now);
+      k.edgeWhooshBp.frequency.linearRampToValueAtTime(2500, now + 0.25);
+      k.edgeWhooshBp.frequency.linearRampToValueAtTime(500, now + 0.5);
+      k.edgeWhoosh.triggerAttackRelease(0.5, now, 0.6);
+      return true;
+    }
+    case "neon-cascade":
+      return true; // rings own the audio -- deliberate silence (visual flash stays)
+    default:
+      return false; // unrouted: caller plays its default thump/chime
+  }
+}
+
+/* ----------------------------------------------------------- stopMoments --- */
+/** Disable path: silence + stop continuous sources, re-prime all latches. */
+export function stopMoments(): void {
+  for (const e of allEdges) e.reset();
+  neonPrimed = false;
+  neonLast = -1;
+  const k = kit;
+  if (!k) return;
+  gWhoosh.v = 0;
+  gCrowd.v = 0;
+  k.popWhooshGain.gain.rampTo(0, 0.1);
+  k.crowdGain.gain.rampTo(0, 0.1);
+  if (popOn) {
+    k.popWhoosh.stop();
+    k.crowdA.stop();
+    k.crowdB.stop();
+    k.crowdC.stop();
+    k.hushNoise.stop();
+    popOn = false;
+  }
+}

--- a/lib/audio/recipes.ts
+++ b/lib/audio/recipes.ts
@@ -1,0 +1,474 @@
+import type { ToneAudioNode } from "tone";
+import { audioRecipes, type AudioRecipe, type ToneModule } from "./types";
+import { h01, hash, moveTo, Stepper } from "./util";
+
+/**
+ * Wave B: the 12 per-issue ambiences (audioRecipes slots, indexed like
+ * issues/registry.ts). Imported for side effect by the director. Rules:
+ * - Tone only via the T module handed to build() (never a static import)
+ * - all timing/pattern variation hashes an integer step of T.now() -- no
+ *   Math.random anywhere; patterns survive stop()/start() cleanly
+ * - param moves via moveTo() (rampTo on real target changes only)
+ * - one-shots via triggerAttackRelease at T.now()
+ * - these are AMBIENCES: out gains sit far below the master ceiling
+ * - 3-8 nodes per recipe; no allocations inside update()
+ */
+
+interface Built {
+  out: ToneAudioNode;
+  nodes: { dispose(): void }[];
+  start?: () => void;
+  stop?: () => void;
+  update?: (tLocal: number, dtSec: number, velocity: number) => void;
+}
+
+function defineRecipe(build: (T: ToneModule) => Built): AudioRecipe {
+  let b: Built | null = null;
+  return {
+    build(T) {
+      b = build(T);
+      return b.out;
+    },
+    start() {
+      b?.start?.();
+    },
+    stop() {
+      b?.stop?.();
+    },
+    update(tLocal, dtSec, velocity) {
+      b?.update?.(tLocal, dtSec, velocity);
+    },
+    dispose() {
+      if (!b) return;
+      for (const n of b.nodes) n.dispose();
+      b = null;
+    },
+  };
+}
+
+/* ---- 0 Cover: soft print-shop room tone, near-silent (ruling) ----------- */
+audioRecipes[0] = defineRecipe((T) => {
+  const noise = new T.Noise("brown");
+  const lp = new T.Filter(260, "lowpass");
+  const out = new T.Gain(0.05);
+  noise.chain(lp, out);
+  return {
+    out,
+    nodes: [noise, lp, out],
+    start: () => noise.start(),
+    stop: () => noise.stop(),
+  };
+});
+
+/* ---- 1 Noir: vinyl crackle + distant brushed drums ----------------------- */
+audioRecipes[1] = defineRecipe((T) => {
+  const out = new T.Gain(0.2);
+  const crackle = new T.NoiseSynth({
+    noise: { type: "white" },
+    envelope: { attack: 0.001, decay: 0.03, sustain: 0 },
+    volume: -14,
+  });
+  const crackleHp = new T.Filter(2000, "highpass");
+  crackle.chain(crackleHp, out);
+  const brush = new T.Noise("pink");
+  const brushLp = new T.Filter(480, "lowpass");
+  const swell = new T.Gain(0.1);
+  brush.chain(brushLp, swell, out);
+  const ticks = new Stepper(9);
+  const bars = new Stepper(0.6);
+  const sw = { v: 0.1 };
+  return {
+    out,
+    nodes: [crackle, crackleHp, brush, brushLp, swell, out],
+    start: () => {
+      ticks.reset();
+      bars.reset();
+      brush.start();
+    },
+    stop: () => brush.stop(),
+    update: () => {
+      const now = T.now();
+      const s = ticks.tick(now);
+      if (s >= 0 && h01(s * 3 + 1) < 0.24)
+        crackle.triggerAttackRelease(0.02, now, 0.25 + 0.5 * h01(s * 7 + 2));
+      const b = bars.tick(now);
+      // slow brushed swells: mostly on, an occasional dropped bar breathes
+      if (b >= 0)
+        moveTo(swell.gain, sw, hash(b) % 4 === 0 ? 0.08 : 0.35 + 0.35 * h01(b * 5 + 3), 1.1, 0.01);
+    },
+  };
+});
+
+/* ---- 2 Desk: warm room tone + mechanical key switches -------------------- */
+audioRecipes[2] = defineRecipe((T) => {
+  const out = new T.Gain(0.16);
+  const room = new T.Noise({ type: "brown", volume: -10 });
+  const roomLp = new T.Filter(420, "lowpass");
+  room.chain(roomLp, out);
+  const key = new T.NoiseSynth({
+    noise: { type: "white" },
+    envelope: { attack: 0.001, decay: 0.02, sustain: 0 },
+    volume: -10,
+  });
+  const keyBp = new T.Filter(3400, "bandpass");
+  key.chain(keyBp, out);
+  const clock = new Stepper(9);
+  return {
+    out,
+    nodes: [room, roomLp, key, keyBp, out],
+    start: () => {
+      clock.reset();
+      room.start();
+    },
+    stop: () => room.stop(),
+    update: () => {
+      const now = T.now();
+      const s = clock.tick(now);
+      if (s < 0) return;
+      // typing comes in hash-gated bursts (~2.7 s windows), not a metronome
+      const typing = h01(Math.floor(s / 24) * 11 + 5) < 0.55;
+      if (typing && h01(s * 13 + 1) < 0.55)
+        key.triggerAttackRelease(0.012, now, 0.2 + 0.4 * h01(s + 3));
+    },
+  };
+});
+
+/* ---- 3 Neon: stuttering glitch synth (sound only) ------------------------ */
+const NEON_NOTES = [110, 146.83, 220, 293.66, 440];
+audioRecipes[3] = defineRecipe((T) => {
+  const out = new T.Gain(0.13);
+  const synth = new T.Synth({
+    oscillator: { type: "square" },
+    envelope: { attack: 0.002, decay: 0.07, sustain: 0, release: 0.03 },
+    volume: -12,
+  });
+  const lp = new T.Filter(2200, "lowpass");
+  synth.chain(lp, out);
+  const clock = new Stepper(8);
+  const fc = { v: 2200 };
+  return {
+    out,
+    nodes: [synth, lp, out],
+    start: () => clock.reset(),
+    stop: () => {
+      /* one-shot synth; nothing continuous */
+    },
+    update: (tLocal) => {
+      const now = T.now();
+      // filter opens across the issue -- pure f(t), scrub-safe
+      moveTo(lp.frequency, fc, 1600 + 1400 * tLocal, 0.12, 60);
+      const s = clock.tick(now);
+      if (s < 0) return;
+      if (h01((s >> 3) * 5 + 2) < 0.25) return; // glitch dropout bar
+      if (h01(s * 7 + 1) >= 0.62) return; // per-step gate
+      // pitch holds for 4 steps -> stutter feel on one note, then jumps
+      const note = NEON_NOTES[hash(s >> 2) % NEON_NOTES.length]!;
+      synth.triggerAttackRelease(note, 0.05, now, 0.35 + 0.3 * h01(s + 9));
+    },
+  };
+});
+
+/* ---- 4 Origin: muted valley -- low wind + sparse music box (ruling) ------ */
+const BOX_NOTES = ["C6", "E6", "G6", "A6", "D6"];
+audioRecipes[4] = defineRecipe((T) => {
+  const out = new T.Gain(0.07);
+  const wind = new T.Noise("pink");
+  const windLp = new T.Filter(220, "lowpass");
+  wind.chain(windLp, out);
+  const gust = new T.LFO(0.07, 130, 330);
+  gust.connect(windLp.frequency);
+  const box = new T.Synth({
+    oscillator: { type: "sine" },
+    envelope: { attack: 0.002, decay: 0.5, sustain: 0, release: 0.6 },
+    volume: -10,
+  });
+  const shimmer = new T.FeedbackDelay(0.45, 0.35);
+  shimmer.wet.value = 0.3;
+  box.chain(shimmer, out);
+  const clock = new Stepper(0.7);
+  return {
+    out,
+    nodes: [wind, windLp, gust, box, shimmer, out],
+    start: () => {
+      clock.reset();
+      wind.start();
+      gust.start();
+    },
+    stop: () => {
+      wind.stop();
+      gust.stop();
+    },
+    update: () => {
+      const now = T.now();
+      const s = clock.tick(now);
+      if (s >= 0 && h01(s * 5 + 1) < 0.42)
+        box.triggerAttackRelease(BOX_NOTES[hash(s) % BOX_NOTES.length]!, 0.4, now, 0.25);
+    },
+  };
+});
+
+/* ---- 5 Press: rhythmic press thumps + steam puffs (ruling) --------------- */
+audioRecipes[5] = defineRecipe((T) => {
+  const out = new T.Gain(0.25);
+  const thump = new T.MembraneSynth({
+    pitchDecay: 0.06,
+    octaves: 3.5,
+    envelope: { attack: 0.002, decay: 0.3, sustain: 0, release: 0.08 },
+    volume: -8,
+  });
+  thump.connect(out);
+  const steam = new T.NoiseSynth({
+    noise: { type: "white" },
+    envelope: { attack: 0.05, decay: 0.3, sustain: 0 },
+    volume: -16,
+  });
+  const steamBp = new T.Filter(1400, "bandpass");
+  steam.chain(steamBp, out);
+  const clock = new Stepper(2.2);
+  return {
+    out,
+    nodes: [thump, steam, steamBp, out],
+    start: () => clock.reset(),
+    stop: () => {
+      /* one-shots only */
+    },
+    update: () => {
+      const now = T.now();
+      const s = clock.tick(now);
+      if (s < 0) return;
+      // dum-DUM-dum-rest press cycle; steam vents on a longer period
+      if (s % 4 !== 3)
+        thump.triggerAttackRelease("F1", 0.12, now, (s % 4 === 0 ? 0.85 : 0.4) + 0.1 * h01(s));
+      if (s % 8 === 5) steam.triggerAttackRelease(0.25, now, 0.5 + 0.3 * h01(s * 3 + 1));
+    },
+  };
+});
+
+/* ---- 6 Newsprint: paper rustle + teletype click bursts ------------------- */
+audioRecipes[6] = defineRecipe((T) => {
+  const out = new T.Gain(0.18);
+  const rustle = new T.NoiseSynth({
+    noise: { type: "pink" },
+    envelope: { attack: 0.06, decay: 0.22, sustain: 0 },
+    volume: -14,
+  });
+  const rustleBp = new T.Filter(1900, "bandpass");
+  rustle.chain(rustleBp, out);
+  const tele = new T.NoiseSynth({
+    noise: { type: "white" },
+    envelope: { attack: 0.001, decay: 0.012, sustain: 0 },
+    volume: -10,
+  });
+  const teleHp = new T.Filter(3200, "highpass");
+  tele.chain(teleHp, out);
+  const clock = new Stepper(13);
+  return {
+    out,
+    nodes: [rustle, rustleBp, tele, teleHp, out],
+    start: () => clock.reset(),
+    stop: () => {
+      /* one-shots only */
+    },
+    update: () => {
+      const now = T.now();
+      const s = clock.tick(now);
+      if (s < 0) return;
+      // teletype: ~1.5 s hash-gated burst windows of rapid clicks
+      const burst = h01(Math.floor(s / 20) * 7 + 3) < 0.45;
+      if (burst && h01(s * 11 + 4) < 0.8) tele.triggerAttackRelease(0.01, now, 0.25 + 0.3 * h01(s + 6));
+      if (hash(s) % 41 === 13) rustle.triggerAttackRelease(0.18, now, 0.4 + 0.3 * h01(s * 5 + 2));
+    },
+  };
+});
+
+/* ---- 7 Screentone: subway rail rhythm, tempo-locked to the boil grid ----- */
+/**
+ * The shader line boil steps at 10 Hz: components/PostPipeline.tsx drives
+ * uBoilJitter/uStepSeed with stepNoise(elapsed, 10, *). The rail clock runs
+ * on the same 10 Hz grid so every wheel hit lands exactly on a boil step;
+ * the ka-thunk pair sits on adjacent steps every 8 steps (0.8 s bogie period).
+ */
+const RAIL_HZ = 10;
+audioRecipes[7] = defineRecipe((T) => {
+  const out = new T.Gain(0.22);
+  const wheel = new T.MembraneSynth({
+    pitchDecay: 0.03,
+    octaves: 2.5,
+    envelope: { attack: 0.001, decay: 0.16, sustain: 0, release: 0.05 },
+    volume: -8,
+  });
+  wheel.connect(out);
+  const rail = new T.Noise({ type: "brown", volume: -20 });
+  const railBp = new T.Filter(320, "bandpass");
+  rail.chain(railBp, out);
+  const clock = new Stepper(RAIL_HZ);
+  return {
+    out,
+    nodes: [wheel, rail, railBp, out],
+    start: () => {
+      clock.reset();
+      rail.start();
+    },
+    stop: () => rail.stop(),
+    update: () => {
+      const now = T.now();
+      const s = clock.tick(now);
+      if (s < 0) return;
+      const pos = s % 8;
+      if (pos === 0) wheel.triggerAttackRelease("D2", 0.05, now, 0.3 + 0.1 * h01(s)); // ka
+      else if (pos === 1) wheel.triggerAttackRelease("A1", 0.1, now, 0.7 + 0.15 * h01(s + 4)); // thunk
+    },
+  };
+});
+
+/* ---- 8 Pop: bright chiptune arp + sparse chat blips ----------------------- */
+const POP_NOTES = [261.63, 329.63, 392, 523.25, 659.25];
+const POP_PAT = [0, 2, 1, 3, 2, 4, 3, 1];
+audioRecipes[8] = defineRecipe((T) => {
+  const out = new T.Gain(0.13);
+  const arp = new T.Synth({
+    oscillator: { type: "square" },
+    envelope: { attack: 0.002, decay: 0.09, sustain: 0, release: 0.04 },
+    volume: -14,
+  });
+  arp.connect(out);
+  const blip = new T.Synth({
+    oscillator: { type: "sine" },
+    envelope: { attack: 0.001, decay: 0.05, sustain: 0, release: 0.03 },
+    volume: -14,
+  });
+  blip.connect(out);
+  const clock = new Stepper(7.5);
+  return {
+    out,
+    nodes: [arp, blip, out],
+    start: () => clock.reset(),
+    stop: () => {
+      /* one-shots only */
+    },
+    update: () => {
+      const now = T.now();
+      const s = clock.tick(now);
+      if (s < 0) return;
+      // fixed 8-step arp figure; whole 16-step phrases occasionally rest
+      if (h01((s >> 4) * 9 + 2) < 0.85)
+        arp.triggerAttackRelease(POP_NOTES[POP_PAT[s % 8]!]!, 0.06, now, 0.5);
+      if (hash(s) % 29 === 11)
+        blip.triggerAttackRelease(h01(s + 4) < 0.5 ? 987.77 : 1318.51, 0.05, now, 0.4);
+    },
+  };
+});
+
+/* ---- 9 Sketchbook: pencil scratch riding |velocity| ----------------------- */
+audioRecipes[9] = defineRecipe((T) => {
+  const out = new T.Gain(0.3);
+  const scratch = new T.Noise("white");
+  const hp = new T.Filter(3800, "highpass");
+  const g = new T.Gain(0);
+  scratch.chain(hp, g, out);
+  const gs = { v: 0 };
+  const fs = { v: 3800 };
+  return {
+    out,
+    nodes: [scratch, hp, g, out],
+    start: () => scratch.start(),
+    stop: () => scratch.stop(),
+    update: (_tLocal, _dtSec, velocity) => {
+      // graphite only speaks when the reader draws the page: gain ~ |v|^2
+      const a = Math.min(1, Math.abs(velocity) * 1.5);
+      moveTo(g.gain, gs, a * a, 0.06, 0.01);
+      moveTo(hp.frequency, fs, 3200 + 2200 * a, 0.08, 120);
+    },
+  };
+});
+
+/* ---- 10 Spread: airy FM pads, slow, wide (FeedbackDelay space) ------------ */
+const SPREAD_CHORDS: readonly [number, number][] = [
+  [130.81, 196],
+  [146.83, 220],
+  [98, 164.81],
+  [123.47, 185],
+];
+const SPREAD_RATE = 0.12; // chord change ~every 8.3 s
+audioRecipes[10] = defineRecipe((T) => {
+  const out = new T.Gain(0.18);
+  const space = new T.FeedbackDelay(0.6, 0.45);
+  space.wet.value = 0.35;
+  space.connect(out);
+  const panL = new T.Panner(-0.5).connect(space);
+  const panR = new T.Panner(0.5).connect(space);
+  const padA = new T.FMSynth({
+    harmonicity: 2,
+    modulationIndex: 2.2,
+    envelope: { attack: 2.5, decay: 1.5, sustain: 0.6, release: 3.5 },
+    modulationEnvelope: { attack: 3, decay: 1, sustain: 0.4, release: 3 },
+    volume: -16,
+  }).connect(panL);
+  const padB = new T.FMSynth({
+    harmonicity: 1.5,
+    modulationIndex: 1.8,
+    envelope: { attack: 3, decay: 1.5, sustain: 0.5, release: 4 },
+    modulationEnvelope: { attack: 2.5, decay: 1, sustain: 0.5, release: 3 },
+    volume: -16,
+  }).connect(panR);
+  const clock = new Stepper(SPREAD_RATE);
+  const fire = (s: number, now: number): void => {
+    const c = SPREAD_CHORDS[hash(s) % SPREAD_CHORDS.length]!;
+    padA.triggerAttackRelease(c[0], 6.5, now, 0.45);
+    padB.triggerAttackRelease(c[1], 6.5, now + 0.4, 0.4);
+  };
+  return {
+    out,
+    nodes: [space, panL, panR, padA, padB, out],
+    start: () => {
+      clock.reset();
+      // fire the current chord immediately -- the clock period is far too
+      // long to wait for its first edge (still deterministic: hash of step)
+      const now = T.now();
+      fire(Math.floor(now * SPREAD_RATE), now);
+    },
+    stop: () => {
+      /* long releases decay on their own */
+    },
+    update: () => {
+      const now = T.now();
+      const s = clock.tick(now);
+      if (s >= 0) fire(s, now);
+    },
+  };
+});
+
+/* ---- 11 Terminal: mains hum + sparse terminal beeps ----------------------- */
+audioRecipes[11] = defineRecipe((T) => {
+  const out = new T.Gain(0.09);
+  const hum = new T.Oscillator({ frequency: 50, type: "sine", volume: -10 });
+  const hum2 = new T.Oscillator({ frequency: 100, type: "sine", volume: -24 });
+  hum.connect(out);
+  hum2.connect(out);
+  const beep = new T.Synth({
+    oscillator: { type: "square" },
+    envelope: { attack: 0.002, decay: 0.07, sustain: 0, release: 0.02 },
+    volume: -14,
+  });
+  beep.connect(out);
+  const clock = new Stepper(0.55);
+  return {
+    out,
+    nodes: [hum, hum2, beep, out],
+    start: () => {
+      clock.reset();
+      hum.start();
+      hum2.start();
+    },
+    stop: () => {
+      hum.stop();
+      hum2.stop();
+    },
+    update: () => {
+      const now = T.now();
+      const s = clock.tick(now);
+      if (s >= 0 && h01(s * 3 + 1) < 0.38)
+        beep.triggerAttackRelease(hash(s) % 3 === 0 ? 1318.51 : 880, 0.06, now, 0.5);
+    },
+  };
+});

--- a/lib/audio/transitions.ts
+++ b/lib/audio/transitions.ts
@@ -1,0 +1,135 @@
+import type { Filter, Gain, Noise, Oscillator } from "tone";
+import { clamp01 } from "@/lib/shots";
+import { RANGES } from "@/issues/timeline";
+import type { ToneModule } from "./types";
+import { moveTo } from "./util";
+
+/**
+ * Wave B: scored transitions. Pure f(t, velocity) gains on the sfx bus,
+ * driven once per director loop tick (the single call site). Scrub-safe both
+ * directions: everything is windowed on the gutter's t-range, nothing is
+ * event-armed. Sub-thumps stay with the beat hook -- never doubled here.
+ *
+ * Gutters derived from issues/timeline.ts RANGES (never hardcoded):
+ * - riser: Desk -> Neon dot-zoom gutter (pitch + cutoff climb with progress)
+ * - whoosh: Noir -> Desk title whip and Pop -> Sketchbook whip; gain =
+ *   gutter-progress bell x |velocity|, so a parked scrub stays silent
+ */
+
+const DOT_ZOOM: readonly [number, number] = [RANGES[2]![1], RANGES[3]![0]];
+const WHIPS: readonly (readonly [number, number])[] = [
+  [RANGES[1]![1], RANGES[2]![0]], // noir -> desk title whip
+  [RANGES[8]![1], RANGES[9]![0]], // pop -> sketchbook whip
+];
+
+/** Sources idle this long at zero gain before they are stopped. */
+const QUIET_STOP_S = 0.3;
+
+interface Rig {
+  riser: Oscillator;
+  riserLp: Filter;
+  riserGain: Gain;
+  whoosh: Noise;
+  whooshBp: Filter;
+  whooshGain: Gain;
+}
+
+let rig: Rig | null = null;
+let riserOn = false;
+let whooshOn = false;
+let riserQuiet = 0;
+let whooshQuiet = 0;
+const gR = { v: 0 };
+const gW = { v: 0 };
+const fFreq = { v: 70 };
+const fLp = { v: 320 };
+const fBp = { v: 380 };
+
+function build(T: ToneModule, sfx: Gain): Rig {
+  const riser = new T.Oscillator({ frequency: 70, type: "sawtooth", volume: -10 });
+  const riserLp = new T.Filter(320, "lowpass");
+  const riserGain = new T.Gain(0);
+  riser.chain(riserLp, riserGain, sfx);
+  const whoosh = new T.Noise("pink");
+  const whooshBp = new T.Filter(380, "bandpass");
+  const whooshGain = new T.Gain(0);
+  whoosh.chain(whooshBp, whooshGain, sfx);
+  return { riser, riserLp, riserGain, whoosh, whooshBp, whooshGain };
+}
+
+/** Called once per director rAF tick while audio is enabled. */
+export function scoreTransitions(
+  T: ToneModule,
+  sfx: Gain,
+  t: number,
+  dtSec: number,
+  velocity: number,
+): void {
+  if (!rig) rig = build(T, sfx);
+
+  // riser into the dot-zoom: gain and pitch are pure functions of gutter
+  // progress (backwards scrub = falling riser, equally valid)
+  const p = clamp01((t - DOT_ZOOM[0]) / (DOT_ZOOM[1] - DOT_ZOOM[0]));
+  const inRiser = t > DOT_ZOOM[0] && t < DOT_ZOOM[1];
+  const riserTarget = inRiser ? p * p * 0.4 : 0;
+  if (riserTarget > 0.001) {
+    if (!riserOn) {
+      rig.riser.start();
+      riserOn = true;
+    }
+    riserQuiet = 0;
+    moveTo(rig.riser.frequency, fFreq, 70 * Math.pow(2, 2.6 * p), 0.05, 1.5);
+    moveTo(rig.riserLp.frequency, fLp, 320 + 2400 * p * p, 0.05, 25);
+  } else if (riserOn) {
+    riserQuiet += dtSec;
+    if (riserQuiet > QUIET_STOP_S) {
+      rig.riser.stop();
+      riserOn = false;
+    }
+  }
+  moveTo(rig.riserGain.gain, gR, riserTarget, 0.05, 0.008);
+
+  // whoosh on the whip gutters: bell envelope x |velocity|
+  let bell = 0;
+  for (let i = 0; i < WHIPS.length; i++) {
+    const w = WHIPS[i]!;
+    if (t > w[0] && t < w[1]) {
+      bell = Math.sin(Math.PI * clamp01((t - w[0]) / (w[1] - w[0])));
+      break;
+    }
+  }
+  const whooshTarget = bell * Math.min(Math.abs(velocity), 1) * 0.55;
+  if (whooshTarget > 0.001) {
+    if (!whooshOn) {
+      rig.whoosh.start();
+      whooshOn = true;
+    }
+    whooshQuiet = 0;
+    moveTo(rig.whooshBp.frequency, fBp, 380 + 2600 * bell, 0.05, 30);
+  } else if (whooshOn) {
+    whooshQuiet += dtSec;
+    if (whooshQuiet > QUIET_STOP_S) {
+      rig.whoosh.stop();
+      whooshOn = false;
+    }
+  }
+  moveTo(rig.whooshGain.gain, gW, whooshTarget, 0.04, 0.008);
+}
+
+/** Disable path: silence + stop sources (instances kept; restart is cheap). */
+export function stopTransitions(): void {
+  const r = rig;
+  if (!r) return;
+  gR.v = 0;
+  gW.v = 0;
+  r.riserGain.gain.rampTo(0, 0.1);
+  r.whooshGain.gain.rampTo(0, 0.1);
+  if (riserOn) {
+    r.riser.stop();
+    riserOn = false;
+  }
+  if (whooshOn) {
+    r.whoosh.stop();
+    whooshOn = false;
+  }
+}

--- a/lib/audio/transitions.ts
+++ b/lib/audio/transitions.ts
@@ -14,6 +14,14 @@ import { moveTo } from "./util";
  * - riser: Desk -> Neon dot-zoom gutter (pitch + cutoff climb with progress)
  * - whoosh: Noir -> Desk title whip and Pop -> Sketchbook whip; gain =
  *   gutter-progress bell x |velocity|, so a parked scrub stays silent
+ *
+ * Phase 4 enrichment: 8 more gutter voices + 1 global page-riffle complete
+ * all 11 gutters. Each new voice is a pooled Noise/Osc/Filter/Gain built once,
+ * driven pure f(t[,velocity]) via moveTo(), and quiet-stopped when idle like
+ * the whoosh. Percussive accents (crash punch-through, stamp metal contact,
+ * tear flap, dot-match resolve) fire once on a forward gutter-progress
+ * crossing with hysteresis re-arm (BeatRunner idiom) -- idempotent both
+ * directions and deep-jump safe (a single fire, never a catch-up burst).
  */
 
 const DOT_ZOOM: readonly [number, number] = [RANGES[2]![1], RANGES[3]![0]];
@@ -25,6 +33,516 @@ const WHIPS: readonly (readonly [number, number])[] = [
 /** Sources idle this long at zero gain before they are stopped. */
 const QUIET_STOP_S = 0.3;
 
+// ---- new-voice shared helpers -------------------------------------------
+
+/** Anything with start()/stop() -- Tone sources (Noise/Oscillator/LFO). */
+type Src = { start(): void; stop(): void };
+interface Gate {
+  on: boolean;
+  quiet: number;
+}
+interface Cross {
+  init: boolean;
+  armed: boolean;
+  last: number;
+}
+interface Voice {
+  update(t: number, dtSec: number, velocity: number): void;
+  stop(): void;
+}
+
+const bell = (p: number): number => Math.sin(Math.PI * p);
+const tri = (p: number, c: number, w: number): number => clamp01(1 - Math.abs(p - c) / w);
+/** Gutter i->j window = [range i end, range j start] (never hardcoded). */
+const win = (a: number, b: number): readonly [number, number] => [RANGES[a]![1], RANGES[b]![0]];
+
+/** whoosh-style start/quiet-stop for a group of pooled sources (no alloc). */
+function runGate(g: Gate, active: boolean, dt: number, srcs: readonly Src[]): void {
+  if (active) {
+    if (!g.on) {
+      for (const s of srcs) s.start();
+      g.on = true;
+    }
+    g.quiet = 0;
+  } else if (g.on) {
+    g.quiet += dt;
+    if (g.quiet > QUIET_STOP_S) {
+      for (const s of srcs) s.stop();
+      g.on = false;
+    }
+  }
+}
+
+/**
+ * BeatRunner hysteresis as pure module state: true once, on a forward cross
+ * of `trig`; re-arms only after `value` retreats below trig - hyst. First
+ * sighting primes without firing (no retroactive hit on a mid-page load);
+ * a deep jump across the trigger fires exactly once (no catch-up burst).
+ */
+function crossFwd(c: Cross, value: number, trig: number, hyst: number): boolean {
+  if (!c.init) {
+    c.init = true;
+    c.armed = value < trig;
+    c.last = value;
+    return false;
+  }
+  const last = c.last;
+  c.last = value;
+  if (c.armed && last < trig && value >= trig) {
+    c.armed = false;
+    return true;
+  }
+  if (!c.armed && value < trig - hyst) c.armed = true;
+  return false;
+}
+
+// ---- gutter windows ------------------------------------------------------
+
+const CRASH = win(0, 1); // 0->1 cover crash-through (+ absorbed crash-tear)
+const PWIPE = win(3, 4); // 3->4 panel-wipe swish
+const PORTAL = win(4, 5); // 4->5 panel-portal glide
+const STAMP = win(5, 6); // 5->6 stamp cut
+const TEAR = win(6, 7); // 6->7 paper-tear
+const FLIP = win(7, 8); // 7->8 page-flip world-turn
+const INK = win(9, 10); // 9->10 ink-flood to black
+const DOTM = win(10, 11); // 10->11 dot-match twinkle-zip
+
+// ---- new gutter voices ---------------------------------------------------
+
+/** 0->1 crash-through-cover: paper burst + punch body + membrane/chirp hit. */
+function buildCrash(T: ToneModule, sfx: Gain): Voice {
+  const w = CRASH;
+  const burst = new T.Noise("white");
+  const burstBp = new T.Filter(900, "bandpass");
+  burstBp.Q.value = 1.2;
+  const burstGain = new T.Gain(0);
+  burst.chain(burstBp, burstGain, sfx);
+  const body = new T.Oscillator({ frequency: 140, type: "sine", volume: -6 });
+  const bodyLp = new T.Filter(200, "lowpass");
+  const bodyGain = new T.Gain(0);
+  body.chain(bodyLp, bodyGain, sfx);
+  const crash = new T.MembraneSynth({
+    pitchDecay: 0.1,
+    octaves: 4,
+    envelope: { attack: 0.002, decay: 0.3, sustain: 0, release: 0.1 },
+    volume: -9,
+  });
+  crash.connect(sfx);
+  const chirp = new T.Synth({
+    oscillator: { type: "square" },
+    envelope: { attack: 0.001, decay: 0.18, sustain: 0, release: 0.05 },
+    volume: -14,
+  });
+  chirp.connect(sfx);
+  const g: Gate = { on: false, quiet: 0 };
+  const srcs: Src[] = [burst, body];
+  const cx: Cross = { init: false, armed: true, last: 0 };
+  const gB = { v: 0 };
+  const gY = { v: 0 };
+  const fB = { v: 900 };
+  const fY = { v: 140 };
+  return {
+    update(t, dt, velocity) {
+      const p = clamp01((t - w[0]) / (w[1] - w[0]));
+      const inw = t > w[0] && t < w[1];
+      const av = Math.min(Math.abs(velocity), 1);
+      const bt = tri(p, 0.4, 0.35);
+      const burstT = inw ? Math.min(tri(p, 0.3, 0.3) * tri(p, 0.3, 0.3) * av, 0.5) : 0;
+      const bodyT = inw ? Math.min(bt * bt * (0.4 + 0.6 * av), 0.4) : 0;
+      runGate(g, burstT > 0.001 || bodyT > 0.001, dt, srcs);
+      moveTo(burstBp.frequency, fB, 900 + 1700 * p, 0.05, 20);
+      moveTo(body.frequency, fY, 140 - 80 * p, 0.05, 1);
+      moveTo(burstGain.gain, gB, burstT, 0.04, 0.008);
+      moveTo(bodyGain.gain, gY, bodyT, 0.04, 0.008);
+      if (crossFwd(cx, p, 0.3, 0.1) && av > 0.05) {
+        const now = T.now();
+        crash.triggerAttackRelease("C1", 0.3, now, 0.5 * av);
+        chirp.triggerAttackRelease(300, 0.18, now, 0.5 * av);
+        chirp.frequency.rampTo(80, 0.18, now);
+      }
+    },
+    stop() {
+      gB.v = 0;
+      gY.v = 0;
+      burstGain.gain.rampTo(0, 0.1);
+      bodyGain.gain.rampTo(0, 0.1);
+      if (g.on) {
+        for (const s of srcs) s.stop();
+        g.on = false;
+      }
+    },
+  };
+}
+
+/** 3->4 panel-wipe: crisp high bandpass swipe, bell x |velocity|. */
+function buildPanelWipe(T: ToneModule, sfx: Gain): Voice {
+  const w = PWIPE;
+  const noise = new T.Noise("white");
+  const bp = new T.Filter(1500, "bandpass");
+  bp.Q.value = 2.5;
+  const gain = new T.Gain(0);
+  noise.chain(bp, gain, sfx);
+  const g: Gate = { on: false, quiet: 0 };
+  const srcs: Src[] = [noise];
+  const gC = { v: 0 };
+  const fC = { v: 1500 };
+  return {
+    update(t, dt, velocity) {
+      const p = clamp01((t - w[0]) / (w[1] - w[0]));
+      const inw = t > w[0] && t < w[1];
+      const av = Math.min(Math.abs(velocity), 1);
+      const target = inw ? Math.min(bell(p) * av, 0.35) : 0;
+      runGate(g, target > 0.001, dt, srcs);
+      moveTo(bp.frequency, fC, 1500 + 2500 * p, 0.05, 25);
+      moveTo(gain.gain, gC, target, 0.04, 0.008);
+    },
+    stop() {
+      gC.v = 0;
+      gain.gain.rampTo(0, 0.1);
+      if (g.on) {
+        noise.stop();
+        g.on = false;
+      }
+    },
+  };
+}
+
+/** 4->5 panel-portal: ethereal glide tone + air through a delay tail (no vel gate). */
+function buildPortal(T: ToneModule, sfx: Gain): Voice {
+  const w = PORTAL;
+  const delay = new T.FeedbackDelay(0.2, 0.25);
+  delay.wet.value = 0.25;
+  delay.connect(sfx);
+  const glide = new T.Oscillator({ frequency: 300, type: "sine", volume: -8 });
+  const glideLp = new T.Filter(600, "lowpass");
+  const glideGain = new T.Gain(0);
+  glide.chain(glideLp, glideGain, delay);
+  const air = new T.Noise("pink");
+  const airBp = new T.Filter(2000, "bandpass");
+  const airGain = new T.Gain(0);
+  air.chain(airBp, airGain, delay);
+  const g: Gate = { on: false, quiet: 0 };
+  const srcs: Src[] = [glide, air];
+  const gG = { v: 0 };
+  const gA = { v: 0 };
+  const fG = { v: 300 };
+  const fL = { v: 600 };
+  return {
+    update(t, dt) {
+      const p = clamp01((t - w[0]) / (w[1] - w[0]));
+      const inw = t > w[0] && t < w[1];
+      const b = bell(p);
+      const gT = inw ? Math.pow(b, 0.8) * 0.3 : 0;
+      const aT = inw ? b * 0.12 : 0;
+      runGate(g, gT > 0.001 || aT > 0.001, dt, srcs);
+      moveTo(glide.frequency, fG, 300 + 600 * p, 0.05, 5);
+      moveTo(glideLp.frequency, fL, 600 + 2400 * p, 0.06, 25);
+      moveTo(glideGain.gain, gG, gT, 0.05, 0.008);
+      moveTo(airGain.gain, gA, aT, 0.05, 0.008);
+    },
+    stop() {
+      gG.v = 0;
+      gA.v = 0;
+      glideGain.gain.rampTo(0, 0.1);
+      airGain.gain.rampTo(0, 0.1);
+      if (g.on) {
+        for (const s of srcs) s.stop();
+        g.on = false;
+      }
+    },
+  };
+}
+
+/** 5->6 stamp cut: ka-chunk body + metal-contact transient + pneumatic hiss. */
+function buildStamp(T: ToneModule, sfx: Gain): Voice {
+  const w = STAMP;
+  const chunk = new T.Oscillator({ frequency: 220, type: "square", volume: -8 });
+  const chunkBp = new T.Filter(800, "bandpass");
+  chunkBp.Q.value = 2;
+  const chunkGain = new T.Gain(0);
+  chunk.chain(chunkBp, chunkGain, sfx);
+  const metal = new T.NoiseSynth({
+    noise: { type: "white" },
+    envelope: { attack: 0.001, decay: 0.02, sustain: 0 },
+    volume: -8,
+  });
+  metal.connect(sfx);
+  const air = new T.Noise("white");
+  const airHp = new T.Filter(3000, "highpass");
+  const airGain = new T.Gain(0);
+  air.chain(airHp, airGain, sfx);
+  const g: Gate = { on: false, quiet: 0 };
+  const srcs: Src[] = [chunk, air];
+  const cx: Cross = { init: false, armed: true, last: 0 };
+  const gC = { v: 0 };
+  const gA = { v: 0 };
+  const fC = { v: 220 };
+  return {
+    update(t, dt, velocity) {
+      const p = clamp01((t - w[0]) / (w[1] - w[0]));
+      const inw = t > w[0] && t < w[1];
+      const av = Math.min(Math.abs(velocity), 1);
+      const ct = tri(p, 0.32, 0.28);
+      const chunkT = inw ? Math.min(Math.pow(ct, 4) * av, 0.5) : 0;
+      const airT = inw ? clamp01((p - 0.4) / 0.6) * 0.25 : 0; // not vel-gated: hiss lingers
+      runGate(g, chunkT > 0.001 || airT > 0.001, dt, srcs);
+      moveTo(chunk.frequency, fC, 220 - 70 * p, 0.05, 2);
+      moveTo(chunkGain.gain, gC, chunkT, 0.03, 0.008);
+      moveTo(airGain.gain, gA, airT, 0.05, 0.008);
+      if (crossFwd(cx, p, 0.32, 0.1) && av > 0.05)
+        metal.triggerAttackRelease(0.01, T.now(), 0.5 * av);
+    },
+    stop() {
+      gC.v = 0;
+      gA.v = 0;
+      chunkGain.gain.rampTo(0, 0.1);
+      airGain.gain.rampTo(0, 0.1);
+      if (g.on) {
+        for (const s of srcs) s.stop();
+        g.on = false;
+      }
+    },
+  };
+}
+
+/** 6->7 paper-tear: rising bandpass tear line (ripple texture) + late flap. */
+function buildTear(T: ToneModule, sfx: Gain): Voice {
+  const w = TEAR;
+  const noise = new T.Noise("pink");
+  const bp = new T.Filter(1200, "bandpass");
+  bp.Q.value = 1;
+  const gain = new T.Gain(0);
+  noise.chain(bp, gain, sfx);
+  const flap = new T.NoiseSynth({
+    noise: { type: "brown" },
+    envelope: { attack: 0.002, decay: 0.12, sustain: 0 },
+    volume: -8,
+  });
+  const flapLp = new T.Filter(300, "lowpass");
+  flap.chain(flapLp, sfx);
+  const g: Gate = { on: false, quiet: 0 };
+  const srcs: Src[] = [noise];
+  const cx: Cross = { init: false, armed: true, last: 0 };
+  const gC = { v: 0 };
+  const fC = { v: 1200 };
+  const fQ = { v: 1 };
+  return {
+    update(t, dt, velocity) {
+      const p = clamp01((t - w[0]) / (w[1] - w[0]));
+      const inw = t > w[0] && t < w[1];
+      const av = Math.min(Math.abs(velocity), 1);
+      // sin ripple is amplitude texture (depth 0.4, well under strobe threshold)
+      const ripple = 0.6 + 0.4 * Math.abs(Math.sin(40 * Math.PI * p));
+      const target = inw ? Math.min(Math.pow(p, 0.6) * ripple * av, 0.45) : 0;
+      runGate(g, target > 0.001, dt, srcs);
+      moveTo(bp.frequency, fC, 1200 + 2300 * p, 0.05, 25);
+      moveTo(bp.Q, fQ, 1 + 2 * p, 0.08, 0.05);
+      moveTo(gain.gain, gC, target, 0.04, 0.008);
+      if (crossFwd(cx, p, 0.85, 0.08) && av > 0.05)
+        flap.triggerAttackRelease(0.14, T.now(), 0.4 * av);
+    },
+    stop() {
+      gC.v = 0;
+      gain.gain.rampTo(0, 0.1);
+      if (g.on) {
+        noise.stop();
+        g.on = false;
+      }
+    },
+  };
+}
+
+/** 7->8 page-flip: early flutter flap (page catching air) + late whoosh tail. */
+function buildFlip(T: ToneModule, sfx: Gain): Voice {
+  const w = FLIP;
+  const noise = new T.Noise("pink");
+  const flapBp = new T.Filter(700, "bandpass");
+  const flapGain = new T.Gain(0);
+  noise.chain(flapBp, flapGain, sfx);
+  const whBp = new T.Filter(400, "bandpass");
+  const whGain = new T.Gain(0);
+  noise.connect(whBp);
+  whBp.connect(whGain);
+  whGain.connect(sfx);
+  const g: Gate = { on: false, quiet: 0 };
+  const srcs: Src[] = [noise];
+  const gF = { v: 0 };
+  const gW = { v: 0 };
+  const fW = { v: 400 };
+  return {
+    update(t, dt, velocity) {
+      const p = clamp01((t - w[0]) / (w[1] - w[0]));
+      const inw = t > w[0] && t < w[1];
+      const av = Math.min(Math.abs(velocity), 1);
+      const flapT = inw ? Math.min(tri(p, 0.28, 0.22) * (0.7 + 0.3 * Math.sin(12 * Math.PI * p)), 0.4) : 0;
+      const whT = inw ? Math.min(bell(p) * (0.3 + 0.7 * p) * av, 0.4) : 0;
+      runGate(g, flapT > 0.001 || whT > 0.001, dt, srcs);
+      moveTo(whBp.frequency, fW, 400 + 2000 * p, 0.05, 25);
+      moveTo(flapGain.gain, gF, flapT, 0.04, 0.008);
+      moveTo(whGain.gain, gW, whT, 0.04, 0.008);
+    },
+    stop() {
+      gF.v = 0;
+      gW.v = 0;
+      flapGain.gain.rampTo(0, 0.1);
+      whGain.gain.rampTo(0, 0.1);
+      if (g.on) {
+        noise.stop();
+        g.on = false;
+      }
+    },
+  };
+}
+
+/** 9->10 ink-flood: sub swell + dark liquid gulp, resolves to true silence (no vel gate). */
+function buildInk(T: ToneModule, sfx: Gain): Voice {
+  const w = INK;
+  const sub = new T.Oscillator({ frequency: 50, type: "sine", volume: -6 });
+  const subLp = new T.Filter(400, "lowpass");
+  const subGain = new T.Gain(0);
+  sub.chain(subLp, subGain, sfx);
+  const gulp = new T.Noise("brown");
+  const gulpLp = new T.Filter(300, "lowpass");
+  const gulpGain = new T.Gain(0);
+  gulp.chain(gulpLp, gulpGain, sfx);
+  const g: Gate = { on: false, quiet: 0 };
+  const srcs: Src[] = [sub, gulp];
+  const gS = { v: 0 };
+  const gGl = { v: 0 };
+  const fS = { v: 400 };
+  const fGl = { v: 300 };
+  return {
+    update(t, dt) {
+      const p = clamp01((t - w[0]) / (w[1] - w[0]));
+      const inw = t > w[0] && t < w[1];
+      const swell = inw ? Math.min(clamp01(p / 0.65), clamp01((1 - p) / 0.35)) : 0;
+      runGate(g, swell > 0.001, dt, srcs);
+      moveTo(subLp.frequency, fS, 400 - 310 * p, 0.06, 15); // muffling into black
+      moveTo(gulpLp.frequency, fGl, 300 - 220 * p, 0.06, 10);
+      moveTo(subGain.gain, gS, swell * 0.4, 0.06, 0.008);
+      moveTo(gulpGain.gain, gGl, swell * 0.3, 0.06, 0.008);
+    },
+    stop() {
+      gS.v = 0;
+      gGl.v = 0;
+      subGain.gain.rampTo(0, 0.1);
+      gulpGain.gain.rampTo(0, 0.1);
+      if (g.on) {
+        for (const s of srcs) s.stop();
+        g.on = false;
+      }
+    },
+  };
+}
+
+/** 10->11 dot-match: twinkle partials (9Hz shimmer) + zip, resolving to a cursor sine. */
+function buildDotMatch(T: ToneModule, sfx: Gain): Voice {
+  const w = DOTM;
+  const pa = new T.Oscillator({ frequency: 400, type: "sine", volume: -12 });
+  const pb = new T.Oscillator({ frequency: 600, type: "sine", volume: -12 });
+  const twBp = new T.Filter(800, "bandpass");
+  const shim = new T.Gain(0); // 9Hz shimmer, LFO-driven (base 0 + LFO = [0.65, 1])
+  const twGain = new T.Gain(0); // bell envelope
+  const shimLfo = new T.LFO(9, 0.65, 1);
+  pa.connect(twBp);
+  pb.connect(twBp);
+  twBp.chain(shim, twGain, sfx);
+  shimLfo.connect(shim.gain);
+  const zip = new T.Noise("white");
+  const zipHp = new T.Filter(2000, "highpass");
+  const zipGain = new T.Gain(0);
+  zip.chain(zipHp, zipGain, sfx);
+  const resolve = new T.Synth({
+    oscillator: { type: "sine" },
+    envelope: { attack: 0.005, decay: 0.15, sustain: 0, release: 0.05 },
+    volume: -14,
+  });
+  resolve.connect(sfx);
+  const g: Gate = { on: false, quiet: 0 };
+  const srcs: Src[] = [pa, pb, zip, shimLfo];
+  const cx: Cross = { init: false, armed: true, last: 0 };
+  const gT = { v: 0 };
+  const gZ = { v: 0 };
+  const fA = { v: 400 };
+  const fBb = { v: 600 };
+  const fT = { v: 800 };
+  const fZ = { v: 2000 };
+  return {
+    update(t, dt, velocity) {
+      const p = clamp01((t - w[0]) / (w[1] - w[0]));
+      const inw = t > w[0] && t < w[1];
+      const av = Math.min(Math.abs(velocity), 1);
+      const b = bell(p);
+      const twT = inw ? Math.min(b * (0.5 + 0.5 * av) * 0.3, 0.3) : 0;
+      const zpT = inw ? b * 0.15 : 0;
+      runGate(g, twT > 0.001 || zpT > 0.001, dt, srcs);
+      moveTo(pa.frequency, fA, 400 + 1200 * p, 0.05, 8);
+      moveTo(pb.frequency, fBb, 600 + 1800 * p, 0.05, 8);
+      moveTo(twBp.frequency, fT, 800 + 2200 * p, 0.05, 25);
+      moveTo(zipHp.frequency, fZ, 2000 + 4000 * p, 0.05, 40);
+      moveTo(twGain.gain, gT, twT, 0.04, 0.008);
+      moveTo(zipGain.gain, gZ, zpT, 0.04, 0.008);
+      // collapse the twinkle onto a single held ~1600Hz sine = the cursor
+      if (crossFwd(cx, p, 0.92, 0.05) && av > 0.03)
+        resolve.triggerAttackRelease(1600, 0.15, T.now(), 0.3 * (0.5 + 0.5 * av));
+    },
+    stop() {
+      gT.v = 0;
+      gZ.v = 0;
+      twGain.gain.rampTo(0, 0.1);
+      zipGain.gain.rampTo(0, 0.1);
+      if (g.on) {
+        for (const s of srcs) s.stop();
+        g.on = false;
+      }
+    },
+  };
+}
+
+/**
+ * Global page-riffle: fast flings / deep-jump momentum fan the pages. Threshold
+ * hysteresis (arm > 0.45, re-arm < 0.38) keeps normal reading silent; sits
+ * under every per-issue bed; symmetric on back-scrub. Tremolo = one pooled LFO
+ * on a gain (depth 0.5 -- a page-fan flutter, never a strobe).
+ */
+function buildRiffle(T: ToneModule, sfx: Gain): Voice {
+  const noise = new T.Noise("pink");
+  const bp = new T.Filter(1600, "bandpass");
+  const trem = new T.Gain(0); // LFO-driven flutter (base 0 + LFO = [0.5, 1])
+  const master = new T.Gain(0); // |velocity| envelope
+  const lfo = new T.LFO(10, 0.5, 1);
+  noise.chain(bp, trem, master, sfx);
+  lfo.connect(trem.gain);
+  const g: Gate = { on: false, quiet: 0 };
+  const srcs: Src[] = [noise, lfo];
+  let armed = false;
+  const gM = { v: 0 };
+  const fC = { v: 1600 };
+  const fR = { v: 10 };
+  return {
+    update(_t, dt, velocity) {
+      const av = Math.abs(velocity);
+      if (av > 0.45) armed = true;
+      else if (av < 0.38) armed = false;
+      const cav = Math.min(av, 1);
+      const env = armed ? clamp01((av - 0.45) / 0.4) * 0.3 : 0;
+      runGate(g, armed, dt, srcs);
+      moveTo(bp.frequency, fC, 1600 + 1600 * cav, 0.08, 25);
+      moveTo(lfo.frequency, fR, 10 + 8 * cav, 0.08, 0.2);
+      moveTo(master.gain, gM, env, 0.05, 0.008);
+    },
+    stop() {
+      gM.v = 0;
+      armed = false;
+      master.gain.rampTo(0, 0.1);
+      if (g.on) {
+        for (const s of srcs) s.stop();
+        g.on = false;
+      }
+    },
+  };
+}
+
 interface Rig {
   riser: Oscillator;
   riserLp: Filter;
@@ -32,6 +550,7 @@ interface Rig {
   whoosh: Noise;
   whooshBp: Filter;
   whooshGain: Gain;
+  voices: Voice[];
 }
 
 let rig: Rig | null = null;
@@ -54,7 +573,18 @@ function build(T: ToneModule, sfx: Gain): Rig {
   const whooshBp = new T.Filter(380, "bandpass");
   const whooshGain = new T.Gain(0);
   whoosh.chain(whooshBp, whooshGain, sfx);
-  return { riser, riserLp, riserGain, whoosh, whooshBp, whooshGain };
+  const voices: Voice[] = [
+    buildCrash(T, sfx),
+    buildPanelWipe(T, sfx),
+    buildPortal(T, sfx),
+    buildStamp(T, sfx),
+    buildTear(T, sfx),
+    buildFlip(T, sfx),
+    buildInk(T, sfx),
+    buildDotMatch(T, sfx),
+    buildRiffle(T, sfx),
+  ];
+  return { riser, riserLp, riserGain, whoosh, whooshBp, whooshGain, voices };
 }
 
 /** Called once per director rAF tick while audio is enabled. */
@@ -90,22 +620,22 @@ export function scoreTransitions(
   moveTo(rig.riserGain.gain, gR, riserTarget, 0.05, 0.008);
 
   // whoosh on the whip gutters: bell envelope x |velocity|
-  let bell = 0;
+  let bellW = 0;
   for (let i = 0; i < WHIPS.length; i++) {
     const w = WHIPS[i]!;
     if (t > w[0] && t < w[1]) {
-      bell = Math.sin(Math.PI * clamp01((t - w[0]) / (w[1] - w[0])));
+      bellW = Math.sin(Math.PI * clamp01((t - w[0]) / (w[1] - w[0])));
       break;
     }
   }
-  const whooshTarget = bell * Math.min(Math.abs(velocity), 1) * 0.55;
+  const whooshTarget = bellW * Math.min(Math.abs(velocity), 1) * 0.55;
   if (whooshTarget > 0.001) {
     if (!whooshOn) {
       rig.whoosh.start();
       whooshOn = true;
     }
     whooshQuiet = 0;
-    moveTo(rig.whooshBp.frequency, fBp, 380 + 2600 * bell, 0.05, 30);
+    moveTo(rig.whooshBp.frequency, fBp, 380 + 2600 * bellW, 0.05, 30);
   } else if (whooshOn) {
     whooshQuiet += dtSec;
     if (whooshQuiet > QUIET_STOP_S) {
@@ -114,6 +644,9 @@ export function scoreTransitions(
     }
   }
   moveTo(rig.whooshGain.gain, gW, whooshTarget, 0.04, 0.008);
+
+  // 8 new gutter voices + the global page-riffle, each pure f(t[,velocity])
+  for (const v of rig.voices) v.update(t, dtSec, velocity);
 }
 
 /** Disable path: silence + stop sources (instances kept; restart is cheap). */
@@ -132,4 +665,5 @@ export function stopTransitions(): void {
     r.whoosh.stop();
     whooshOn = false;
   }
+  for (const v of r.voices) v.stop();
 }

--- a/lib/audio/types.ts
+++ b/lib/audio/types.ts
@@ -1,0 +1,46 @@
+import type { ToneAudioNode } from "tone";
+
+/**
+ * Phase 4 audio contracts (Wave A). Tone.js is NEVER imported statically at
+ * value level -- the director lazy-imports it on first enable and hands the
+ * module to each recipe as `T`. This file is types + the recipe slot table
+ * only, so it stays out of the server/initial bundle.
+ */
+
+/** The lazily imported tone module: `const T = await import("tone")`. */
+export type ToneModule = typeof import("tone");
+
+/**
+ * One per-issue sound design (Wave B authors these). Lifecycle, all driven
+ * by the director (lib/audio/director.ts):
+ *
+ *   build   -- called once, lazily, the first time the issue enters the
+ *              active +/-1 window while audio is enabled. Create sources /
+ *              synths / effects here and return the recipe's single output
+ *              node; the director connects it to the music bus behind a
+ *              per-issue crossfade gain it owns (recipes never touch the
+ *              destination or master chain).
+ *   start   -- (re)start continuous sources. May be called again after
+ *              stop() -- Tone sources restart fine; keep your instances.
+ *   stop    -- stop continuous sources; do NOT dispose (instances are kept
+ *              and restarted when the issue re-enters the window).
+ *   update  -- once per director rAF tick while in the active window.
+ *              tLocal is 0..1 through the issue's own range (clamped;
+ *              scrub-safe both directions), dtSec is the frame delta,
+ *              velocity is the smoothed scroll velocity ~[-1, 1].
+ *              Param moves use rampTo(), never per-frame .value writes.
+ *   dispose -- full teardown of everything built; only on engine teardown.
+ */
+export interface AudioRecipe {
+  build(T: ToneModule): ToneAudioNode;
+  start(): void;
+  stop(): void;
+  update(tLocal: number, dtSec: number, velocity: number): void;
+  dispose(): void;
+}
+
+/**
+ * Indexed like issues/registry.ts ISSUES (12 slots). null = silence for that
+ * issue (legal placeholder). Wave B fills these in place.
+ */
+export const audioRecipes: (AudioRecipe | null)[] = Array.from({ length: 12 }, () => null);

--- a/lib/audio/ui.ts
+++ b/lib/audio/ui.ts
@@ -1,0 +1,317 @@
+import type { Filter, FMSynth, Gain, MembraneSynth, Noise, NoiseSynth, Synth } from "tone";
+import { useScrollStore } from "@/lib/scrollStore";
+import type { ToneModule } from "./types";
+import { hash } from "./util";
+
+/**
+ * Wave B: UI / diegetic one-shots (event-driven, NOT f(t)). Every trigger
+ * here is a genuine user event -- a raycast/DOM click, a keystroke, or a
+ * store change (meowCount, jumpCover) -- so none are scrub-fired: there is no
+ * BeatRunner hysteresis window to arm, only per-event idempotence (the store
+ * subs guard s === prev). All variation is a Knuth hash of an integer index
+ * (util hash); no Math.random anywhere. All output rides the sfx bus the
+ * director hands us (Compressor -> Limiter master chain), mixed low.
+ *
+ * GESTURE GATE: the director calls wireUi(T, sfx) only after enableAudio()
+ * has unlocked the AudioContext. Until then `mod` is null and every uiSound /
+ * meow / catPurr call is a no-op, so scene handlers that fire pre-enable
+ * create zero AudioContext and zero output. Post-disable the master out gain
+ * is ramped to 0 by the director, so any late trigger is silent. Synths are
+ * pooled: built once, lazily, on the first real trigger; never per event.
+ */
+
+export type UiKind =
+  | "cmdOk"
+  | "cmdErr"
+  | "linkPress"
+  | "ctaPress"
+  | "openTab"
+  | "key"
+  | "keyBack"
+  | "keyEsc"
+  | "toggleOn"
+  | "toggleOff";
+
+interface Mod {
+  T: ToneModule;
+  sfx: Gain;
+}
+
+interface Pool {
+  uiBeep: Synth;
+  uiBuzz: FMSynth;
+  uiBuzzLp: Filter;
+  uiTick: Synth;
+  uiThud: MembraneSynth;
+  uiNoise: NoiseSynth;
+  uiNoiseBp: Filter;
+  swishNoise: Noise;
+  swishBp: Filter;
+  swishGain: Gain;
+  meowSynth: FMSynth;
+}
+
+let mod: Mod | null = null;
+let pool: Pool | null = null;
+let subscribed = false;
+
+/** Build the pooled synths once (lazy, on first real trigger). */
+function ensure(): Pool | null {
+  const m = mod;
+  if (!m) return null;
+  if (pool) return pool;
+  const { T, sfx } = m;
+
+  const uiBeep = new T.Synth({
+    oscillator: { type: "triangle" },
+    envelope: { attack: 0.002, decay: 0.06, sustain: 0, release: 0.05 },
+    volume: -15,
+  }).connect(sfx);
+
+  const uiBuzz = new T.FMSynth({
+    harmonicity: 1,
+    modulationIndex: 12,
+    envelope: { attack: 0.002, decay: 0.14, sustain: 0, release: 0.02 },
+    volume: -14,
+  });
+  const uiBuzzLp = new T.Filter(800, "lowpass");
+  uiBuzz.chain(uiBuzzLp, sfx);
+
+  const uiTick = new T.Synth({
+    oscillator: { type: "square" },
+    envelope: { attack: 0.001, decay: 0.012, sustain: 0, release: 0.008 },
+    volume: -20,
+  }).connect(sfx);
+
+  const uiThud = new T.MembraneSynth({
+    pitchDecay: 0.05,
+    octaves: 4,
+    envelope: { attack: 0.002, decay: 0.2, sustain: 0, release: 0.08 },
+    volume: -10,
+  }).connect(sfx);
+
+  const uiNoise = new T.NoiseSynth({
+    noise: { type: "pink" },
+    envelope: { attack: 0.001, decay: 0.03, sustain: 0 },
+    volume: -12,
+  });
+  const uiNoiseBp = new T.Filter(1200, "bandpass");
+  uiNoise.chain(uiNoiseBp, sfx);
+
+  // swish: one continuous noise gated by its own gain envelope (no per-event
+  // source alloc; two swishes never realistically overlap, and a fresh
+  // cancelScheduledValues re-arms cleanly if they do).
+  const swishNoise = new T.Noise({ type: "pink", volume: -14 });
+  const swishBp = new T.Filter(600, "bandpass");
+  const swishGain = new T.Gain(0);
+  swishNoise.chain(swishBp, swishGain, sfx);
+  swishNoise.start();
+
+  const meowSynth = new T.FMSynth({
+    harmonicity: 1.5,
+    modulationIndex: 4,
+    envelope: { attack: 0.03, decay: 0.2, sustain: 0.5, release: 0.12 },
+    modulationEnvelope: { attack: 0.05, decay: 0.2, sustain: 0.3, release: 0.1 },
+    volume: -12,
+  }).connect(sfx);
+
+  pool = {
+    uiBeep,
+    uiBuzz,
+    uiBuzzLp,
+    uiTick,
+    uiThud,
+    uiNoise,
+    uiNoiseBp,
+    swishNoise,
+    swishBp,
+    swishGain,
+    meowSynth,
+  };
+  return pool;
+}
+
+/** Fire the shared swish: sweep the bandpass startF -> endF over dur, auto-stop. */
+function swish(p: Pool, m: Mod, startF: number, endF: number, dur: number): void {
+  const now = m.T.now();
+  const g = p.swishGain.gain;
+  g.cancelScheduledValues(now);
+  g.setValueAtTime(0, now);
+  g.linearRampToValueAtTime(1, now + 0.02);
+  g.linearRampToValueAtTime(0, now + dur);
+  const f = p.swishBp.frequency;
+  f.cancelScheduledValues(now);
+  f.setValueAtTime(startF, now);
+  f.exponentialRampToValueAtTime(endF, now + dur);
+}
+
+/** Event-driven UI one-shots from scene handlers / the director. */
+export function uiSound(kind: UiKind, seed = 0): void {
+  const m = mod;
+  if (!m) return;
+  const p = ensure();
+  if (!p) return;
+  const now = m.T.now();
+  switch (kind) {
+    case "cmdOk": {
+      // two-note retro ACK; per-command pitch identity within +/- 100 cents
+      const f0 = 660 * Math.pow(2, ((seed % 201) - 100) / 1200);
+      p.uiBeep.triggerAttackRelease(f0, 0.045, now, 0.7);
+      p.uiBeep.triggerAttackRelease(f0 * 1.5, 0.05, now + 0.05, 0.7);
+      break;
+    }
+    case "cmdErr": {
+      // gritty descending bzzt through the fixed 800 Hz lowpass
+      p.uiBuzz.triggerAttack(200, now, 0.9);
+      p.uiBuzz.frequency.rampTo(150, 0.13, now);
+      p.uiBuzz.triggerRelease(now + 0.14);
+      break;
+    }
+    case "linkPress": {
+      // ka-chunk (thud) + paper snap (noise) + page opening (rising beeps)
+      p.uiThud.triggerAttackRelease("A1", 0.08, now, 0.8);
+      p.uiNoise.triggerAttackRelease(0.03, now, 0.5);
+      p.uiBeep.triggerAttackRelease(700, 0.05, now, 0.7);
+      p.uiBeep.triggerAttackRelease(1050, 0.05, now + 0.055, 0.7);
+      break;
+    }
+    case "ctaPress": {
+      // heavier manufactured press + a downward swish hinting the scroll
+      p.uiThud.triggerAttackRelease("F1", 0.1, now, 0.9);
+      p.uiNoise.triggerAttackRelease(0.03, now, 0.5);
+      swish(p, m, 1100, 450, 0.18);
+      break;
+    }
+    case "openTab": {
+      // bright rising open blip + a hair of tab detent; per-row pitch step
+      const top = 1320 * (1 + 0.03 * seed);
+      p.uiBeep.triggerAttack(880, now, 0.7);
+      p.uiBeep.frequency.rampTo(top, 0.07, now);
+      p.uiBeep.triggerRelease(now + 0.08);
+      p.uiThud.triggerAttackRelease("C2", 0.05, now, 0.55);
+      break;
+    }
+    case "key": {
+      // organic mechanical click; deterministic per-position jitter
+      p.uiTick.triggerAttackRelease(1400 + (hash(seed) % 120), 0.008, now, 0.6);
+      break;
+    }
+    case "keyBack": {
+      p.uiTick.triggerAttackRelease(900, 0.01, now, 0.4);
+      break;
+    }
+    case "keyEsc": {
+      // three quick descending ticks = "cleared"
+      p.uiTick.triggerAttackRelease(1200, 0.008, now, 0.5);
+      p.uiTick.triggerAttackRelease(900, 0.008, now + 0.03, 0.5);
+      p.uiTick.triggerAttackRelease(650, 0.008, now + 0.06, 0.5);
+      break;
+    }
+    case "toggleOn": {
+      // D5 -> A5 print-press chime; first thing the user hears
+      p.uiBeep.triggerAttackRelease(587.33, 0.05, now, 0.75);
+      p.uiBeep.triggerAttackRelease(880, 0.05, now + 0.05, 0.75);
+      break;
+    }
+    case "toggleOff": {
+      // A5 -> D5 descending, softer
+      p.uiBeep.triggerAttackRelease(880, 0.05, now, 0.55);
+      p.uiBeep.triggerAttackRelease(587.33, 0.05, now + 0.05, 0.55);
+      break;
+    }
+  }
+}
+
+/** Cat contours: 4 deterministic families selected by hash(count). */
+export function meow(count: number): void {
+  const m = mod;
+  if (!m) return;
+  const p = ensure();
+  if (!p) return;
+  const h = hash(count);
+  const fam = (h >>> 16) % 4;
+  if (fam === 3) {
+    catPurr();
+    return;
+  }
+  const now = m.T.now();
+  const s = p.meowSynth;
+  const base = 480 + (h % 200);
+  s.harmonicity.value = 1.3 + fam * 0.13;
+  if (fam === 2) {
+    // CHIRP: single short pop, low modIndex, no dip
+    s.modulationIndex.value = 2;
+    s.triggerAttackRelease(600 + (h % 120), 0.16, now, 0.8);
+    return;
+  }
+  s.modulationIndex.value = 4;
+  s.triggerAttack(base, now, 0.8);
+  if (fam === 1) {
+    // QUESTION: end freq ramps up, tail rises a touch more
+    const top = base * 1.4;
+    s.frequency.rampTo(top, 0.24, now + 0.02);
+    s.frequency.rampTo(top * 1.06, 0.08, now + 0.26);
+    s.triggerRelease(now + 0.36);
+  } else {
+    // 0 ME-OW: dip up to the peak then back down
+    s.frequency.rampTo(base * 1.32, 0.1, now + 0.02);
+    s.frequency.rampTo(base * 0.82, 0.2, now + 0.14);
+    s.triggerRelease(now + 0.38);
+  }
+}
+
+/** TRILL / PURR contour -- the purr flavor without hover (meow family 3). */
+export function catPurr(): void {
+  const m = mod;
+  if (!m) return;
+  const p = ensure();
+  if (!p) return;
+  const now = m.T.now();
+  const s = p.meowSynth;
+  const base = 300;
+  s.harmonicity.value = 1.6;
+  s.modulationIndex.value = 4;
+  s.modulationIndex.rampTo(8, 0.3, now);
+  s.triggerAttack(base, now, 0.7);
+  // two fast +/- 8% wobbles at ~18 Hz, then settle
+  s.frequency.rampTo(base * 1.08, 0.028, now);
+  s.frequency.rampTo(base * 0.92, 0.028, now + 0.028);
+  s.frequency.rampTo(base * 1.08, 0.028, now + 0.056);
+  s.frequency.rampTo(base * 0.92, 0.028, now + 0.084);
+  s.frequency.rampTo(base, 0.16, now + 0.112);
+  s.triggerRelease(now + 0.42);
+}
+
+/**
+ * Director hands us (T, sfx) here, once, post-enable. Owns the meow-variety
+ * and jump-land store subscriptions (director drops its inline meow closure).
+ * Subscriptions attach once and survive disable; they inherit the gesture
+ * gate because meow / uiSound / swish all early-return while `mod` is null,
+ * and are silent post-disable via the director's out-gain ramp.
+ */
+export function wireUi(T: ToneModule, sfx: Gain): void {
+  mod = { T, sfx };
+  if (subscribed) return;
+  subscribed = true;
+
+  // meow-variety: every cat onClick already bumps meowCount
+  useScrollStore.subscribe((s, prev) => {
+    if (s.meowCount === prev.meowCount) return;
+    meow(s.meowCount);
+  });
+
+  // jump-land: null -> N page-flip whoosh; N -> null soft landing. Guarded so
+  // it is idempotent per transition and deep-jump safe.
+  useScrollStore.subscribe((s, prev) => {
+    if (s.jumpCover === prev.jumpCover) return;
+    const m = mod;
+    if (!m) return;
+    if (prev.jumpCover === null && s.jumpCover !== null) {
+      const p = ensure();
+      if (p) swish(p, m, 300, 1800, 0.18);
+    } else if (prev.jumpCover !== null && s.jumpCover === null) {
+      const p = ensure();
+      if (p) p.uiThud.triggerAttackRelease("C2", 0.12, m.T.now(), 0.7);
+    }
+  });
+}

--- a/lib/audio/util.ts
+++ b/lib/audio/util.ts
@@ -1,0 +1,54 @@
+/**
+ * Wave B shared audio helpers. Determinism law: no Math.random anywhere --
+ * all pattern variation hashes an integer step index derived from T.now(),
+ * so patterns survive stop()/start() and are identical across sessions.
+ */
+
+/** Knuth multiplicative hash -> uint32 (same constant as the meow hash). */
+export const hash = (n: number): number => Math.imul(n, 2654435761) >>> 0;
+
+/** Deterministic 0..1 from an integer. */
+export const h01 = (n: number): number => hash(n) / 4294967296;
+
+/** Structural type for anything with rampTo (Tone Param / Signal). */
+export interface RampTarget {
+  rampTo(value: number, rampTime: number): unknown;
+}
+
+/**
+ * rampTo only on real target moves -- per-frame automation writes are banned
+ * (Wave A rule). `s.v` caches the last committed target; a hard 0 always
+ * commits so fades never strand a residual.
+ */
+export function moveTo(
+  p: RampTarget,
+  s: { v: number },
+  target: number,
+  time = 0.08,
+  eps = 0.015,
+): void {
+  if (target === s.v) return;
+  if (Math.abs(target - s.v) < eps && target > 0) return;
+  s.v = target;
+  p.rampTo(target, time);
+}
+
+/**
+ * Integer step clock over T.now(). tick() returns the step index when the
+ * clock advances, else -1. The first tick after reset() only primes (no
+ * burst of catch-up hits when an issue re-enters the active window).
+ */
+export class Stepper {
+  private last = -1;
+  constructor(private readonly rate: number) {}
+  tick(now: number): number {
+    const s = Math.floor(now * this.rate);
+    if (s === this.last) return -1;
+    const primed = this.last !== -1;
+    this.last = s;
+    return primed ? s : -1;
+  }
+  reset(): void {
+    this.last = -1;
+  }
+}

--- a/lib/beats.ts
+++ b/lib/beats.ts
@@ -81,6 +81,13 @@ export interface JawDropSpec {
 const jawDrops = new Map<string, Beat>();
 let beatList: Beat[] | null = null;
 
+/** Phase 4 audio hook: the director registers a one-shot player; called after animate/flash. */
+let beatSound: ((id: string, flash: number) => void) | null = null;
+
+export function setBeatSound(fn: ((id: string, flash: number) => void) | null): void {
+  beatSound = fn;
+}
+
 /** flash-budget-guarded impact double pop + sub-thump, shared by all drops */
 function impactPop(intensity: number) {
   if (!requestFlash()) return;
@@ -101,6 +108,7 @@ export function registerJawDrop(spec: JawDropSpec): void {
     fire: () => {
       spec.animate?.();
       if (spec.flash) impactPop(spec.flash);
+      beatSound?.(spec.id, spec.flash ?? 0);
     },
   });
   beatList = null;

--- a/lib/fx.ts
+++ b/lib/fx.ts
@@ -13,4 +13,10 @@ export const fx = {
    * so an unfired beat (deep jump, reduced motion) shows the card resting.
    */
   title: 0,
+  /**
+   * 0..1 music envelope written by the audio director each frame (0 whenever
+   * audio is off/muted). Read by PostPipeline for the S-Phase-4 halftone
+   * dot-scale breathe. Subtle by contract: consumers scale it way down.
+   */
+  audioPulse: 0,
 };

--- a/lib/scrollStore.ts
+++ b/lib/scrollStore.ts
@@ -24,6 +24,7 @@ interface ScrollState {
   setPointer: (x: number, y: number) => void;
   setQuality: (q: Quality) => void;
   setReducedMotion: (v: boolean) => void;
+  setAudioOn: (v: boolean) => void;
   meow: () => void;
 }
 
@@ -44,5 +45,6 @@ export const useScrollStore = create<ScrollState>()((set) => ({
   setPointer: (pointerX, pointerY) => set({ pointerX, pointerY }),
   setQuality: (quality) => set({ quality }),
   setReducedMotion: (reducedMotion) => set({ reducedMotion }),
+  setAudioOn: (audioOn) => set({ audioOn }),
   meow: () => set((s) => ({ meowCount: s.meowCount + 1 })),
 }));

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react": "19.2.7",
         "react-dom": "19.2.7",
         "three": "0.185.1",
+        "tone": "15.1.22",
         "zustand": "5.0.14"
       },
       "devDependencies": {
@@ -1380,6 +1381,19 @@
         "react": ">= 16.8.0"
       }
     },
+    "node_modules/automation-events": {
+      "version": "7.1.19",
+      "resolved": "https://registry.npmjs.org/automation-events/-/automation-events-7.1.19.tgz",
+      "integrity": "sha512-cD+TLhJTI0q4AI3ktd353lrGZiVa9AchowSDzQzzGjSoYe22js4vlS32VUtWuaulghi1Yq0KYNWKk9wWuGymPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.2.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -2359,6 +2373,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/standardized-audio-context": {
+      "version": "25.3.77",
+      "resolved": "https://registry.npmjs.org/standardized-audio-context/-/standardized-audio-context-25.3.77.tgz",
+      "integrity": "sha512-Ki9zNz6pKcC5Pi+QPjPyVsD9GwJIJWgryji0XL9cAJXMGyn+dPOf6Qik1AHei0+UNVcc4BOCa0hWLBzlwqsW/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.6",
+        "automation-events": "^7.0.9",
+        "tslib": "^2.7.0"
+      }
+    },
     "node_modules/stats-gl": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/stats-gl/-/stats-gl-2.4.2.tgz",
@@ -2475,6 +2500,16 @@
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
       "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
       "license": "MIT"
+    },
+    "node_modules/tone": {
+      "version": "15.1.22",
+      "resolved": "https://registry.npmjs.org/tone/-/tone-15.1.22.tgz",
+      "integrity": "sha512-TCScAGD4sLsama5DjvTUXlLDXSqPealhL64nsdV1hhr6frPWve0DeSo63AKnSJwgfg55fhvxj0iPPRwPN5o0ag==",
+      "license": "MIT",
+      "dependencies": {
+        "standardized-audio-context": "^25.3.70",
+        "tslib": "^2.3.1"
+      }
     },
     "node_modules/troika-three-text": {
       "version": "0.52.4",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "three": "0.185.1",
+    "tone": "15.1.22",
     "zustand": "5.0.14"
   },
   "devDependencies": {

--- a/shaders/PrintEffect.ts
+++ b/shaders/PrintEffect.ts
@@ -42,6 +42,7 @@ const fragment = /* glsl */ `
   uniform float uEdge;
   uniform float uHalftone;
   uniform float uHalftoneScale;
+  uniform float uAudioPulse;
   uniform float uGrain;
   uniform float uPaperTex;
   uniform float uVignette;
@@ -90,7 +91,11 @@ const fragment = /* glsl */ `
     mat2 R = mat2(0.70710678, -0.70710678, 0.70710678, 0.70710678);
     vec2 p = (R * fragPx) / max(uHalftoneScale, 1.0);
     vec2 f = fract(p) - 0.5;
-    float r = (1.0 - shade) * 0.75;
+    // Phase 4 audio breathe: dot RADIUS swells up to +5% with the music
+    // envelope; cell pitch stays fixed so dot centers never crawl. At
+    // uAudioPulse == 0 the factor is exactly 1.0 -- bit-identical to the
+    // silent path (settle-determinism gates unaffected).
+    float r = (1.0 - shade) * 0.75 * (1.0 + 0.05 * uAudioPulse);
     float d = length(f);
     float aa = fwidth(d) + 1e-4;
     return 1.0 - smoothstep(r - aa, r + aa, d);
@@ -206,6 +211,7 @@ export class PrintEffect extends Effect {
         ["uEdge", new Uniform(0.7)],
         ["uHalftone", new Uniform(0.4)],
         ["uHalftoneScale", new Uniform(6)],
+        ["uAudioPulse", new Uniform(0)],
         ["uGrain", new Uniform(0.06)],
         ["uPaperTex", new Uniform(0.1)],
         ["uVignette", new Uniform(0.25)],


### PR DESCRIPTION
## Phase 4 - Sound + polish

Every issue now has its own synthesized audio treatment, as distinct as its print recipe. All runtime-synthesized (Tone.js, pre-approved for this phase); no audio files fetched or awaited; gesture-gated, off by default, degrades silently.

### Audio engine
- `tone@15.1.22` pinned (Context7-verified before coding); lazy-imported so it never touches the initial bundle. `lookAhead = 0.02` so beat thumps land inside their ~60ms visual impact frames.
- Director singleton: music/sfx buses -> Compressor -> Limiter (-9dB ceiling). `AudioToggle` DOM overlay: off by default, `aria-pressed`, never autoplays. Beat sounds ride the single `setBeatSound` hook at the `beats.ts` `fire()` choke point.
- **`meowCount` consumer shipped** (Phase 3 queue): hash-seeded synth meow on cat click, upgraded to contour families (question / trill / chirp).

### Sound design
- 12 per-issue ambiences per SPEC (Cover/Origin/Press nearest-analog rulings). Screentone rail rhythm synced to the actual 10Hz halftone boil grid; sketchbook pencil scratch follows scroll velocity.
- **All 11 gutter transitions scored** with signature sounds matched to their visuals (crash-through burst, stamp ka-chunk, paper-tear ripple, page-flip flap, ink-flood swell to true silence, dot-match shimmer resolve...) + a global velocity page-riffle.
- 15 scroll-window scene reactions (`moments.ts`): KA-CHING bell, KRAKA-THOOM, KRUNCH/SLAM, SWISH, neon 10-ring cascade zaps, star-chart shimmer, terminal typing ticks - all pure f(t) with hysteresis, deep-jump safe.
- 10 input reactions (`ui.ts`): terminal keystroke/Enter/error, [open] tab, newsprint link press, press CTA, toggle on/off - across 10 approved scene call sites.

### Visual
- Halftone dot-scale **breathes** with the music (`uAudioPulse`, +5% radius cap, cell pitch fixed so dots never crawl). Bit-exact at 0, so settle-determinism gates are unaffected.
- Global color-script pass: 23 shots, 11/11 boundaries harmonize-while-contrasting.

### Determinism & comfort
- Zero `Math.random` (Knuth-hash step clocks, restart-safe). Everything scrub-safe both directions. All one-shots mixed at/below the sub-thump reference through the limiter. S2.16 audio spirit honored (no strobe-like stutter on the sfx layer).

### Gates
- **Full Phase 4 gate 10/10**, plus **focused enrichment re-gate 6/6** - both DevTools-MCP measured (reconnected mid-session). Audio adds **zero main-thread cost** (Web Audio renders off-main-thread; Pop with audio on averaged *faster* than off). No autoplay at any of the 10 new call sites; gutter-jitter hysteresis holds; deep-jump landing bounded.
- Adversarial law-compliance review PASS 10/10.
- Formal DevTools re-trace **closes the Phase 3 queued item**.

### Advisory (carried to REPORT.md)
Pre-existing single-frame cold-mount stalls (desk/pop) read 90-143ms in the dev build (StrictMode + unminified inflate the 58ms Phase 2 baseline). Audio-neutral; re-measure on a production build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)