### PR TITLE
Rename public-facing PANEL JUMP -> Saeed Kolivand -- Portfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PANEL JUMP
+# Saeed Kolivand — Portfolio
 
 **A scroll-driven portfolio that reads like a living comic book.**
 
@@ -65,7 +65,7 @@ append `?low` to the URL, or narrow the window below 820px.
 
 ## How it was built
 
-PANEL JUMP was built autonomously with **Claude Code**, one phase per session,
+This portfolio was built autonomously with **Claude Code**, one phase per session,
 under a self-directed execution protocol — a roster of specialized subagents
 (scene builder, shader engineer, gate auditor, performance profiler, docs
 researcher, content scribe) coordinated by an orchestrator. The agent

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -20,7 +20,7 @@ const jetbrainsMono = JetBrains_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Saeed Kolivand -- Senior Frontend Developer",
+  title: "Saeed Kolivand -- Portfolio",
   description:
     "Saeed Kolivand -- Senior Frontend Developer. A scroll-driven comic-book portfolio.",
 };

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -20,7 +20,7 @@ const jetbrainsMono = JetBrains_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "PANEL JUMP -- Saeed Kolivand",
+  title: "Saeed Kolivand -- Senior Frontend Developer",
   description:
     "Saeed Kolivand -- Senior Frontend Developer. A scroll-driven comic-book portfolio.",
 };

--- a/issues/registry.ts
+++ b/issues/registry.ts
@@ -84,7 +84,7 @@ const row = (
 
 /** S0.3 locked timeline -- ranges + gutters chain exactly to 1.000. Do not re-balance. */
 export const ISSUES: IssueEntry[] = [
-  row("cover", "PANEL JUMP", 0, 1, "crash-through", Cover, { shots: COVER_SHOTS }),
+  row("cover", "Saeed Kolivand -- Portfolio", 0, 1, "crash-through", Cover, { shots: COVER_SHOTS }),
   row("noir", "ISSUE 1 - NOIR", 1, 2, "title-drop", Noir, { shots: NOIR_SHOTS }),
   row("desk", "ISSUE 2 - DESK", 2, 2, "dot-zoom", Desk, { shots: DESK_SHOTS }),
   row("neon", "ISSUE 3 - NEON INK", 3, 5, "panel-wipe", Neon, { shots: NEON_SHOTS }),


### PR DESCRIPTION
Renames the **public-facing** "PANEL JUMP" branding to **Saeed Kolivand -- Portfolio** for the live site at iamsaeed.dev:

- **Page title** (`app/layout.tsx`) -> `Saeed Kolivand -- Portfolio` (browser tab + SEO)
- **Cover scene label** (`issues/registry.ts`)
- **README** H1 + the "how it was built" line

**Intentionally left unchanged:** the internal build-story docs (`.claude/` agents, `CLAUDE.md`, the `claude-review` workflow). "PANEL JUMP" is the project's proper name in that prose, so substituting it there would read as nonsense (e.g. "you own every line of GLSL in Saeed Kolivand -- Portfolio").

Compiled files verified pure ASCII; `tsc` clean. Merges to `main` auto-deploy, so the live tab title updates on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)