### PR TITLE
Add README + deploy to GitHub Pages (iamsaeed.dev)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,62 @@
+name: Deploy to GitHub Pages
+
+# Builds the Next.js static export and publishes it to GitHub Pages.
+# Served at the apex custom domain iamsaeed.dev (public/CNAME) -- so
+# configure-pages is used WITHOUT `static_site_generator: next`, which would
+# otherwise force a basePath meant for project subpaths (user.github.io/repo)
+# and break asset paths at the domain root.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; don't cancel an in-progress publish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Install dependencies
+        run: npm ci
+
+      # `npm run build` runs the prebuild bake (contributions JSON) then
+      # `next build`, which emits the static site to ./out (incl. CNAME).
+      - name: Build static export
+        run: npm run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./out
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,16 +26,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: "lts/*"
           cache: npm
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Install dependencies
         run: npm ci
@@ -46,7 +46,7 @@ jobs:
         run: npm run build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./out
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,87 @@
+# PANEL JUMP
+
+**A scroll-driven portfolio that reads like a living comic book.**
+
+### [iamsaeed.dev](https://iamsaeed.dev)
+
+The portfolio of **Saeed Kolivand** — Senior Frontend Developer, Cologne. One
+global scroll timeline, twelve comic "issues," a camera that behaves like a
+film editor (holds, dollies, crash-zooms, and hard *cuts* between designed
+shots), and a printed comic aesthetic throughout: halftone dots, ink edges,
+line boil, stepped animation, paper texture.
+
+The scroll wheel is the reader's thumb on the page corner.
+
+---
+
+## What's inside
+
+- **Twelve issues, each a distinct print treatment** — noir ink, warm desk
+  halftone, neon city, origin page, a skills factory, newsprint, a manga-tone
+  subway, an oversaturated streaming pop print, a pencil-and-ink sketchbook, a
+  cosmic double-page spread, and a CRT terminal letters page.
+- **Designed transitions, not raw jumps** — every boundary is a cut with
+  intent: dot-zoom, page-flip, paper-tear, whip, stamp slam, panel wipe,
+  ink-flood, match-cut. All scrub-safe in both directions.
+- **A synthesized soundscape** — twelve per-issue ambiences, eleven scored
+  transitions, and dozens of reactions, all generated at runtime (no audio
+  files). Gesture-gated, off by default. The halftone dots breathe with it.
+- **The cat is the through-line** — Harley (a real, fluffy golden tabby) guides
+  the journey scene to scene and hides in every issue.
+- **The Print Edition** — for reduced-motion, mobile, and low-power devices, a
+  genuinely designed *static* comic renders instead: same content, same
+  lettering, zero WebGL, zero motion. First-class, not a fallback. This is also
+  the accessible, crawlable copy — all text lives in the DOM.
+
+## Accessibility
+
+- `prefers-reduced-motion`, mobile, low tier, and no-WebGL all get the static
+  **Print Edition** — no animation, no flashes, no WebGL context created.
+- All content is real DOM text (SEO + screen readers); real `<a>` links; one
+  `<h1>`, proper landmarks and heading order; a skip link; keyboard focus is
+  never trapped under the canvas.
+- WCAG: AA color contrast, flash safety per 2.3.1 (≤3 flashes/s, no strobe).
+
+## Tech
+
+Next.js 16 (App Router, static export) · React 19 · TypeScript (strict) ·
+React Three Fiber + drei + `postprocessing` · Three.js (GLSL print shaders) ·
+Tone.js (runtime-synthesized audio) · GSAP + ScrollTrigger · Lenis · Zustand ·
+Tailwind CSS. One `<Canvas>`, one scroll `t`, one post-processing composer.
+
+## Run it locally
+
+```bash
+npm install
+npm run dev        # http://localhost:3000
+```
+
+Other scripts: `npm run build` (static export to `./out`) · `npm run typecheck`.
+
+Try the Print Edition locally by enabling your OS "reduce motion" setting, or
+append `?low` to the URL, or narrow the window below 820px.
+
+> Open the browser console for a small easter egg. 🐈
+
+## How it was built
+
+PANEL JUMP was built autonomously with **Claude Code**, one phase per session,
+under a self-directed execution protocol — a roster of specialized subagents
+(scene builder, shader engineer, gate auditor, performance profiler, docs
+researcher, content scribe) coordinated by an orchestrator. The agent
+definitions live in [`.claude/`](.claude/) if you're curious how the sausage
+was made.
+
+## Deployment
+
+Deployed to **GitHub Pages** at the apex domain `iamsaeed.dev` via
+[`.github/workflows/deploy.yml`](.github/workflows/deploy.yml): `next build`
+produces a static `./out`, which is published on every push to `main`. No
+server, no runtime fetches — the GitHub contribution chart is baked at build
+time.
+
+---
+
+<sub>© Saeed Kolivand. Style borrows the generic technique vocabulary of comic
+printing; no third-party characters, logos, or IP. Fonts are OFL
+(Bangers, Caveat, JetBrains Mono).</sub>

--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,10 @@ const nextConfig: NextConfig = {
   // GitHub-contribution data is baked at build time (scripts/bake-contributions.mjs),
   // so nothing needs a server. Served at the apex domain root, so no basePath.
   output: "export",
+  // Companion to `output: export` -- the default image optimizer needs a
+  // server. The app uses plain <img>, so this is defensive: it keeps the
+  // export build working if next/image is ever introduced.
+  images: { unoptimized: true },
 };
 
 export default nextConfig;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,11 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {};
+const nextConfig: NextConfig = {
+  // Static export for GitHub Pages: `next build` emits ./out (HTML/CSS/JS).
+  // The app is 100% client-side (one R3F canvas + a static DOM Print Edition),
+  // GitHub-contribution data is baked at build time (scripts/bake-contributions.mjs),
+  // so nothing needs a server. Served at the apex domain root, so no basePath.
+  output: "export",
+};
 
 export default nextConfig;

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+iamsaeed.dev


### PR DESCRIPTION
## README + GitHub Pages deployment

### README.md
Public portfolio README: what PANEL JUMP is, the live link (iamsaeed.dev), feature highlights (12 issues, scored soundscape, the Print Edition), accessibility notes, tech stack, local-run instructions, a nod to the autonomous Claude Code build, and deployment.

### Static export + Pages deploy
- `next.config.ts`: `output: "export"` -- the app is 100% client-side (one R3F canvas + a static DOM Print Edition) with build-time-baked contribution data, so it exports cleanly with no server.
- `.github/workflows/deploy.yml`: builds the static export and publishes to GitHub Pages on every push to `main`. Uses `configure-pages@v5` **without** `static_site_generator: next` on purpose -- that input forces a project-subpath basePath, which would break asset paths on the apex domain.
- `public/CNAME` -> `iamsaeed.dev` (copied into `./out` so the custom domain sticks).

### Verified
`npm run build` emits `./out` with `index.html` (full Print Edition content, **zero `<canvas>` in the static HTML** -> crawlers/screen-readers get the semantic comic), the `CNAME`, baked `contributions.json`, all images, and fonts. Because it deploys to the **apex root**, the absolute `/images/...` paths resolve correctly with no `basePath`.

### After merge -- manual steps (one-time)
1. **Repo Settings -> Pages**: Source = **GitHub Actions**; set Custom domain = `iamsaeed.dev`.
2. **DNS at your registrar** (apex `A` records): `185.199.108.153`, `185.199.109.153`, `185.199.110.153`, `185.199.111.153` (optionally the matching `AAAA` records).
3. Once DNS propagates, tick **Enforce HTTPS**.

The workflow runs automatically on merge to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)