### PR TITLE
Add Dependabot version-update rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Enables Dependabot **version updates** (weekly) for the two ecosystems in this repo:

- `npm` (root `package-lock.json`) — minor/patch grouped into a single PR to cut noise; majors land as individual PRs.
- `github-actions` (`.github/workflows/`).

### Repo security state (verified via `gh api`)
Already enabled, no change needed:
- Dependabot **alerts** ✅
- Dependabot **security updates** ✅
- **Secret scanning** ✅
- Secret scanning **push protection** ✅

Not enabled — `secret_scanning_non_provider_patterns` and `secret_scanning_validity_checks`: the API returns `200 OK` but the toggles no-op because the repo has no GitHub Advanced Security / Secret Protection layer (`advanced_security` is `null`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)