### PR TITLE
Fix postcss XSS (GHSA-qx2v-qp2m-jg93)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2137,34 +2137,6 @@
         }
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -2184,7 +2156,6 @@
       "version": "8.5.16",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
       "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
     "@types/three": "0.185.0",
     "tailwindcss": "4.3.2",
     "typescript": "6.0.3"
+  },
+  "overrides": {
+    "postcss": "^8.5.10"
   }
 }


### PR DESCRIPTION
Resolves Dependabot alert #1.

`next@16.2.10` bundles `postcss@8.4.31`, vulnerable to **CVE-2026-41305** — unescaped `</style>` in CSS stringify output enables XSS (CVSS 6.1, medium). Fixed in postcss 8.5.10.

Since it's a transitive dep pinned by Next, added an npm `overrides` entry (`"postcss": "^8.5.10"`). The nested copy now dedupes to `8.5.16` (the version Tailwind already resolved). `npm audit` → **0 vulnerabilities**.

Build-time-only dependency, so real-world exposure was negligible, but this clears the alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)