### PR TITLE
Full sound-design pass, real stream desk, print/3D scroll mapping

### DIFF
--- a/components/ExperienceGate.tsx
+++ b/components/ExperienceGate.tsx
@@ -3,13 +3,14 @@
 import { useEffect, useRef, useState } from "react";
 import { links, printEdition } from "@/lib/content";
 import { useScrollStore } from "@/lib/scrollStore";
+import { RANGES } from "@/issues/timeline";
 import AudioToggle from "./AudioToggle";
 import Experience from "./Experience";
 import JumpCover from "./JumpCover";
 import Lettering from "./Lettering";
 import PressCta from "./PressCta";
 import PrintEdition from "./PrintEdition";
-import ScrollProxy from "./ScrollProxy";
+import ScrollProxy, { scrollToT } from "./ScrollProxy";
 import styles from "./PrintEdition.module.css";
 
 /*
@@ -56,8 +57,51 @@ function probeWebGL(): boolean {
   }
 }
 
+/** Clamp an issue index into the valid 0..11 registry range. */
+function clampIssue(i: number): number {
+  return Math.min(11, Math.max(0, Math.round(i)));
+}
+
+/*
+ * print -> 3D scroll map (WS-E): find which Print Edition section sits at the
+ * viewport top and how far through it we have scrolled, then convert that to a
+ * global t via the issue's authored range (RANGES). Sections render in document
+ * order, so their getBoundingClientRect().top increases monotonically; the
+ * current section is the last one whose top has passed above the viewport top
+ * (top <= 0), and frac is how far its box has scrolled past. #projects and
+ * #contact live past the last issue, so they fall back to issue 11's range.
+ * MUST be read synchronously before the toggle collapses the print layout.
+ */
+function measurePrintT(): number {
+  const sections: { issue: number; id: string }[] = [];
+  for (let i = 0; i <= 11; i++) sections.push({ issue: i, id: "issue-" + i });
+  sections.push({ issue: 11, id: "projects" });
+  sections.push({ issue: 11, id: "contact" });
+
+  let curIssue = 0;
+  let frac = 0;
+  for (const { issue, id } of sections) {
+    const el = document.getElementById(id);
+    if (!el) continue;
+    const r = el.getBoundingClientRect();
+    if (r.top > 24) break; // 1rem scroll-margin (16px) + rounding headroom
+    curIssue = issue;
+    // a section resting at its scroll-margin (top ~16px) maps to frac 0 of THAT
+    // issue; only extra scroll past the margin advances frac.
+    frac = r.height > 0 ? Math.min(1, Math.max(0, -Math.min(r.top - 16, 0) / r.height)) : 0;
+  }
+
+  const [s, e] = RANGES[curIssue]!;
+  return s + frac * (e - s);
+}
+
 export default function ExperienceGate() {
   const printRef = useRef<HTMLDivElement>(null);
+  // WS-E scroll bridge: issue to scroll the print doc to after 3D -> print;
+  // global t to restore in the 3D stack after print -> 3D. Consumed + cleared
+  // by the mapping effect below.
+  const pendingReaderIssue = useRef<number | null>(null);
+  const pendingExperienceT = useRef<number | null>(null);
   const [showExperience, setShowExperience] = useState(false);
   const [forceReader, setForceReader] = useState(false);
   const [forceExperience, setForceExperience] = useState(false);
@@ -94,16 +138,48 @@ export default function ExperienceGate() {
   // print mode -- the reduced-motion opt-in, and the undo for a manual switch.
   const offerExperience = capable && !effectiveShow && (reduced || forceReader);
 
+  // WS-E: map scroll position across the print <-> 3D toggle. Runs whenever the
+  // mount decision flips. Into the experience: restore the t captured from the
+  // print doc -- the child ScrollProxy's mount effect runs before this parent
+  // effect, so activeLenis is live (scrollToT still guards null). Into the print
+  // doc: scroll the now-visible section into view (Lenis is gone, plain DOM). No
+  // pending value on first load, so this never scrolls on initial mount.
+  useEffect(() => {
+    if (effectiveShow) {
+      const t = pendingExperienceT.current;
+      if (t !== null) {
+        pendingExperienceT.current = null;
+        scrollToT(t, { immediate: true });
+      }
+    } else {
+      const i = pendingReaderIssue.current;
+      if (i !== null) {
+        pendingReaderIssue.current = null;
+        document.getElementById("issue-" + i)?.scrollIntoView();
+      }
+    }
+  }, [effectiveShow]);
+
+  // 3D -> print: capture the live issue BEFORE tearing the stack down, so the
+  // print doc can scroll to the matching section once it becomes visible.
+  const goToReader = () => {
+    pendingReaderIssue.current = clampIssue(useScrollStore.getState().activeIssue);
+    setForceReader(true);
+  };
+
   const revealReader = () => {
     // A keyboard/AT user tabbed into the print doc hidden behind the canvas:
     // reveal it and tear the whole interactive stack down so focus is visible.
+    // Do NOT capture pendingReaderIssue here -- the focus path must not
+    // reposition, or the tabbed-to element gets yanked out from under the user.
+    // Only the visible button click (goToReader) scrolls to the active issue.
     if (effectiveShow) setForceReader(true);
   };
 
   return (
     <>
       {effectiveShow ? (
-        <button type="button" className={styles.switchReader} onClick={() => setForceReader(true)}>
+        <button type="button" className={styles.switchReader} onClick={goToReader}>
           {printEdition.toReaderLabel}
         </button>
       ) : null}
@@ -117,6 +193,9 @@ export default function ExperienceGate() {
           type="button"
           className={styles.switchExperience}
           onClick={() => {
+            // print -> 3D: measure the in-view section synchronously, BEFORE the
+            // state change collapses the print layout, then restore in the effect.
+            pendingExperienceT.current = measurePrintT();
             setForceReader(false);
             setForceExperience(true);
           }}

--- a/components/ScrollProxy.tsx
+++ b/components/ScrollProxy.tsx
@@ -46,7 +46,7 @@ function progressToT(s: number): number {
 }
 
 /** Exact inverse of progressToT, so scrollToT(t) lands on precisely t. */
-function tToProgress(t: number): number {
+export function tToProgress(t: number): number {
   const [a, b] = SLOW_WINDOW;
   const u = t <= a ? t : t <= b ? a + (t - a) * SLOW_FACTOR : t + SLOW_EXTRA;
   return u / (1 + SLOW_EXTRA);
@@ -59,14 +59,19 @@ let activeLenis: Lenis | null = null;
  * Programmatic scroll surface for diegetic UI (e.g. the Issue 5 "See
  * projects" CTA): smooth-scroll the document so global progress lands on
  * `t`. lenis.limit is the max scroll value (lenis 1.3.25 README), matching
- * ScrollTrigger's 0->"max" progress mapping. Instant under reduced motion.
+ * ScrollTrigger's 0->"max" progress mapping. Instant under reduced motion,
+ * or when opts.immediate is set (print<->3D toggle jump: no scrub animation
+ * across a document swap).
  */
-export function scrollToT(t: number) {
+export function scrollToT(t: number, opts?: { immediate?: boolean }) {
   const lenis = activeLenis;
   if (!lenis) return;
   const target = tToProgress(Math.min(Math.max(t, 0), 1)) * lenis.limit;
-  if (useScrollStore.getState().reducedMotion) lenis.scrollTo(target, { immediate: true });
-  else lenis.scrollTo(target, { duration: 2.2 });
+  if (opts?.immediate || useScrollStore.getState().reducedMotion) {
+    lenis.scrollTo(target, { immediate: true });
+  } else {
+    lenis.scrollTo(target, { duration: 2.2 });
+  }
 }
 
 export default function ScrollProxy() {

--- a/issues/01-noir/Noir.tsx
+++ b/issues/01-noir/Noir.tsx
@@ -222,6 +222,7 @@ function NoirCat({ cx }: { cx: number }) {
   const leapTail = useRef<Group>(null);
   const walkPaw = useRef<Group>(null);
   const armed = useRef(true);
+  const crouchArmed = useRef(true);
 
   useEffect(() => {
     spotRect.enabled = 1;
@@ -269,12 +270,26 @@ function NoirCat({ cx }: { cx: number }) {
       if (armed.current) {
         armed.current = false;
         sayWord(lettering.onomatopoeia.cat, [cx + x, y + 0.7, z], 0.37, INK);
-        // leap meow is skipped under reduced motion (the leap animation still
-        // plays; only the sfx is gated, matching the beat-sound suppression)
-        if (!reducedMotion) sfxMoment("meow", 3);
+        // leap meow + whoosh are skipped under reduced motion (the leap
+        // animation still plays; only the sfx is gated, matching the beat-sound
+        // suppression)
+        if (!reducedMotion) {
+          sfxMoment("meow", 3);
+          sfxMoment("leap", 3); // whoosh as the cat leaves the parapet
+        }
       }
     } else if (!armed.current && p4 < 0.67) {
       armed.current = true; // hysteresis re-arm for reverse scrollers
+    }
+
+    // crouch plant: one soft pad as the cat sets for the leap (trot crosses
+    // 0.75); own hysteresis latch so reverse scrubbers hear it once
+    const setting = k === 0 && p4 > 0 && trot >= 0.75;
+    if (setting && crouchArmed.current) {
+      crouchArmed.current = false;
+      if (!reducedMotion) sfxMoment("pad", 11);
+    } else if (!setting && trot < 0.73) {
+      crouchArmed.current = true;
     }
 
     g.position.set(x, y, z);

--- a/issues/03-neon/Neon.tsx
+++ b/issues/03-neon/Neon.tsx
@@ -12,6 +12,7 @@ import { stepTime, stepNoise } from "@/lib/steppedClock";
 import { useScrollStore } from "@/lib/scrollStore";
 import { clamp01 } from "@/lib/shots";
 import { lettering } from "@/lib/content";
+import { sfxMoment } from "@/lib/audio/moments";
 import { NEON_CASCADE_T, NEON_CASCADE_END } from "./shots";
 
 /**
@@ -303,6 +304,9 @@ export default function Neon({ index }: { index: number }) {
   const padMat = useRef<MeshBasicMaterial>(null);
   const cat = useRef<Group>(null);
   const lastRadius = useRef(-1);
+  // per-sign lit latch (preallocated at mount, primed to the mount state so a
+  // deep-jump into the cascade never fires a buzz burst); no per-frame alloc
+  const lit = useRef<boolean[]>([]);
 
   const applyRadius = (radius: number) => {
     const body = bodyRef.current;
@@ -374,6 +378,10 @@ export default function Neon({ index }: { index: number }) {
     const radius = cascadeRadius(useScrollStore.getState().t);
     lastRadius.current = radius;
     applyRadius(radius);
+    // prime the buzz latch to the mount state (no ignition sound on mount)
+    CITY.signs.forEach((s, i) => {
+      lit.current[i] = s.preLit || s.dist <= radius;
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -387,10 +395,24 @@ export default function Neon({ index }: { index: number }) {
       applyRadius(radius);
     }
 
-    // signs pop on when the wave reaches them (visibility step, no fade)
+    // signs pop on when the wave reaches them (visibility step, no fade); the
+    // ignition edge (false->true, non-pilot) fires a sign-buzz. Event marker,
+    // so it plays under reduced motion too; re-arms when a sign goes dark.
+    // A jump/teleport (print<->3D, JumpCover, scrollbar drag) can flip many
+    // signs in one frame -> serialized buzz volley. Count ignitions first; the
+    // normal cascade lights at most 1-2/frame, so more than 2 is a teleport:
+    // update lit[] silently (re-prime), no buzz.
+    let ignitions = 0;
     CITY.signs.forEach((s, i) => {
+      if (!s.preLit && s.dist <= radius && !lit.current[i]) ignitions++;
+    });
+    const jump = ignitions > 2;
+    CITY.signs.forEach((s, i) => {
+      const on = s.preLit || s.dist <= radius;
       const g = signRefs.current[i];
-      if (g) g.visible = s.preLit || s.dist <= radius;
+      if (g) g.visible = on;
+      if (on && !lit.current[i] && !s.preLit && !jump) sfxMoment("signBuzz", i);
+      lit.current[i] = on;
     });
 
     // krackle: stepped-time jitter (ambient loop, S2.8), gated by the wave

--- a/issues/06-newsprint/Newsprint.tsx
+++ b/issues/06-newsprint/Newsprint.tsx
@@ -396,6 +396,7 @@ function PanelButton({ x, label, url }: { x: number; label: string; url: string 
       }}
       onPointerOver={(e) => {
         e.stopPropagation();
+        if (!hovered.current) uiSound("hover"); // tick on false -> true only
         hovered.current = true;
         document.body.style.cursor = "pointer";
       }}

--- a/issues/08-pop/Pop.tsx
+++ b/issues/08-pop/Pop.tsx
@@ -105,21 +105,27 @@ const slab = (
 slab(0, 2.3, 0, 7.5, 0.35, 3, DESK);
 for (const lx of [-3.4, 3.4])
   for (const lz of [-1.2, 1.2]) slab(lx, 1.06, lz, 0.28, 2.12, 0.28, DARK);
-// monitor: bezel, glass, flat stream-layout UI (cyan header, pink chat
-// column, ink/cyan code lines)
-slab(0.4, 4.05, -0.7, 3.6, 2.3, 0.2, DARK);
-slab(0.4, 4.05, -0.56, 3.25, 1.95, 0.05, SCREEN);
-slab(0.4, 4.85, -0.53, 3.25, 0.28, 0.04, CYAN);
-slab(1.55, 3.85, -0.53, 0.75, 1.6, 0.04, PINK);
-slab(-0.35, 4.15, -0.53, 1.5, 0.12, 0.04, INK);
-slab(-0.5, 3.9, -0.53, 1.2, 0.12, 0.04, CYAN);
-slab(-0.25, 3.65, -0.53, 1.7, 0.12, 0.04, YELLOW);
-slab(-0.6, 3.4, -0.53, 1.0, 0.12, 0.04, INK);
+// wide main monitor: bezel, glass, cyan title bar, a 2-pane code editor
+// (center divider + two columns of ink/cyan/yellow code lines)
+slab(0.4, 4.05, -0.7, 4.6, 2.3, 0.2, DARK);
+slab(0.4, 4.05, -0.56, 4.25, 1.95, 0.05, SCREEN);
+slab(0.4, 4.85, -0.53, 4.0, 0.24, 0.04, CYAN);
+slab(0.4, 3.9, -0.53, 0.08, 1.55, 0.04, DARK);
+// left pane
+slab(-0.6, 4.35, -0.53, 1.3, 0.1, 0.04, CYAN);
+slab(-0.75, 4.15, -0.53, 1.0, 0.1, 0.04, INK);
+slab(-0.55, 3.95, -0.53, 1.4, 0.1, 0.04, YELLOW);
+slab(-0.8, 3.75, -0.53, 0.9, 0.1, 0.04, INK);
+// right pane
+slab(1.5, 4.35, -0.53, 1.3, 0.1, 0.04, YELLOW);
+slab(1.35, 4.15, -0.53, 1.0, 0.1, 0.04, CYAN);
+slab(1.55, 3.95, -0.53, 1.4, 0.1, 0.04, INK);
+slab(1.35, 3.75, -0.53, 0.9, 0.1, 0.04, CYAN);
 // monitor stand
 slab(0.4, 2.75, -0.75, 0.5, 0.55, 0.3, DARK);
 slab(0.4, 2.51, -0.7, 1.3, 0.08, 0.9, DARK);
 // monitor BACK detail + cable drop (the 360 films the set from behind)
-slab(0.4, 4.6, -0.83, 2.2, 0.16, 0.06, CYAN);
+slab(0.4, 4.6, -0.83, 3.0, 0.16, 0.06, CYAN);
 slab(-0.4, 3.7, -0.83, 0.9, 0.7, 0.06, PINK);
 slab(0.9, 3.1, -0.9, 0.1, 1.3, 0.1, YELLOW, 0.25);
 // PC tower + accent stripes (both faces -- the 360)
@@ -141,10 +147,9 @@ for (let i = 0; i < 6; i++)
     0.22,
     [PINK, CYAN, YELLOW][i % 3]!,
   );
-// mic arm + mic head (head raised clear of the tower cat, iteration 2)
+// mic boom arm (dynamic capsule + glowing CYAN ring live in Props, on the end)
 slab(-1.5, 2.95, 0.9, 0.12, 1.3, 0.12, DARK, 0.35);
 slab(-2.15, 3.75, 0.82, 0.12, 1.2, 0.12, DARK, 1.15);
-slab(-2.75, 4.1, 0.75, 0.42, 0.6, 0.42, PINK);
 // the empty chair, pushed aside to the far left-back quadrant, out of every
 // shot's sight line (iterations 1-2, loop log in shots.md) -- the cat is
 // running the stream
@@ -160,6 +165,47 @@ slab(-3.5, 3.15, -2.8, 0.22, 6.3, 0.22, GEAR);
 slab(-4.9, 6.35, -2.8, 3.2, 0.2, 0.2, GEAR);
 // ring light pole
 slab(-4.2, 2.15, 1.4, 0.14, 4.3, 0.14, GEAR);
+
+/* ---- real streamer setup (WS-D): monitors, softboxes, decks -------------- */
+// 2 studio monitors on foam pads + stand posts, flanking the main monitor;
+// fronts carry woofer/tweeter circles (Props), backs carry accent slabs for
+// the 360
+for (const [mx, mz, bc] of [
+  [-2.6, -0.55, PINK],
+  [3.2, -0.5, YELLOW],
+] as const) {
+  slab(mx, 2.53, mz, 1.15, 0.1, 0.85, GEAR); // foam pad
+  slab(mx, 2.95, mz, 0.35, 0.9, 0.35, DARK); // stand post
+  slab(mx, 4.2, mz, 1.1, 1.6, 0.9, DARK); // cabinet
+  slab(mx, 4.5, mz - 0.48, 0.7, 0.12, 0.06, CYAN); // back port stripe
+  slab(mx, 3.9, mz - 0.48, 0.5, 0.5, 0.06, bc); // back panel accent
+}
+// 2 softboxes hung from the ON AIR truss: DARK cabinet, bright INK diffusion
+// panel, dark egg-crate grid (3x3 = 4 slabs), GEAR back brace for the orbit
+for (const sx of [-5.5, -4.3] as const) {
+  slab(sx, 5.7, -2.62, 1.4, 1.0, 0.25, DARK);
+  slab(sx, 5.7, -2.49, 1.25, 0.85, 0.02, INK);
+  slab(sx - 0.21, 5.7, -2.46, 0.03, 0.85, 0.02, PAPER);
+  slab(sx + 0.21, 5.7, -2.46, 0.03, 0.85, 0.02, PAPER);
+  slab(sx, 5.84, -2.46, 1.25, 0.03, 0.02, PAPER);
+  slab(sx, 5.56, -2.46, 1.25, 0.03, 0.02, PAPER);
+  slab(sx, 5.7, -2.75, 0.5, 0.14, 0.05, GEAR);
+}
+// Stream Deck Plus: dark deck + cyan touch strip (4 dials in Props)
+slab(2.55, 2.55, 1.15, 1.05, 0.14, 0.48, DARK);
+slab(2.55, 2.63, 1.08, 0.85, 0.03, 0.14, CYAN);
+// Scarlett audio interface: pink body + yellow gain halo (2 knobs in Props)
+slab(-1.7, 2.65, 1.15, 0.9, 0.35, 0.45, PINK);
+slab(-1.95, 2.83, 1.0, 0.16, 0.02, 0.16, YELLOW);
+// monitor controller: dark body (big knurled knob in Props)
+slab(1.6, 2.6, 1.2, 0.5, 0.28, 0.44, DARK);
+// keyboard keycap deck (subtle) + 2 pink accent keys (Esc/Enter nod)
+slab(0.2, 2.63, 0.85, 2.0, 0.02, 0.66, PAPER);
+slab(-0.72, 2.65, 0.55, 0.14, 0.02, 0.14, PINK);
+slab(1.05, 2.65, 1.05, 0.18, 0.02, 0.16, PINK);
+// LED backglow slabs low behind the desk (the purple wall wash)
+slab(0, 1.2, -2.0, 6.5, 0.5, 0.1, PINK);
+slab(0, 0.55, -2.0, 6.5, 0.3, 0.1, CYAN);
 
 function Slabs() {
   const inst = useRef<InstancedMesh>(null);
@@ -206,6 +252,61 @@ function Props() {
       <mesh position={[-4.2, 4.4, 1.4]} rotation={[Math.PI / 2, 0, 0]}>
         <cylinderGeometry args={[0.62, 0.62, 0.14, 24]} />
         <meshBasicMaterial color={DARK} />
+      </mesh>
+      {/* studio monitor woofers (DARK ring + RUG cone) + CYAN tweeters --
+          the Shot-3 front-face read; backs carry accent slabs for the 360 */}
+      {(
+        [
+          // cabinets sit at z -0.55 / -0.50 with depth 0.9, so their front faces
+          // are at -0.10 / -0.05. Each driver's back (mz - 0.03) rests 0.03 proud
+          // of that face (the stacked-cylinder standoff), not the old 0.07 float.
+          [-2.6, -0.04],
+          [3.2, 0.01],
+        ] as const
+      ).map(([mx, mz]) => (
+        <group key={mx}>
+          <mesh position={[mx, 3.95, mz]} rotation={[Math.PI / 2, 0, 0]}>
+            <cylinderGeometry args={[0.32, 0.32, 0.06, 24]} />
+            <meshBasicMaterial color={DARK} />
+          </mesh>
+          <mesh position={[mx, 3.95, mz + 0.03]} rotation={[Math.PI / 2, 0, 0]}>
+            <cylinderGeometry args={[0.06, 0.2, 0.12, 20]} />
+            <meshBasicMaterial color={RUG} />
+          </mesh>
+          <mesh position={[mx, 4.62, mz]} rotation={[Math.PI / 2, 0, 0]}>
+            <cylinderGeometry args={[0.12, 0.12, 0.06, 16]} />
+            <meshBasicMaterial color={CYAN} />
+          </mesh>
+        </group>
+      ))}
+      {/* Stream Deck Plus dials */}
+      {[2.2, 2.42, 2.65, 2.88].map((kx) => (
+        <mesh key={kx} position={[kx, 2.65, 1.3]}>
+          <cylinderGeometry args={[0.06, 0.06, 0.07, 16]} />
+          <meshBasicMaterial color={GEAR} />
+        </mesh>
+      ))}
+      {/* Scarlett gain knobs */}
+      {[-1.95, -1.5].map((kx) => (
+        <mesh key={kx} position={[kx, 2.88, 1.0]}>
+          <cylinderGeometry args={[0.09, 0.09, 0.12, 16]} />
+          <meshBasicMaterial color={GEAR} />
+        </mesh>
+      ))}
+      {/* monitor-controller big knurled knob (echoes the Desk-scene knob) */}
+      <mesh position={[1.6, 2.85, 1.2]}>
+        <cylinderGeometry args={[0.18, 0.18, 0.16, 24]} />
+        <meshBasicMaterial color={GEAR} />
+      </mesh>
+      {/* dynamic mic capsule + glowing ring on the boom end (real ring is
+          green; CYAN is the palette-legal glow) */}
+      <mesh position={[-2.75, 4.0, 0.78]} rotation={[0, 0, -0.35]}>
+        <cylinderGeometry args={[0.14, 0.14, 0.55, 20]} />
+        <meshBasicMaterial color={DARK} />
+      </mesh>
+      <mesh position={[-2.84, 3.77, 0.78]} rotation={[0, 0, -0.35]}>
+        <cylinderGeometry args={[0.17, 0.17, 0.1, 24]} />
+        <meshBasicMaterial color={CYAN} />
       </mesh>
     </group>
   );

--- a/issues/08-pop/shots.ts
+++ b/issues/08-pop/shots.ts
@@ -4,6 +4,7 @@ import { printRecipe } from "@/lib/recipes";
 import { registerJawDrop } from "@/lib/beats";
 import { PopPool } from "@/lib/pops";
 import { sayWord } from "@/lib/onomatopoeia";
+import { sfxMoment } from "@/lib/audio/moments";
 import { issueCopy, lettering } from "@/lib/content";
 import { issueCenter, RANGES } from "../timeline";
 
@@ -86,6 +87,9 @@ export function spawnChat(seed?: number): void {
   const slot = chatPool.spawn([x, y, z], seed);
   slot.data.line = CHAT_LINES[i % CHAT_LINES.length]!;
   slot.data.accent = ACCENT_CYCLE[i % ACCENT_CYCLE.length]!;
+  // one hook covers ambient cadence AND the orbit volley; the case gates on
+  // reduced motion + the issue window (silent while mounted at +/-1).
+  sfxMoment("chatPop", i);
 }
 
 // ---- donation beat (the issue's ONE budgeted flash, S2.16) ------------------

--- a/issues/11-terminal/shots.ts
+++ b/issues/11-terminal/shots.ts
@@ -6,6 +6,7 @@ import { PopPool } from "@/lib/pops";
 import { snapshots } from "@/lib/snapshots";
 import { content, issueCopy, links } from "@/lib/content";
 import { uiSound } from "@/lib/audio/ui";
+import { sfxMoment } from "@/lib/audio/moments";
 import { issueCenter, RANGES } from "../timeline";
 
 /**
@@ -206,7 +207,10 @@ export function runCommand(cmd: string): boolean {
     return false;
   }
   spawnPanel(cmd, cmd === "contact" ? locked + "\n" + assembleEmail() : locked);
-  if (cmd === "resume") dropPool.spawn(RESUME_DROP_POS);
+  if (cmd === "resume") {
+    dropPool.spawn(RESUME_DROP_POS);
+    sfxMoment("resumeDrop"); // flutter down + fwump onto the desk snapshot
+  }
   if (cmd === "github" && links.githubUrl !== "") window.open(links.githubUrl, "_blank", "noopener");
   if (cmd === "linkedin" && links.linkedinUrl !== "") window.open(links.linkedinUrl, "_blank", "noopener");
   uiSound("cmdOk", charSum(cmd)); // per-command pitch identity (Enter + card click)

--- a/lib/audio/debug.ts
+++ b/lib/audio/debug.ts
@@ -1,0 +1,14 @@
+/**
+ * Dev-only structural audio tap. Every fire* helper / sfxMoment case calls
+ * logFire(name); the gate audit reads (window as any).__audioLog to assert
+ * trigger counts per scroll window. Dead-stripped in production builds.
+ */
+import { useScrollStore } from "@/lib/scrollStore";
+
+export function logFire(name: string): void {
+  if (process.env.NODE_ENV === "production") return;
+  if (typeof window === "undefined") return;
+  const w = window as unknown as { __audioLog?: { name: string; t: number }[] };
+  if (!w.__audioLog) w.__audioLog = [];
+  w.__audioLog.push({ name, t: useScrollStore.getState().t });
+}

--- a/lib/audio/debug.ts
+++ b/lib/audio/debug.ts
@@ -11,4 +11,5 @@ export function logFire(name: string): void {
   const w = window as unknown as { __audioLog?: { name: string; t: number }[] };
   if (!w.__audioLog) w.__audioLog = [];
   w.__audioLog.push({ name, t: useScrollStore.getState().t });
+  if (w.__audioLog.length > 2000) w.__audioLog.splice(0, w.__audioLog.length - 2000);
 }

--- a/lib/audio/director.ts
+++ b/lib/audio/director.ts
@@ -63,6 +63,10 @@ let session = 0;
 let raf = 0;
 let lastNow = 0;
 let warned = false;
+// monotonic guard for the shared thump/chime one-shots: next Tone time they are
+// free to schedule. A deep jump can resolve two beat crossings in one frame, so
+// two hits arrive at the same `now` -- Tone throws if starts invert on a synth.
+let beatFree = 0;
 
 function warn(e: unknown): void {
   if (warned) return;
@@ -90,6 +94,7 @@ export function enableAudio(): void {
     enabled = true;
     pending = false;
     lastNow = performance.now();
+    beatFree = 0; // reset the one-shot gate on every (re-)enable
     cancelAnimationFrame(raf);
     raf = requestAnimationFrame(loop);
   })().catch((e) => {
@@ -198,11 +203,20 @@ function wire(): void {
     try {
       const now = m.T.now();
       if (beatMoment(id, flash)) return; // moment owns the hit (sound or silence)
+      // monotonic gate: two beats can resolve in one frame on a deep jump, so
+      // stagger the second start past the first. Consumed only for default hits
+      // (below the beatMoment return, so moment-owned beats never advance it).
+      const a = now <= beatFree ? beatFree + 0.008 : now;
+      beatFree = a + 0.35;
       // sidechain duck: a strong director thump dips the bed, then recovers.
       // BELOW the beatMoment return, so moment-owned beats (some deliberately
       // silent, e.g. neon cascade) never duck. Rides duckGain (not music.gain)
       // so the meter/visual pulse stays clean. Event-driven (fires on a beat
       // crossing) -- zero per-frame alloc; inherits the beat hook's gates.
+      // Based at `now`, NOT the gated `a`: params have no strict-time constraint,
+      // and cancel-from-now + setValueAtTime(g.value, now) is click-free. Only the
+      // thump/chime SYNTH triggers below take `a` (starts must be strictly
+      // increasing). Rebasing the ramps onto `a` popped when a is bumped ahead.
       if (flash > 0.25) {
         const g = m.duckGain.gain;
         g.cancelScheduledValues(now);
@@ -210,8 +224,8 @@ function wire(): void {
         g.linearRampToValueAtTime(0.55, now + 0.03);
         g.linearRampToValueAtTime(1, now + 0.53);
       }
-      if (flash > 0) m.thump.triggerAttackRelease("A1", 0.3, now, 0.4 + 0.6 * Math.min(flash, 1));
-      else m.chime.triggerAttackRelease("D6", 0.2, now, 0.7);
+      if (flash > 0) m.thump.triggerAttackRelease("A1", 0.3, a, 0.4 + 0.6 * Math.min(flash, 1));
+      else m.chime.triggerAttackRelease("D6", 0.2, a, 0.7);
     } catch (e) {
       warn(e);
     }

--- a/lib/audio/moments.ts
+++ b/lib/audio/moments.ts
@@ -8,6 +8,7 @@ import type {
   Noise,
   NoiseSynth,
   Oscillator,
+  Panner,
   Synth,
 } from "tone";
 import { clamp01 } from "@/lib/shots";
@@ -16,16 +17,20 @@ import { RANGES } from "@/issues/timeline";
 import type { ToneModule } from "./types";
 import { h01, hash, moveTo } from "./util";
 import { fireMeowVoice } from "./ui";
+import { logFire } from "./debug";
 // Read-only scene constants (all already exported). These are pure numbers /
 // pure f(t) helpers -- importing them adds NO Tone at module scope and no new
 // autoplay path (Tone stays lazy, handed in via scoreMoments' T argument).
-import { KEYS_R } from "@/issues/02-desk/shots";
+import { NOIR_SHOTS } from "@/issues/01-noir/shots";
+import { KEYS_R, PANELS_R } from "@/issues/02-desk/shots";
 import { NEON_CASCADE_END, NEON_CASCADE_T } from "@/issues/03-neon/shots";
-import { PRESS_PART_T } from "@/issues/05-press/shots";
-import { STATION_X, trainSpeed, trainX } from "@/issues/07-screentone/shots";
+import { ORIGIN_CAT_HOP, ORIGIN_CAT_WALK } from "@/issues/04-origin/shots";
+import { PRESS_CTA_IN, PRESS_PART_T } from "@/issues/05-press/shots";
+import { STATION_X, trainDisplayX, trainSpeed, trainX } from "@/issues/07-screentone/shots";
 import { ORBIT_START_T } from "@/issues/08-pop/shots";
 import { FLOOD_T, inkAt } from "@/issues/09-sketchbook/shots";
 import { UNFOLD_RANGE } from "@/issues/10-spread/shots";
+import { CAT_WALK_RANGE } from "@/issues/11-terminal/shots";
 
 /**
  * Wave C: the reactive "moments" layer -- a self-contained sibling of
@@ -84,6 +89,25 @@ class Edge {
   }
 }
 
+/* ------------------------------------------------------------- VoiceGate --- */
+/** Strictly-increasing start-time gate for one mono voice. at() returns the
+ * admissible start (bumped past the voice's busy window if needed). One fast
+ * scrub or a single frame crossing several Edge thresholds of one bank would
+ * otherwise start the same synth twice at the same/inverted time -> Tone's
+ * "Start time must be strictly greater than previous start time" RangeError,
+ * which the director catch turns into a global audio disable. */
+class VoiceGate {
+  private free = 0;
+  at(now: number, busy: number): number {
+    const a = now <= this.free ? this.free + 0.008 : now;
+    this.free = a + busy;
+    return a;
+  }
+  reset(): void {
+    this.free = 0;
+  }
+}
+
 /* -------------------------------------------------- windows + note tables --- */
 const CLACK_FRACS = [0.12, 0.3, 0.46, 0.62, 0.76, 0.9] as const;
 const CLACK_HYST = 0.0008;
@@ -92,10 +116,29 @@ const STATION_HYST = 4; // world units (stations ~24 apart)
 const INK_HYST = 0.02;
 const STAR_HYST = 0.015;
 const PAW_HYST = 0.008; // < pawprint spacing (0.3/9) so each step re-arms alone
+const NOIR_PAW_HYST = 0.02; // < noir stride spacing (1/9) so each step re-arms
+
+// screentone station machine: DWELL stations get brake/chime/depart; the two
+// PASS stations get the horn + a dedicated pass-whoosh (indices from KNOTS).
+const DWELL_STATIONS = [0, 1, 2, 4, 6, 7] as const;
+const PASS_STATIONS = [3, 5] as const;
+const R7 = RANGES[7]!;
+
+// desk panel-drop pops: 3 comic panels land across PANELS_R with a note step.
+const PANEL_FRACS = [0.1, 0.42, 0.74] as const;
+const PANEL_NOTES = ["C3", "D3", "E3"] as const;
 
 const POP_RANGE = RANGES[8]!;
-/** ORBIT_F is not exported by 08-pop; derive it from ORBIT_START_T. */
-const ORBIT_F = (ORBIT_START_T - POP_RANGE[0]) / (POP_RANGE[1] - POP_RANGE[0]);
+/**
+ * ORBIT_F is not exported by 08-pop; derive it from ORBIT_START_T. Computed
+ * lazily (NOT at module scope): spawnChat now calls sfxMoment, so moments and
+ * 08-pop/shots form an import cycle -- reading ORBIT_START_T at module scope
+ * could hit its TDZ if 08-pop/shots is the cycle entry. At first tick both
+ * modules are fully evaluated.
+ */
+let orbitF = -1;
+const orbitFrac = () =>
+  orbitF < 0 ? (orbitF = (ORBIT_START_T - POP_RANGE[0]) / (POP_RANGE[1] - POP_RANGE[0])) : orbitF;
 /** wash-flood onset expressed in sketch ink-u (== inkAt(FLOOD_T) == 0.65). */
 const FLOOD_U = inkAt(FLOOD_T);
 
@@ -127,6 +170,29 @@ interface Kit {
   hornB: Synth;
   hornLp: Filter;
   hornDelay: FeedbackDelay;
+  // screentone station machine (brake / PA chime / door beep / pass-whoosh),
+  // all placed on screen by trainPan while the train is in the issue window
+  trainPan: Panner;
+  brakeSqueal: Synth;
+  brakeBp: Filter;
+  brakeHiss: NoiseSynth;
+  brakeHissHp: Filter;
+  chimeSyn: Synth;
+  departSyn: Synth;
+  passWhoosh: NoiseSynth;
+  passWhooshBp: Filter;
+  // neon sign-ignition buzz (FM crackle + a reused ring snap)
+  signBuzz: FMSynth;
+  // pop chat-balloon bloops, panned per balloon
+  chatBloop: Synth;
+  chatPan: Panner;
+  // spread page-riffle whoosh, alternating L/R with the fan-out
+  pageWhoosh: NoiseSynth;
+  pageWhooshBp: Filter;
+  spreadPan: Panner;
+  // terminal resume paper-flutter
+  flutter: NoiseSynth;
+  flutterBp: Filter;
   // pop 360 whoosh + crowd (continuous)
   popWhoosh: Noise;
   popWhooshBp: Filter;
@@ -188,6 +254,10 @@ interface Kit {
   landLp: Filter;
   pawTick: NoiseSynth;
   pawLp: Filter;
+  // paw steps route through catPan (default center); the terminal walk-off
+  // ramps it stage-right per step. Every firePaw sets the pan, so no other
+  // scene inherits a stale offset.
+  catPan: Panner;
   boopSyn: Synth;
 }
 
@@ -279,6 +349,50 @@ function buildKit(T: ToneModule, sfx: Gain): Kit {
   const hornB = new T.Synth({ oscillator: { type: "fattriangle", count: 2, spread: 14 }, envelope: hornEnv, volume: -22 });
   hornA.connect(hornLp);
   hornB.connect(hornLp);
+
+  // -- screentone station machine, all through trainPan (screen placement)
+  const trainPan = new T.Panner(0);
+  trainPan.connect(sfx);
+  // brake squeal: descending fatsaw through a tight bandpass + an air hiss
+  const brakeBp = new T.Filter({ frequency: 2400, type: "bandpass", Q: 4 });
+  brakeBp.connect(trainPan);
+  const brakeSqueal = new T.Synth({
+    oscillator: { type: "fatsawtooth", count: 3, spread: 20 },
+    envelope: { attack: 0.02, decay: 0.5, sustain: 0.3, release: 0.15 },
+    volume: -22,
+  });
+  brakeSqueal.connect(brakeBp);
+  const brakeHissHp = new T.Filter(3500, "highpass");
+  brakeHissHp.connect(trainPan);
+  const brakeHiss = new T.NoiseSynth({
+    noise: { type: "white" },
+    envelope: { attack: 0.02, decay: 0.25, sustain: 0.1, release: 0.15 },
+    volume: -20,
+  });
+  brakeHiss.connect(brakeHissHp);
+  // PA ding-dong chime (rides the global hall reverb on the sfx bus)
+  const chimeSyn = new T.Synth({
+    oscillator: { type: "sine" },
+    envelope: { attack: 0.005, decay: 0.35, sustain: 0, release: 0.3 },
+    volume: -20,
+  });
+  chimeSyn.connect(trainPan);
+  // door double-beep on departure
+  const departSyn = new T.Synth({
+    oscillator: { type: "square" },
+    envelope: { attack: 0.002, decay: 0.06, sustain: 0, release: 0.03 },
+    volume: -22,
+  });
+  departSyn.connect(trainPan);
+  // pass-whoosh: pink noise through a falling bandpass (train blows past)
+  const passWhooshBp = new T.Filter({ frequency: 2400, type: "bandpass", Q: 1.2 });
+  passWhooshBp.connect(trainPan);
+  const passWhoosh = new T.NoiseSynth({
+    noise: { type: "pink" },
+    envelope: { attack: 0.02, decay: 0.4, sustain: 0.2, release: 0.15 },
+    volume: -16,
+  });
+  passWhoosh.connect(passWhooshBp);
 
   // -- pop 360 whoosh + crowd (continuous, started on demand)
   const popWhooshGain = new T.Gain(0);
@@ -477,6 +591,47 @@ function buildKit(T: ToneModule, sfx: Gain): Kit {
   });
   edgeHorn.connect(sfx);
 
+  // -- neon sign-ignition buzz (FM crackle; the snap reuses ringSnap above)
+  const signBuzz = new T.FMSynth({
+    harmonicity: 1,
+    modulationIndex: 20,
+    envelope: { attack: 0.005, decay: 0.18, sustain: 0, release: 0.08 },
+    volume: -20,
+  });
+  signBuzz.connect(sfx);
+
+  // -- pop chat-balloon bloops (rising sine, panned per balloon)
+  const chatPan = new T.Panner(0);
+  chatPan.connect(sfx);
+  const chatBloop = new T.Synth({
+    oscillator: { type: "sine" },
+    envelope: { attack: 0.005, decay: 0.1, sustain: 0, release: 0.05 },
+    volume: -18,
+  });
+  chatBloop.connect(chatPan);
+
+  // -- spread page-riffle whoosh (rising bandpass, alternating L/R fan-out)
+  const spreadPan = new T.Panner(0);
+  spreadPan.connect(sfx);
+  const pageWhooshBp = new T.Filter(500, "bandpass");
+  pageWhooshBp.connect(spreadPan);
+  const pageWhoosh = new T.NoiseSynth({
+    noise: { type: "pink" },
+    envelope: { attack: 0.02, decay: 0.28, sustain: 0 },
+    volume: -20,
+  });
+  pageWhoosh.connect(pageWhooshBp);
+
+  // -- terminal resume paper-flutter (pink noise, stepped-down bandpass)
+  const flutterBp = new T.Filter(1600, "bandpass");
+  flutterBp.connect(sfx);
+  const flutter = new T.NoiseSynth({
+    noise: { type: "pink" },
+    envelope: { attack: 0.002, decay: 0.05, sustain: 0 },
+    volume: -22,
+  });
+  flutter.connect(flutterBp);
+
   // -- cat meow: no local synth -- moments fires ui.ts's shared meow voice
   // (fireMeowVoice), so a single FMSynth + ME-OW contour serves click + sfx.
 
@@ -497,14 +652,18 @@ function buildKit(T: ToneModule, sfx: Gain): Kit {
   });
   landNoise.chain(landLp, sfx);
 
-  // -- paw-step tick (sketch walk pad-steps): very short brown-noise pad, quiet.
+  // -- paw-step tick (walk pad-steps): very short brown-noise pad, quiet.
+  // Routed through catPan so the terminal walk-off can pan steps stage-right;
+  // every firePaw sets the pan (default 0) so other scenes stay centered.
+  const catPan = new T.Panner(0);
+  catPan.connect(sfx);
   const pawLp = new T.Filter(700, "lowpass");
   const pawTick = new T.NoiseSynth({
     noise: { type: "brown" },
     envelope: { attack: 0.001, decay: 0.02, sustain: 0 },
     volume: -26,
   });
-  pawTick.chain(pawLp, sfx);
+  pawTick.chain(pawLp, catPan);
 
   // -- playful "boop" (cat bats the halftone dot): short triangle blip.
   const boopSyn = new T.Synth({
@@ -519,6 +678,11 @@ function buildKit(T: ToneModule, sfx: Gain): Kit {
     ringSyn, ringBp, ringDelay, ringSnap, ringSnapHp,
     partMembrane, partReact, partTs, partTsBp, partRust, partAiA, partAiB,
     hornA, hornB, hornLp, hornDelay,
+    trainPan, brakeSqueal, brakeBp, brakeHiss, brakeHissHp, chimeSyn, departSyn, passWhoosh, passWhooshBp,
+    signBuzz,
+    chatBloop, chatPan,
+    pageWhoosh, pageWhooshBp, spreadPan,
+    flutter, flutterBp,
     popWhoosh, popWhooshBp, popWhooshGain, crowdA, crowdB, crowdC, crowdLp, crowdGain, hushNoise, hushLp,
     inkTick, inkTickHp, washNoise, washLp, washSine,
     starBell, starDelay,
@@ -528,7 +692,7 @@ function buildKit(T: ToneModule, sfx: Gain): Kit {
     newsMembrane, newsBody, newsTele, newsTeleHp,
     titleMembrane, titleClang, titleCrack,
     edgeMembrane, edgeScreech, edgeScreechBp, edgeWhoosh, edgeWhooshBp, edgeHorn,
-    landThud, landNoise, landLp, pawTick, pawLp, boopSyn,
+    landThud, landNoise, landLp, pawTick, pawLp, catPan, boopSyn,
   };
 }
 
@@ -547,6 +711,17 @@ const inkEdges = Array.from({ length: 6 }, () => new Edge());
 const washEdge = new Edge();
 const starEdges = Array.from({ length: 10 }, () => new Edge());
 const pawEdges = Array.from({ length: 10 }, () => new Edge()); // sketch pad-steps
+const panelEdges = Array.from({ length: 3 }, () => new Edge()); // desk panel drops
+const brakeEdges = Array.from({ length: 6 }, () => new Edge()); // screentone DWELL
+const chimeEdges = Array.from({ length: 6 }, () => new Edge());
+const departEdges = Array.from({ length: 6 }, () => new Edge());
+const passEdges = Array.from({ length: 2 }, () => new Edge()); // screentone PASS
+const ctaEdge = new Edge(); // press CTA plop
+const pawEdgesNoir = Array.from({ length: 9 }, () => new Edge()); // noir parapet
+const pawEdgesOrigin = Array.from({ length: 6 }, () => new Edge()); // origin margin
+const hopEdgeOrigin = new Edge();
+const catWalkEdges = Array.from({ length: 8 }, () => new Edge()); // terminal exit
+const catHopEdge = new Edge();
 const allEdges: Edge[] = [
   ...clackEdges,
   ...partEdges,
@@ -555,7 +730,55 @@ const allEdges: Edge[] = [
   washEdge,
   ...starEdges,
   ...pawEdges,
+  ...panelEdges,
+  ...brakeEdges,
+  ...chimeEdges,
+  ...departEdges,
+  ...passEdges,
+  ctaEdge,
+  ...pawEdgesNoir,
+  ...pawEdgesOrigin,
+  hopEdgeOrigin,
+  ...catWalkEdges,
+  catHopEdge,
 ];
+
+// Per-voice monotonic start-time gates: one per mono voice that a bank loop or
+// shared usage can start more than once per tick. Every fire* below routes its
+// synth start(s) through the matching gate so a multi-cross frame staggers the
+// starts instead of throwing (params/filters are not gated -- only synth starts).
+const clackGate = new VoiceGate(); // desk clackNoise/clackThock pair (+ panel clack)
+const partGate = new VoiceGate(); // press part-add voices
+const hornGate = new VoiceGate(); // screentone hornA + hornB
+const inkGate = new VoiceGate(); // sketch ink ticks + noir wet-splash tick
+const starGate = new VoiceGate(); // spread starBell + pageWhoosh
+const brakeGate = new VoiceGate(); // screentone brakeSqueal + brakeHiss
+const chimeGate = new VoiceGate(); // screentone PA chime
+const departGate = new VoiceGate(); // screentone door beep
+const passGate = new VoiceGate(); // screentone pass-whoosh
+const pawGate = new VoiceGate(); // cat pawTick (every pad-step bank)
+const landGate = new VoiceGate(); // landThud + landNoise (land/hop/panel/resumeDrop)
+const kachGate = new VoiceGate(); // kachPop (cta plop + resumeDrop share it)
+const boopGate = new VoiceGate(); // boopSyn (boop + cta plop)
+const chatGate = new VoiceGate(); // pop chatBloop
+const signGate = new VoiceGate(); // neon signBuzz
+const flutterGate = new VoiceGate(); // terminal resume flutter
+const ringGate = new VoiceGate(); // neon ringSyn (fireRing primary voice)
+const washGate = new VoiceGate(); // sketch washNoise + washSine flood
+const edgeGate = new VoiceGate(); // edgeWhoosh shared: leap + edge-run + orbit-360
+const stampGate = new VoiceGate(); // stampMembrane shared: press-stamp + terminal-back-cover
+const ringSnapGate = new VoiceGate(); // ringSnap shared: fireRing + fireSignBuzz (same cascade frame)
+const gates: VoiceGate[] = [
+  clackGate, partGate, hornGate, inkGate, starGate, brakeGate, chimeGate,
+  departGate, passGate, pawGate, landGate, kachGate, boopGate, chatGate,
+  signGate, flutterGate, ringGate, washGate, edgeGate, stampGate, ringSnapGate,
+];
+
+// deep-jump guard: a t delta this large is a teleport (print<->3D toggle,
+// JumpCover nav, scrollbar drag), not a scroll -- without it every crossed Edge
+// fires, serialized by the VoiceGates into seconds of machine-gun sound. NaN =
+// unprimed (first tick after enable / reset). See the top of scoreMoments.
+let lastScoreT = NaN;
 
 // neon cascade: step-increment latch (own priming; scrub-back re-arms silent)
 let neonPrimed = false;
@@ -568,23 +791,36 @@ const gWhoosh = { v: 0 };
 const gCrowd = { v: 0 };
 const fWhooshC = { v: 300 };
 
+// screentone train panner (only ramped while t is inside the issue window)
+const gTrainPan = { v: 0 };
+
 /* --------------------------------------------- score-reaction one-shots --- */
 function fireClack(k: Kit, now: number, i: number): void {
+  logFire("clack");
+  now = clackGate.at(now, 0.1);
   k.clackNoise.triggerAttackRelease(0.018, now, 0.6 + 0.2 * h01(i * 7 + 1));
   const f = 180 + ((hash(i * 5 + 2) % 61) - 30); // 180 +/- 30 Hz, hashed
   k.clackThock.triggerAttackRelease(f, 0.04, now, 0.7 + 0.2 * h01(i + 3));
 }
 
 function fireRing(k: Kit, now: number, ring: number): void {
+  logFire("ring");
+  // step latch advances to `step` in one assignment (fires once per tick), but a
+  // scrub oscillating across the cascade could re-arm within the 0.05 release --
+  // gate so ringSyn/ringSnap never re-attack before a pending release.
+  now = ringGate.at(now, 0.3);
   const note = 196 * Math.pow(2, ring / 12); // climb the cascade
   k.ringBp.frequency.rampTo(1500 + 1700 * (ring / 10), 0.02, now);
   let vel = 0.4 + 0.3 * h01(ring * 3 + 1);
   if (ring === 10) vel = Math.min(1, vel * 2); // hero tower +6 dB
   k.ringSyn.triggerAttackRelease(note, 0.05, now, vel);
-  if (ring % 2 === 1) k.ringSnap.triggerAttackRelease(0.015, now, 0.4);
+  // ringSnap is shared with fireSignBuzz in the same cascade frame -> own gate
+  if (ring % 2 === 1) k.ringSnap.triggerAttackRelease(0.015, ringSnapGate.at(now, 0.15), 0.4);
 }
 
 function firePart(k: Kit, now: number, i: number): void {
+  logFire("part");
+  now = partGate.at(now, 0.2);
   k.partMembrane.triggerAttackRelease("F1", 0.12, now, 0.9);
   if (i === 0) k.partReact.triggerAttackRelease(660, 0.08, now, 0.6);
   else if (i === 1) k.partTs.triggerAttackRelease(440, 0.09, now, 0.6);
@@ -596,15 +832,21 @@ function firePart(k: Kit, now: number, i: number): void {
 }
 
 function fireHorn(k: Kit, now: number): void {
+  logFire("horn");
+  now = hornGate.at(now, 0.6);
   k.hornA.triggerAttackRelease(155, 0.6, now, 0.7);
   k.hornB.triggerAttackRelease(233, 0.6, now, 0.6);
 }
 
 function fireInk(k: Kit, now: number, i: number): void {
+  logFire("ink");
+  now = inkGate.at(now, 0.05);
   k.inkTick.triggerAttackRelease(0.01, now, 0.4 + 0.3 * h01(i * 9 + 1));
 }
 
 function fireWash(k: Kit, now: number): void {
+  logFire("wash");
+  now = washGate.at(now, 0.4); // washNoise/washSine hold 0.5s; guard re-fire across FLOOD_U
   k.washLp.frequency.cancelScheduledValues(now);
   k.washLp.frequency.setValueAtTime(400, now);
   k.washLp.frequency.linearRampToValueAtTime(2000, now + 0.3);
@@ -613,33 +855,149 @@ function fireWash(k: Kit, now: number): void {
 }
 
 function fireStar(k: Kit, now: number, page: number): void {
+  logFire("star");
+  now = starGate.at(now, 0.3);
   k.starBell.triggerAttackRelease(PENTA[page]!, 0.5, now, 0.4 + 0.2 * h01(page + 1));
+  // page-riffle whoosh: rising bandpass, alternating L/R widening (the fan-out)
+  k.spreadPan.pan.rampTo((page % 2 ? 1 : -1) * (0.25 + 0.045 * page), 0.01, now);
+  k.pageWhooshBp.frequency.cancelScheduledValues(now);
+  k.pageWhooshBp.frequency.setValueAtTime(500, now);
+  k.pageWhooshBp.frequency.linearRampToValueAtTime(1400, now + 0.25);
+  k.pageWhoosh.triggerAttackRelease(0.28, now, 0.4 + 0.2 * h01(page));
+}
+
+/* --- screentone station machine (all voices routed through trainPan) ------- */
+function fireBrake(k: Kit, now: number): void {
+  logFire("brake");
+  now = brakeGate.at(now, 0.55);
+  k.brakeSqueal.triggerAttack(1400, now, 0.5);
+  k.brakeSqueal.frequency.rampTo(600, 0.5, now); // descending metal squeal
+  k.brakeSqueal.triggerRelease(now + 0.5);
+  k.brakeHiss.triggerAttackRelease(0.2, now + 0.35, 0.5); // air-brake release
+}
+
+function fireChime(k: Kit, now: number, i: number): void {
+  logFire("chime");
+  now = chimeGate.at(now, 0.3);
+  const detune = Math.pow(2, ((hash(i) % 3) - 1) / 12); // +/- 1 semitone
+  k.chimeSyn.triggerAttackRelease(659.25 * detune, 0.35, now, 0.6); // E5 ding
+  k.chimeSyn.triggerAttackRelease(523.25 * detune, 0.4, now + 0.28, 0.6); // C5 dong
+}
+
+function fireDepart(k: Kit, now: number): void {
+  logFire("depart");
+  now = departGate.at(now, 0.2);
+  k.departSyn.triggerAttackRelease(783.99, 0.05, now, 0.35); // G5 door beep
+  k.departSyn.triggerAttackRelease(783.99, 0.05, now + 0.09, 0.35);
+}
+
+function firePass(k: Kit, now: number, sp: number): void {
+  logFire("pass");
+  now = passGate.at(now, 0.5);
+  k.passWhooshBp.frequency.cancelScheduledValues(now);
+  k.passWhooshBp.frequency.setValueAtTime(2400, now);
+  k.passWhooshBp.frequency.linearRampToValueAtTime(500, now + 0.45); // falling = passing
+  k.passWhoosh.triggerAttackRelease(0.45, now, 0.5 + 0.3 * sp);
+}
+
+/* --- other scene one-shots -------------------------------------------------- */
+function firePanel(k: Kit, now: number, i: number): void {
+  logFire("panel");
+  // two shared voices: gate each in its own family (clack pair / land pair).
+  k.clackNoise.triggerAttackRelease(0.018, clackGate.at(now, 0.1), 0.5);
+  k.landThud.triggerAttackRelease(PANEL_NOTES[i]!, 0.16, landGate.at(now, 0.2), 0.4);
+}
+
+function firePlop(k: Kit, now: number): void {
+  logFire("plop");
+  // kachPop shares kachGate with resumeDrop; boopSyn shares boopGate with boop.
+  const kp = kachGate.at(now, 0.3);
+  k.kachPopLp.frequency.rampTo(600, 0.02, kp);
+  k.kachPop.triggerAttackRelease(0.4, kp, 0.4);
+  const bp = boopGate.at(now, 0.25);
+  k.boopSyn.triggerAttack(300, bp, 0.5);
+  k.boopSyn.frequency.rampTo(240, 0.08, bp + 0.01);
+  k.boopSyn.triggerRelease(bp + 0.14);
+}
+
+function fireHop(k: Kit, now: number): void {
+  logFire("hop");
+  now = landGate.at(now, 0.2);
+  k.landThud.triggerAttackRelease("C3", 0.16, now, 0.3);
+}
+
+function fireSignBuzz(k: Kit, now: number, seed: number): void {
+  logFire("signBuzz");
+  now = signGate.at(now, 0.2);
+  const freq = 55 * Math.pow(2, 3 + (hash(seed) % 12) / 12);
+  k.signBuzz.triggerAttackRelease(freq, 0.18, now, 0.5);
+  k.ringSnap.triggerAttackRelease(0.015, ringSnapGate.at(now, 0.15), 0.3); // ignition snap (shared voice -> gated)
+}
+
+function fireChatPop(k: Kit, now: number, seed: number): void {
+  logFire("chatPop");
+  now = chatGate.at(now, 0.15);
+  k.chatPan.pan.rampTo((h01(seed * 7 + 2) - 0.5) * 1.1, 0.01, now);
+  const base = 520 + 240 * h01(seed + 3);
+  k.chatBloop.triggerAttack(base, now, 0.5);
+  k.chatBloop.frequency.rampTo(base * 1.35, 0.05, now); // rising = appearing
+  k.chatBloop.triggerRelease(now + 0.12);
+}
+
+function fireResumeDrop(k: Kit, now: number): void {
+  logFire("resumeDrop");
+  now = flutterGate.at(now, 0.4); // the 3-tap flutter sequence rides this base
+  k.flutterBp.frequency.cancelScheduledValues(now);
+  k.flutterBp.frequency.setValueAtTime(1600, now);
+  k.flutter.triggerAttackRelease(0.05, now, 0.5);
+  k.flutterBp.frequency.setValueAtTime(1200, now + 0.12);
+  k.flutter.triggerAttackRelease(0.05, now + 0.12, 0.45);
+  k.flutterBp.frequency.setValueAtTime(900, now + 0.26);
+  k.flutter.triggerAttackRelease(0.05, now + 0.26, 0.4);
+  // fwump: the sheet settles onto the desk snapshot -- landThud + kachPop are
+  // shared, so gate each in its own family (not just the flutter base).
+  const fwump = landGate.at(now + 0.5, 0.2);
+  k.landThud.triggerAttackRelease("C2", 0.16, fwump, 0.35);
+  const pop = kachGate.at(now + 0.5, 0.3);
+  k.kachPopLp.frequency.setValueAtTime(400, pop);
+  k.kachPop.triggerAttackRelease(0.4, pop, 0.4);
 }
 
 /** 3 hash-varied base pitches so repeat meows never sound identical; fires the
  * ui.ts shared voice (one FMSynth + one ME-OW contour, no duplicate synth). */
 const MEOW_BASE = [496, 560, 448] as const;
 function fireMeow(now: number, i: number): void {
+  logFire("meow");
   const base = MEOW_BASE[hash(i * 7 + 1) % 3]!;
   fireMeowVoice(now, base, 1.4 + 0.12 * h01(i + 5));
 }
 
 function fireLand(k: Kit, now: number): void {
+  logFire("land");
+  now = landGate.at(now, 0.2);
   k.landThud.triggerAttackRelease("C2", 0.16, now, 0.75);
   k.landNoise.triggerAttackRelease(0.08, now, 0.6);
 }
 
-function firePaw(k: Kit, now: number, i: number): void {
+/** vel + pan default to the quiet self-hashed pad centered; the terminal
+ * walk-off passes a per-step velocity ramp + a widening stage-right pan. */
+function firePaw(k: Kit, now: number, i: number, vel = 0.4 + 0.2 * h01(i + 2), pan = 0): void {
+  logFire("paw");
+  now = pawGate.at(now, 0.05);
+  k.catPan.pan.rampTo(pan, 0.02, now);
   k.pawLp.frequency.rampTo(600 + (hash(i * 5 + 3) % 240), 0.005, now);
-  k.pawTick.triggerAttackRelease(0.02, now, 0.4 + 0.2 * h01(i + 2));
+  k.pawTick.triggerAttackRelease(0.02, now, vel);
 }
 
 function fireBoop(k: Kit, now: number): void {
+  logFire("boop");
+  now = boopGate.at(now, 0.25);
   const s = k.boopSyn;
   s.triggerAttack(520, now, 0.7);
   s.frequency.rampTo(360, 0.07, now + 0.01); // quick down = "boop"
   s.frequency.rampTo(420, 0.05, now + 0.09); // tiny lift, playful
-  s.triggerRelease(now + 0.14);
+  s.frequency.rampTo(900, 0.06, now + 0.15); // bat contact -> dot flight up
+  s.triggerRelease(now + 0.24);
 }
 
 /* --------------------------------------------------------- scoreMoments --- */
@@ -651,17 +1009,38 @@ export function scoreMoments(
   dtSec: number,
   velocity: number,
 ): void {
-  void velocity; // reactions are pure f(t); velocity is unused here by design
   const k = kit ?? (kit = buildKit(T, sfx));
   if (!TM) TM = T;
   momentsActive = true; // scoreMoments only runs while the director is enabled
   const now = T.now();
   const { reducedMotion } = useScrollStore.getState();
+  // anti catch-up (systemic): any large t jump -- print<->3D toggle, JumpCover
+  // nav, scrollbar drag -- would otherwise fire EVERY Edge it crossed, the
+  // VoiceGates serializing them into a machine-gun volley. On such a jump reset
+  // every latch and skip this tick's fires entirely; the edges re-prime silently
+  // next tick (BeatRunner deep-jump semantics), so no source can catch-up burst.
+  if (!Number.isNaN(lastScoreT) && Math.abs(t - lastScoreT) > 0.03) {
+    for (const e of allEdges) e.reset();
+    neonPrimed = false;
+    neonLast = -1;
+    lastScoreT = t;
+    return;
+  }
+  lastScoreT = t;
+  // anti-machine-gun: motion-narrating banks with >4 latches also gate on speed
+  // so a fling riffles past silent instead of stuttering (global rule).
+  const slow = Math.abs(velocity) < 0.5;
 
   // -- desk keycap clacks (issue 2): 6 CLACKs on the visible keycap dips
   const kw = KEYS_R[1] - KEYS_R[0];
   for (let i = 0; i < 6; i++) {
     if (clackEdges[i]!.crossed(t, KEYS_R[0] + CLACK_FRACS[i]! * kw, CLACK_HYST)) fireClack(k, now, i);
+  }
+
+  // -- desk panel-drop pops (issue 2): 3 comic panels land, each a clack + thud
+  const panelW = PANELS_R[1] - PANELS_R[0];
+  for (let i = 0; i < 3; i++) {
+    if (panelEdges[i]!.crossed(t, PANELS_R[0] + PANEL_FRACS[i]! * panelW, CLACK_HYST)) firePanel(k, now, i);
   }
 
   // -- neon ring zaps (issue 3): same 0..10 quantization as the visual boot.
@@ -680,20 +1059,62 @@ export function scoreMoments(
     neonLast = step; // scrub-back re-arms silently
   }
 
+  // -- noir cat pad-steps (issue 1): wet ink steps down the parapet (shot 3),
+  // motion-narrating -> reduced-motion + fling suppressed. crossed() runs every
+  // tick (brake/depart pattern) so latches never freeze during a fast scroll and
+  // volley when velocity drops; only the FIRE gates on !reducedMotion && slow.
+  // step 0 threshold floored at 0.02: p3 is clamp01'd, so an Edge primed at 0
+  // never crosses upward (same fix as spread star[0]).
+  const noirR = NOIR_SHOTS[2]!.range;
+  const p3 = clamp01((t - noirR[0]) / (noirR[1] - noirR[0]));
+  for (let i = 0; i < 9; i++) {
+    if (pawEdgesNoir[i]!.crossed(p3, Math.max(i / 9, 0.02), NOIR_PAW_HYST) && !reducedMotion && slow) {
+      // wet splash under the paw -- same inkTick voice as fireInk, so gate it
+      // (two parapet steps in one frame would else double-start inkTick).
+      k.inkTick.triggerAttackRelease(0.01, inkGate.at(now, 0.05), 0.15);
+      firePaw(k, now, i);
+    }
+  }
+
   // -- press part-add thumps (issue 5): 4 departments welding on
   for (let i = 0; i < 4; i++) {
     if (partEdges[i]!.crossed(t, PRESS_PART_T[i]!, PART_HYST)) firePart(k, now, i);
   }
 
-  // -- screentone far-off horn (issue 7): arrival at each station, moving only
+  // -- press CTA plop (issue 5): the DOM button drops into frame after the stamp
+  if (ctaEdge.crossed(t, PRESS_CTA_IN[0]!, PART_HYST)) firePlop(k, now);
+
+  // -- screentone station machine (issue 7): PASS stops (3,5) keep the far-off
+  // horn + a dedicated pass-whoosh; DWELL stops get brake squeal -> PA chime ->
+  // door beep. trainPan places every station sound where the train is on screen.
   const tx = trainX(t);
+  const sp = trainSpeed(t);
+  if (t > R7[0] - 0.02 && t < R7[1] + 0.02) {
+    const target = Math.max(-0.85, Math.min(0.85, trainDisplayX(t, reducedMotion) / 105));
+    moveTo(k.trainPan.pan, gTrainPan, target, 0.05, 0.01);
+  }
+  // horn re-gated to PASS stations only (was all 8; DWELL horns would stack on
+  // the brake/chime/depart banks below).
   for (let i = 0; i < 8; i++) {
-    if (stationEdges[i]!.crossed(tx, STATION_X[i]!, STATION_HYST) && trainSpeed(t) > 0.2) fireHorn(k, now);
+    if (stationEdges[i]!.crossed(tx, STATION_X[i]!, STATION_HYST) && sp > 0.2 && (i === 3 || i === 5) && !reducedMotion)
+      fireHorn(k, now);
+  }
+  for (let j = 0; j < 6; j++) {
+    const stx = STATION_X[DWELL_STATIONS[j]!]!;
+    // PA chime is an event marker: fires under reduced motion and at any speed.
+    if (chimeEdges[j]!.crossed(tx, stx - 0.5, STATION_HYST)) fireChime(k, now, j);
+    if (brakeEdges[j]!.crossed(tx, stx - 6, STATION_HYST) && !reducedMotion && slow) fireBrake(k, now);
+    if (departEdges[j]!.crossed(tx, stx + 2, STATION_HYST) && !reducedMotion && slow) fireDepart(k, now);
+  }
+  for (let j = 0; j < 2; j++) {
+    if (passEdges[j]!.crossed(tx, STATION_X[PASS_STATIONS[j]!]!, STATION_HYST) && !reducedMotion && slow)
+      firePass(k, now, sp);
   }
 
   // -- pop 360 whoosh + crowd (issue 8): continuous, pure f(t) both directions
   const tLocal8 = clamp01((t - POP_RANGE[0]) / (POP_RANGE[1] - POP_RANGE[0]));
-  const pp = clamp01((tLocal8 - ORBIT_F) / (1 - ORBIT_F));
+  const of = orbitFrac();
+  const pp = clamp01((tLocal8 - of) / (1 - of));
   const spd = Math.min(1, 6 * pp * (1 - pp)); // d/dp easeInOut, peaks mid-spin
   const swell = Math.sin(Math.PI * pp);
   const popActive = pp > 0.0001 && pp < 0.9999 && (spd > 0.002 || swell > 0.002);
@@ -741,7 +1162,35 @@ export function scoreMoments(
   // -- spread star-chart arp (issue 10): one shimmer per page reveal, stops at 10
   const u10 = clamp01((t - UNFOLD_RANGE[0]) / (UNFOLD_RANGE[1] - UNFOLD_RANGE[0]));
   for (let i = 0; i < 10; i++) {
-    if (starEdges[i]!.crossed(u10, i * 0.055, STAR_HYST)) fireStar(k, now, i);
+    // page 0 needs a positive threshold: clamp01 floors u10 at 0, so an Edge
+    // primed AT 0 never crosses upward (only 9 of 10 pages would sound).
+    if (starEdges[i]!.crossed(u10, Math.max(i * 0.055, 0.02), STAR_HYST)) fireStar(k, now, i);
+  }
+
+  // -- origin cat margin-walk + portal hop (issue 4): quiet guide steps, then a
+  // soft land as it perches on the portal frame. Motion-narrating -> gated.
+  // crossed() runs every tick (brake/depart pattern); only the FIRE gates on
+  // !reducedMotion && slow. Per-bank hysteresis = half this bank's own step
+  // spacing (ow/6): the shared PAW_HYST is ~4x this dense bank's spacing.
+  const ow = ORIGIN_CAT_WALK[1] - ORIGIN_CAT_WALK[0];
+  const originPawHyst = ow / 12;
+  for (let i = 0; i < 6; i++) {
+    if (pawEdgesOrigin[i]!.crossed(t, ORIGIN_CAT_WALK[0] + (i / 6) * ow, originPawHyst) && !reducedMotion && slow)
+      firePaw(k, now, i, 0.25);
+  }
+  if (hopEdgeOrigin.crossed(t, ORIGIN_CAT_HOP[1]!, CLACK_HYST) && !reducedMotion && slow) fireHop(k, now);
+
+  // -- terminal cat walk-off (issue 11): a hop off the tower, then 8 steps that
+  // pan stage-right and fade as the guide exits. Motion-narrating -> gated.
+  // crossed() runs every tick (brake/depart pattern); only the FIRE gates on
+  // !reducedMotion && slow. Per-bank hysteresis = half this bank's own step
+  // spacing (cw/8): the shared PAW_HYST is ~2x this dense bank's spacing.
+  const cw = CAT_WALK_RANGE[1] - CAT_WALK_RANGE[0];
+  const termPawHyst = cw / 16;
+  if (catHopEdge.crossed(t, CAT_WALK_RANGE[0] + 0.06 * cw, CLACK_HYST) && !reducedMotion && slow) fireHop(k, now);
+  for (let i = 0; i < 8; i++) {
+    if (catWalkEdges[i]!.crossed(t, CAT_WALK_RANGE[0] + (i / 8) * cw, termPawHyst) && !reducedMotion && slow)
+      firePaw(k, now, i, 0.35 - 0.03 * i, 0.1 + 0.08 * i);
   }
 }
 
@@ -765,15 +1214,18 @@ export function beatMoment(id: string, flash: number): boolean {
       k.kachA.triggerAttackRelease("E6", 0.35, now, vel);
       k.kachB.triggerAttackRelease("G#6", 0.35, now + 0.06, vel);
       k.kachDrawer.triggerAttackRelease(0.07, now, 0.5);
-      k.kachPopLp.frequency.rampTo(800, 0.02, now);
-      k.kachPop.triggerAttackRelease(0.4, now, 0.5);
+      // kachPop is shared with firePlop/fireResumeDrop + 2 other beat cases
+      const kp = kachGate.at(now, 0.3);
+      k.kachPopLp.frequency.rampTo(800, 0.02, kp);
+      k.kachPop.triggerAttackRelease(0.4, kp, 0.5);
       k.coin.triggerAttackRelease("B6", 0.05, now + 0.12, 0.4);
       k.coin.triggerAttackRelease("D7", 0.05, now + 0.18, 0.4);
       k.coin.triggerAttackRelease("G7", 0.05, now + 0.24, 0.4);
       return true;
     }
     case "press-stamp": {
-      k.stampMembrane.triggerAttackRelease("G0", 0.5, now, v);
+      // stampMembrane is shared with terminal-back-cover -> gate its start
+      k.stampMembrane.triggerAttackRelease("G0", 0.5, stampGate.at(now, 0.5), v);
       k.stampMetal.triggerAttackRelease(0.12, now, 0.8 * v);
       k.stampPaperLp.frequency.rampTo(1200, 0.02, now);
       k.stampPaper.triggerAttackRelease(0.12, now, 0.6);
@@ -806,42 +1258,51 @@ export function beatMoment(id: string, flash: number): boolean {
       return true;
     }
     case "screentone-edge-run": {
-      let ti = now; // accelerating wheel clatter 8 -> 16 Hz
+      // edgeWhoosh is shared with leap + orbit-360; gate the whole sequence on
+      // one strictly-increasing base (busy spans the ~0.63s clatter tail + margin)
+      // so a deep-jump multi-fire staggers instead of double-starting the voice.
+      const base = edgeGate.at(now, 1.2);
+      let ti = base; // accelerating wheel clatter 8 -> 16 Hz
       const hits = 7;
       for (let i = 0; i < hits; i++) {
         k.edgeMembrane.triggerAttackRelease("A1", 0.08, ti, (0.5 + 0.2 * h01(i + 1)) * v);
         ti += 1 / (8 + 8 * (i / (hits - 1)));
       }
-      k.edgeScreech.triggerAttackRelease(300, 0.3, now, 0.5 * v); // wheel screech
-      k.edgeScreech.frequency.rampTo(700, 0.28, now + 0.01);
-      k.edgeWhooshBp.frequency.cancelScheduledValues(now); // rising doppler
-      k.edgeWhooshBp.frequency.setValueAtTime(400, now);
-      k.edgeWhooshBp.frequency.linearRampToValueAtTime(3000, now + 0.3);
-      k.edgeWhoosh.triggerAttackRelease(0.35, now, 0.6 * v);
-      k.edgeHorn.triggerAttackRelease(110, 0.3, now, 0.5 * v); // low horn
+      k.edgeScreech.triggerAttackRelease(300, 0.3, base, 0.5 * v); // wheel screech
+      k.edgeScreech.frequency.rampTo(700, 0.28, base + 0.01);
+      k.edgeWhooshBp.frequency.cancelScheduledValues(base); // rising doppler
+      k.edgeWhooshBp.frequency.setValueAtTime(400, base);
+      k.edgeWhooshBp.frequency.linearRampToValueAtTime(3000, base + 0.3);
+      k.edgeWhoosh.triggerAttackRelease(0.35, base, 0.6 * v);
+      k.edgeHorn.triggerAttackRelease(110, 0.3, base, 0.5 * v); // low horn
       return true;
     }
     case "origin-portal": {
-      k.starBell.triggerAttackRelease(440, 0.9, now, 0.35); // airy pad into the tail
+      // starBell is shared with fireStar (issue 10) -> gate the start
+      k.starBell.triggerAttackRelease(440, 0.9, starGate.at(now, 0.9), 0.35); // airy pad into the tail
       return true;
     }
     case "sketch-print-run": {
-      k.kachPopLp.frequency.rampTo(500, 0.02, now);
-      k.kachPop.triggerAttackRelease(0.4, now, 0.35); // near-silent roller finish
+      const kp = kachGate.at(now, 0.3); // kachPop shared across cases + helpers
+      k.kachPopLp.frequency.rampTo(500, 0.02, kp);
+      k.kachPop.triggerAttackRelease(0.4, kp, 0.35); // near-silent roller finish
       return true;
     }
     case "terminal-back-cover": {
-      k.stampMembrane.triggerAttackRelease("C2", 0.3, now, 0.4); // soft book close
-      k.kachPopLp.frequency.rampTo(300, 0.02, now);
-      k.kachPop.triggerAttackRelease(0.3, now, 0.4); // "fwump"
+      // stampMembrane + kachPop both shared -> gate each in its own family
+      k.stampMembrane.triggerAttackRelease("C2", 0.3, stampGate.at(now, 0.5), 0.4); // soft book close
+      const kp = kachGate.at(now, 0.3);
+      k.kachPopLp.frequency.rampTo(300, 0.02, kp);
+      k.kachPop.triggerAttackRelease(0.3, kp, 0.4); // "fwump"
       return true;
     }
     case "pop-orbit-360": {
-      k.edgeWhooshBp.frequency.cancelScheduledValues(now); // doppler swoop 500->2500->500
-      k.edgeWhooshBp.frequency.setValueAtTime(500, now);
-      k.edgeWhooshBp.frequency.linearRampToValueAtTime(2500, now + 0.25);
-      k.edgeWhooshBp.frequency.linearRampToValueAtTime(500, now + 0.5);
-      k.edgeWhoosh.triggerAttackRelease(0.5, now, 0.6);
+      const base = edgeGate.at(now, 0.6); // shares edgeWhoosh w/ edge-run + leap
+      k.edgeWhooshBp.frequency.cancelScheduledValues(base); // doppler swoop 500->2500->500
+      k.edgeWhooshBp.frequency.setValueAtTime(500, base);
+      k.edgeWhooshBp.frequency.linearRampToValueAtTime(2500, base + 0.25);
+      k.edgeWhooshBp.frequency.linearRampToValueAtTime(500, base + 0.5);
+      k.edgeWhoosh.triggerAttackRelease(0.5, base, 0.6);
       return true;
     }
     case "neon-cascade":
@@ -853,7 +1314,15 @@ export function beatMoment(id: string, flash: number): boolean {
 
 /* ------------------------------------------------------------ sfxMoment --- */
 /** Scene-facing one-shot names (scenes pass these as string literals). */
-export type SfxName = "meow" | "softLand" | "boop" | "pad";
+export type SfxName =
+  | "meow"
+  | "softLand"
+  | "boop"
+  | "pad"
+  | "chatPop"
+  | "signBuzz"
+  | "resumeDrop"
+  | "leap";
 
 /**
  * Scene-local one-shot trigger. Scenes call this at the exact crossings that
@@ -883,6 +1352,33 @@ export function sfxMoment(name: SfxName, seed = 0): void {
       case "pad":
         firePaw(k, now, seed);
         break;
+      case "chatPop": {
+        // one hook covers ambient cadence + the orbit volley; gate centrally so
+        // balloons popping while Pop is mounted at +/-1 stay silent.
+        const st = useScrollStore.getState();
+        if (st.reducedMotion || st.t < POP_RANGE[0] - 0.005 || st.t > POP_RANGE[1] + 0.005) break;
+        fireChatPop(k, now, seed);
+        break;
+      }
+      case "signBuzz": // neon sign ignition (event marker; fires under RM)
+        fireSignBuzz(k, now, seed);
+        break;
+      case "resumeDrop": // terminal resume sheet flutter + fwump
+        // scene pins the sheet statically under RM -> no flutter (matches chatPop)
+        if (!useScrollStore.getState().reducedMotion) fireResumeDrop(k, now);
+        break;
+      case "leap": {
+        // cat launch: rising doppler swoop (shares the edge-run whoosh voice).
+        // Scene windows never overlap, but a deep jump can cross leap + an
+        // edge-run/orbit beat in one frame -> gate the shared mono whoosh.
+        logFire("leap");
+        const base = edgeGate.at(now, 0.4);
+        k.edgeWhooshBp.frequency.cancelScheduledValues(base);
+        k.edgeWhooshBp.frequency.setValueAtTime(500, base);
+        k.edgeWhooshBp.frequency.linearRampToValueAtTime(2200, base + 0.3);
+        k.edgeWhoosh.triggerAttackRelease(0.3, base, 0.5);
+        break;
+      }
       default:
         break;
     }
@@ -895,15 +1391,23 @@ export function sfxMoment(name: SfxName, seed = 0): void {
 /** Disable path: silence + stop continuous sources, re-prime all latches. */
 export function stopMoments(): void {
   for (const e of allEdges) e.reset();
+  for (const g of gates) g.reset();
   neonPrimed = false;
   neonLast = -1;
+  lastScoreT = NaN; // next enable re-primes the deep-jump guard from scratch
   momentsActive = false; // sfxMoment goes silent until the director re-enables
   const k = kit;
   if (!k) return;
   gWhoosh.v = 0;
   gCrowd.v = 0;
+  gTrainPan.v = 0;
   k.popWhooshGain.gain.rampTo(0, 0.1);
   k.crowdGain.gain.rampTo(0, 0.1);
+  // re-center the panners so a re-enable in another scene starts clean
+  k.trainPan.pan.rampTo(0, 0.1);
+  k.chatPan.pan.rampTo(0, 0.1);
+  k.spreadPan.pan.rampTo(0, 0.1);
+  k.catPan.pan.rampTo(0, 0.1);
   if (popOn) {
     k.popWhoosh.stop();
     k.crowdA.stop();

--- a/lib/audio/moments.ts
+++ b/lib/audio/moments.ts
@@ -1009,6 +1009,10 @@ export function scoreMoments(
   dtSec: number,
   velocity: number,
 ): void {
+  // RULING 2026-07-10 (PR 36): audio event EMISSION is deliberately not pure
+  // f(t) -- fires are velocity-gated (anti machine-gun) and deep jumps (>0.03 t)
+  // re-prime latches silently. Visual scroll state remains pure f(t); scrubbing
+  // back and forward slowly still replays every event.
   const k = kit ?? (kit = buildKit(T, sfx));
   if (!TM) TM = T;
   momentsActive = true; // scoreMoments only runs while the director is enabled

--- a/lib/audio/recipes.ts
+++ b/lib/audio/recipes.ts
@@ -1,6 +1,13 @@
 import type { ToneAudioNode } from "tone";
+import { useScrollStore } from "@/lib/scrollStore";
+import { RANGES } from "@/issues/timeline";
+import { trainDisplayX, trainSpeed, trainX } from "@/issues/07-screentone/shots";
 import { audioRecipes, type AudioRecipe, type ToneModule } from "./types";
+import { logFire } from "./debug";
 import { h01, hash, moveTo, Stepper } from "./util";
+
+/** local clamp (pure; avoids a lib/shots import at module scope) */
+const clamp01 = (x: number): number => (x < 0 ? 0 : x > 1 ? 1 : x);
 
 /**
  * Wave B: the 12 per-issue ambiences (audioRecipes slots, indexed like
@@ -11,7 +18,12 @@ import { h01, hash, moveTo, Stepper } from "./util";
  * - param moves via moveTo() (rampTo on real target changes only)
  * - one-shots via triggerAttackRelease at T.now()
  * - these are AMBIENCES: out gains sit far below the master ceiling
- * - 3-8 nodes per recipe; no allocations inside update()
+ * - node-count norm (WS-A 2026-07-10): the base ambience is 3-8 nodes, but the
+ *   motion-coupled beds run richer (Screentone ~13, Press 18) -- physics that
+ *   follows the visible action needs the extra sources; still no allocations
+ *   inside update() (all caches/synths preallocated in build()).
+ * - discrete fires added by the WS-A pass call logFire(name) for the audit tap;
+ *   continuous gain/param moves do NOT log.
  */
 
 interface Built {
@@ -50,13 +62,39 @@ function defineRecipe(build: (T: ToneModule) => Built): AudioRecipe {
 audioRecipes[0] = defineRecipe((T) => {
   const noise = new T.Noise("brown");
   const lp = new T.Filter(260, "lowpass");
+  // attract breathe: the room tone swells gently on a 0.1 Hz LFO (0.7-1)
+  const breatheGain = new T.Gain(0.85);
+  const breatheLfo = new T.LFO(0.1, 0.7, 1);
+  breatheLfo.connect(breatheGain.gain);
   const out = new T.Gain(0.05);
-  noise.chain(lp, out);
+  noise.chain(lp, breatheGain, out);
+  // crash riser: white-noise sweep that climbs with |velocity| across the
+  // 3% cover range and hands off to the 0->1 crash gutter at t=0.03 (tLocal 1)
+  // -- moments/transitions own the impact itself; this only fills the run-up.
+  const riseNoise = new T.Noise("white");
+  const riseBp = new T.Filter({ frequency: 600, type: "bandpass", Q: 1.5 });
+  const riseGain = new T.Gain(0);
+  riseNoise.chain(riseBp, riseGain, out);
+  const rg = { v: 0 };
+  const rf = { v: 600 };
   return {
     out,
-    nodes: [noise, lp, out],
-    start: () => noise.start(),
-    stop: () => noise.stop(),
+    nodes: [noise, lp, breatheGain, breatheLfo, riseNoise, riseBp, riseGain, out],
+    start: () => {
+      noise.start();
+      breatheLfo.start();
+      riseNoise.start();
+    },
+    stop: () => {
+      noise.stop();
+      breatheLfo.stop();
+      riseNoise.stop();
+    },
+    update: (tLocal, _dtSec, velocity) => {
+      const a = Math.min(1, Math.abs(velocity) * 1.5);
+      moveTo(riseGain.gain, rg, tLocal * tLocal * a * 0.35, 0.08, 0.01);
+      moveTo(riseBp.frequency, rf, 600 + 2400 * tLocal, 0.1, 40);
+    },
   };
 });
 
@@ -84,35 +122,78 @@ audioRecipes[1] = defineRecipe((T) => {
   droneB.volume.value = -26;
   droneA.connect(droneLp);
   droneB.connect(droneLp);
+  // rain patter bed: band-limited pink hiss, ~-28 dBFS floor (visual rain is
+  // NOT reduced-motion gated -- an f(t) downpour, so this bed is unconditional)
+  const rain = new T.Noise({ type: "pink", volume: -22 });
+  const rainHp = new T.Filter(1800, "highpass");
+  const rainLp = new T.Filter(5200, "lowpass");
+  const rainGain = new T.Gain(0.5);
+  rain.chain(rainHp, rainLp, rainGain, out);
+  // individual droplets on the tick clock: sharp filtered ticks with a hashed
+  // bandpass sweep so no two land alike
+  const droplet = new T.NoiseSynth({
+    noise: { type: "white" },
+    envelope: { attack: 0.001, decay: 0.008, sustain: 0 },
+    volume: -16,
+  });
+  const dropBp = new T.Filter({ frequency: 3000, type: "bandpass", Q: 3 });
+  droplet.chain(dropBp, out);
+  // distant thunder: sub-rumble swelled on rare bars (0 -> 0.35 -> 0 over 2.5s)
+  const thunder = new T.Noise("brown");
+  const thunderLp = new T.Filter(120, "lowpass");
+  const thunderGain = new T.Gain(0);
+  thunder.chain(thunderLp, thunderGain, out);
   const ticks = new Stepper(9);
   const bars = new Stepper(0.6);
   const sw = { v: 0.1 };
   const dfc = { v: 300 };
   return {
     out,
-    nodes: [crackle, crackleHp, brush, brushLp, swell, droneLp, droneA, droneB, out],
+    nodes: [
+      crackle, crackleHp, brush, brushLp, swell, droneLp, droneA, droneB,
+      rain, rainHp, rainLp, rainGain, droplet, dropBp, thunder, thunderLp, thunderGain, out,
+    ],
     start: () => {
       ticks.reset();
       bars.reset();
       brush.start();
       droneA.start();
       droneB.start();
+      rain.start();
+      thunder.start();
     },
     stop: () => {
       brush.stop();
       droneA.stop();
       droneB.stop();
+      rain.stop();
+      thunder.stop();
     },
     update: () => {
       const now = T.now();
       const s = ticks.tick(now);
       if (s >= 0 && h01(s * 3 + 1) < 0.24)
         crackle.triggerAttackRelease(0.02, now, 0.25 + 0.5 * h01(s * 7 + 2));
+      // droplets ride the same tick grid but their own hash gate
+      if (s >= 0 && h01(s * 17 + 4) < 0.7) {
+        dropBp.frequency.rampTo(2600 + 1600 * h01(s * 23 + 6), 0.02);
+        droplet.triggerAttackRelease(0.01, now, 0.15 + 0.35 * h01(s * 19 + 5));
+        logFire("droplet");
+      }
       const b = bars.tick(now);
       // slow brushed swells + a slow drone-filter breathe, both hashed per bar
       if (b >= 0) {
         moveTo(swell.gain, sw, hash(b) % 4 === 0 ? 0.08 : 0.35 + 0.35 * h01(b * 5 + 3), 1.1, 0.01);
         moveTo(droneLp.frequency, dfc, 220 + 220 * h01(b * 7 + 11), 2.5, 8);
+        // rare thunder swell: schedule an up-then-down envelope on the sub gain
+        if (hash(b * 13 + 7) % 9 === 3) {
+          const g = thunderGain.gain;
+          g.cancelScheduledValues(now);
+          g.setValueAtTime(0, now);
+          g.linearRampToValueAtTime(0.35, now + 0.7);
+          g.linearRampToValueAtTime(0, now + 2.5);
+          logFire("thunder");
+        }
       }
     },
   };
@@ -131,17 +212,34 @@ audioRecipes[2] = defineRecipe((T) => {
   });
   const keyBp = new T.Filter(3400, "bandpass");
   key.chain(keyBp, out);
+  // monitor-grow whoosh: airy sweep as the screen zooms up in the closing hold
+  // (MON_R = [S+0.073, E] -> tLocal ~0.84..1.0; source: 02-desk/shots.ts MON_R).
+  // Velocity-coupled so a parked scrub stays near-silent.
+  const monNoise = new T.Noise("pink");
+  const monBp = new T.Filter({ frequency: 500, type: "bandpass", Q: 1 });
+  const monGain = new T.Gain(0);
+  monNoise.chain(monBp, monGain, out);
+  const mg = { v: 0 };
+  const mf = { v: 500 };
   const clock = new Stepper(9);
   return {
     out,
-    nodes: [room, roomLp, key, keyBp, out],
+    nodes: [room, roomLp, key, keyBp, monNoise, monBp, monGain, out],
     start: () => {
       clock.reset();
       room.start();
+      monNoise.start();
     },
-    stop: () => room.stop(),
-    update: () => {
+    stop: () => {
+      room.stop();
+      monNoise.stop();
+    },
+    update: (tLocal, _dtSec, velocity) => {
       const now = T.now();
+      const p = clamp01((tLocal - 0.84) / 0.14);
+      const vk = 0.25 + 0.75 * Math.min(1, Math.abs(velocity) * 1.5);
+      moveTo(monGain.gain, mg, Math.sin(Math.PI * Math.min(p, 0.95)) * vk * 0.3, 0.08, 0.01);
+      moveTo(monBp.frequency, mf, 500 + 1800 * p, 0.1, 40);
       const s = clock.tick(now);
       if (s < 0) return;
       // typing comes in hash-gated bursts (~2.7 s windows), not a metronome
@@ -173,26 +271,57 @@ audioRecipes[3] = defineRecipe((T) => {
   droneB.volume.value = -24;
   droneA.connect(droneLp);
   droneB.connect(droneLp);
+  // free-fall wind + crash doppler: dive p over the establish, crash q over the
+  // tower zoom (source: 03-neon/shots.ts neon-dive [0,0.32], neon-crash
+  // [0.395,0.595]). Velocity-coupled so a static scrub does not roar.
+  const wind = new T.Noise("white");
+  const windBp = new T.Filter({ frequency: 700, type: "bandpass", Q: 1 });
+  const windGain = new T.Gain(0);
+  wind.chain(windBp, windGain, out);
+  // post-cascade city hum: mains-ish drone that fills in once the grid lights
+  // (source: 03-neon/shots.ts cascade window at(0.67)..at(0.901) -> span 0.23)
+  const humSaw = new T.Oscillator({ frequency: 60, type: "sawtooth", volume: -30 });
+  const humSine = new T.Oscillator({ frequency: 120, type: "sine", volume: -34 });
+  const humLp = new T.Filter(300, "lowpass");
+  const humGain = new T.Gain(0);
+  humSaw.connect(humLp);
+  humSine.connect(humLp);
+  humLp.chain(humGain, out);
   const clock = new Stepper(8);
   const fc = { v: 2200 };
   const dfc = { v: 200 };
+  const wg = { v: 0 };
+  const wf = { v: 700 };
+  const hg = { v: 0 };
   return {
     out,
-    nodes: [synth, lp, droneA, droneB, droneLp, out],
+    nodes: [synth, lp, droneA, droneB, droneLp, wind, windBp, windGain, humSaw, humSine, humLp, humGain, out],
     start: () => {
       clock.reset();
       droneA.start();
       droneB.start();
+      wind.start();
+      humSaw.start();
+      humSine.start();
     },
     stop: () => {
       droneA.stop();
       droneB.stop();
+      wind.stop();
+      humSaw.stop();
+      humSine.stop();
     },
-    update: (tLocal) => {
+    update: (tLocal, _dtSec, velocity) => {
       const now = T.now();
       // filter opens across the issue -- pure f(t), scrub-safe
       moveTo(lp.frequency, fc, 1600 + 1400 * tLocal, 0.12, 60);
       moveTo(droneLp.frequency, dfc, 200 + 900 * tLocal, 0.12, 20);
+      const p = clamp01(tLocal / 0.32);
+      const q = clamp01((tLocal - 0.395) / 0.2);
+      const vk = Math.min(0.4 + 0.6 * Math.abs(velocity), 1);
+      moveTo(windGain.gain, wg, (p * p * (1 - q) + Math.sin(Math.PI * q)) * vk * 0.35, 0.09, 0.01);
+      moveTo(windBp.frequency, wf, 700 + 2600 * Math.max(p, q), 0.1, 60);
+      moveTo(humGain.gain, hg, clamp01((tLocal - 0.67) / 0.23) * 0.5, 0.2, 0.01);
       const s = clock.tick(now);
       if (s < 0) return;
       if (h01((s >> 3) * 5 + 2) < 0.25) return; // glitch dropout bar
@@ -260,22 +389,102 @@ audioRecipes[5] = defineRecipe((T) => {
   });
   const steamBp = new T.Filter(1400, "bandpass");
   steam.chain(steamBp, out);
+  // conveyor rumble: sub belt bed, ~-30 dBFS, wow'd by a slow LFO (0.35-0.5)
+  const belt = new T.Noise({ type: "brown", volume: -24 });
+  const beltLp = new T.Filter(140, "lowpass");
+  const beltGain = new T.Gain(0.5);
+  belt.chain(beltLp, beltGain, out);
+  const beltLfo = new T.LFO(0.4, 0.35, 0.5);
+  beltLfo.connect(beltGain.gain);
+  // roller squeak: sparse high triangle chirps on the press clock
+  const squeak = new T.Synth({
+    oscillator: { type: "triangle" },
+    envelope: { attack: 0.002, decay: 0.08, sustain: 0, release: 0.05 },
+    volume: -30,
+  });
+  const squeakHp = new T.Filter(2100, "highpass");
+  squeak.chain(squeakHp, out);
+  // plotter whir: filtered saw over the TS trace window with a 9 Hz amp flutter
+  // (source: 05-press/shots.ts PRESS_TRACE_RANGE at(0.235)..at(0.365))
+  const whir = new T.Oscillator({ frequency: 1100, type: "sawtooth", volume: -26 });
+  const whirBp = new T.Filter({ frequency: 1500, type: "bandpass", Q: 2 });
+  const flutterGain = new T.Gain(1);
+  const whirGain = new T.Gain(0);
+  whir.chain(whirBp, flutterGain, whirGain, out);
+  const flutterLfo = new T.LFO(9, 0.55, 1);
+  flutterLfo.connect(flutterGain.gain);
+  // React energy swell over the establish (source: PRESS_ENERGY_RANGE [0,0.08])
+  const react = new T.Oscillator({ frequency: 220, type: "sine", volume: -20 });
+  const reactGain = new T.Gain(0);
+  react.chain(reactGain, out);
+  // AI shimmer: one long FM bell latched on entry to the constellation bay
+  // (source: PRESS_PULSE_RANGE at(0.675)..at(0.775) -> tLocal [0.675,0.775])
+  const aiFm = new T.FMSynth({
+    harmonicity: 3,
+    modulationIndex: 4,
+    envelope: { attack: 0.4, decay: 1, sustain: 0.3, release: 1.5 },
+    modulationEnvelope: { attack: 0.6, decay: 0.8, sustain: 0.4, release: 1.2 },
+    volume: -26,
+  });
+  aiFm.connect(out);
   const clock = new Stepper(2.2);
+  const wg = { v: 0 };
+  const wf = { v: 1100 };
+  const rg = { v: 0 };
+  const rf = { v: 220 };
+  let aiArmed = true;
   return {
     out,
-    nodes: [thump, steam, steamBp, out],
-    start: () => clock.reset(),
-    stop: () => {
-      /* one-shots only */
+    nodes: [
+      thump, steam, steamBp, belt, beltLp, beltGain, beltLfo, squeak, squeakHp,
+      whir, whirBp, flutterGain, whirGain, flutterLfo, react, reactGain, aiFm, out,
+    ],
+    start: () => {
+      clock.reset();
+      aiArmed = true;
+      belt.start();
+      beltLfo.start();
+      whir.start();
+      flutterLfo.start();
+      react.start();
     },
-    update: () => {
+    stop: () => {
+      belt.stop();
+      beltLfo.stop();
+      whir.stop();
+      flutterLfo.stop();
+      react.stop();
+    },
+    update: (tLocal) => {
       const now = T.now();
+      // plotter whir: triangular envelope across the trace window, freq climbs
+      const wp = clamp01((tLocal - 0.235) / 0.13);
+      const tri = 1 - Math.abs(2 * wp - 1);
+      moveTo(whirGain.gain, wg, tri * 0.4, 0.09, 0.01);
+      moveTo(whir.frequency, wf, 1100 + 900 * wp, 0.1, 30);
+      // React energy swell: sine glides 220->440 as the establish energizes
+      const rp = clamp01(tLocal / 0.08);
+      moveTo(reactGain.gain, rg, rp * 0.35, 0.09, 0.01);
+      moveTo(react.frequency, rf, 220 + 220 * rp, 0.12, 6);
+      // AI shimmer: fire once on window entry, re-arm when clear before the band
+      const ap = clamp01((tLocal - 0.675) / 0.1);
+      if (ap > 0.05 && aiArmed) {
+        aiFm.triggerAttackRelease(1046.5, 2.5, now, 0.5);
+        logFire("aiShimmer");
+        aiArmed = false;
+      }
+      if (ap < 0.01) aiArmed = true;
       const s = clock.tick(now);
       if (s < 0) return;
       // dum-DUM-dum-rest press cycle; steam vents on a longer period
       if (s % 4 !== 3)
         thump.triggerAttackRelease("F1", 0.12, now, (s % 4 === 0 ? 0.85 : 0.4) + 0.1 * h01(s));
       if (s % 8 === 5) steam.triggerAttackRelease(0.25, now, 0.5 + 0.3 * h01(s * 3 + 1));
+      // roller squeak: hashed sparse chirp, ~1900 Hz
+      if (hash(s * 11 + 5) % 13 === 4) {
+        squeak.triggerAttackRelease(1800 + 200 * h01(s * 13 + 2), 0.06, now, 0.4);
+        logFire("rollerSqueak");
+      }
     },
   };
 });
@@ -297,62 +506,161 @@ audioRecipes[6] = defineRecipe((T) => {
   });
   const teleHp = new T.Filter(3200, "highpass");
   tele.chain(teleHp, out);
-  const clock = new Stepper(13);
+  // ink-flood wash: low pink swell + a 110 Hz sub as the front page floods to
+  // color (source: 06-newsprint/shots.ts NEWS_FLOOD_RANGE at(0.6)..at(0.82)).
+  // The KRAKA-THOOM beat lands on the crest.
+  const flood = new T.Noise("pink");
+  const floodLp = new T.Filter(600, "lowpass");
+  const floodSine = new T.Oscillator({ frequency: 110, type: "sine", volume: -18 });
+  const floodGain = new T.Gain(0);
+  flood.chain(floodLp, floodGain, out);
+  floodSine.connect(floodGain);
+  // teletype re-quantized to 12 Hz to match the visual crawl (12 fps steps)
+  const clock = new Stepper(12);
+  const fg = { v: 0 };
+  const ff = { v: 600 };
   return {
     out,
-    nodes: [rustle, rustleBp, tele, teleHp, out],
-    start: () => clock.reset(),
-    stop: () => {
-      /* one-shots only */
+    nodes: [rustle, rustleBp, tele, teleHp, flood, floodLp, floodSine, floodGain, out],
+    start: () => {
+      clock.reset();
+      flood.start();
+      floodSine.start();
     },
-    update: () => {
+    stop: () => {
+      flood.stop();
+      floodSine.stop();
+    },
+    update: (tLocal) => {
       const now = T.now();
+      // wash gain: pow(p,1.6) up the flood, then settle to a 0.12 residual bed
+      const fp = clamp01((tLocal - 0.6) / 0.22);
+      moveTo(floodGain.gain, fg, fp >= 1 ? 0.12 : Math.pow(fp, 1.6) * 0.4, 0.15, 0.01);
+      moveTo(floodLp.frequency, ff, 600 + 1600 * fp, 0.12, 30);
       const s = clock.tick(now);
       if (s < 0) return;
-      // teletype: ~1.5 s hash-gated burst windows of rapid clicks
+      // teletype: ~1.5 s hash-gated burst windows of rapid clicks; the clacks
+      // crescendo when the ticker band fills the frame (tri peak at tLocal 0.43)
+      const tvk = 0.4 + 0.6 * Math.max(0, 1 - Math.abs(tLocal - 0.43) / 0.15);
       const burst = h01(Math.floor(s / 20) * 7 + 3) < 0.45;
-      if (burst && h01(s * 11 + 4) < 0.8) tele.triggerAttackRelease(0.01, now, 0.25 + 0.3 * h01(s + 6));
+      if (burst && h01(s * 11 + 4) < 0.8)
+        tele.triggerAttackRelease(0.01, now, (0.25 + 0.3 * h01(s + 6)) * tvk);
       if (hash(s) % 41 === 13) rustle.triggerAttackRelease(0.18, now, 0.4 + 0.3 * h01(s * 5 + 2));
     },
   };
 });
 
-/* ---- 7 Screentone: subway rail rhythm, tempo-locked to the boil grid ----- */
+/* ---- 7 Screentone: motion-coupled subway bed (REBUILD, WS-A template) ----- */
 /**
- * The shader line boil steps at 10 Hz: components/PostPipeline.tsx drives
- * uBoilJitter/uStepSeed with stepNoise(elapsed, 10, *). The rail clock runs
- * on the same 10 Hz grid so every wheel hit lands exactly on a boil step;
- * the ka-thunk pair sits on adjacent steps every 8 steps (0.8 s bogie period).
+ * Rebuilt 2026-07-10: the old fixed 10 Hz ka-thunk ignored the train profile
+ * (it clacked at dwells). This bed is now a pure function of the train's own
+ * motion. Reconstruct global t from tLocal + RANGES[7], mirror Screentone.tsx:
+ *   sp = reducedMotion ? 0 : trainSpeed(t)   (0 = parked at a station)
+ * Everything routes through trainBus -> panner (pan tracks trainDisplayX) so
+ * the whole vehicle swings across the stereo field with the visible car; the
+ * platform room tone sits OUTSIDE the bus (the station never moves). At dwells
+ * -- and under reduced motion (a parked train, correct) -- sp is 0, so rumble /
+ * whine / clacks all fall silent and only the platform breathes.
+ * ~13 nodes (motion physics needs the sources; see the file-header node note).
  */
-const RAIL_HZ = 10;
+const SCREENTONE_RANGE = RANGES[7]!;
 audioRecipes[7] = defineRecipe((T) => {
+  const [S7, E7] = SCREENTONE_RANGE;
+  const W7 = E7 - S7;
   const out = new T.Gain(0.22);
+  // the moving vehicle bus: everything train-borne pans with the car
+  const trainBus = new T.Gain(1);
+  const panner = new T.Panner(0);
+  trainBus.chain(panner, out);
+  // rail rumble (re-homed from the old fixed clacks' noise/filter): the loudest
+  // new element, ~-18 dBFS at cruise, dead silent at dwells (gain = sp*sp*0.9)
+  const rail = new T.Noise({ type: "brown", volume: -20 });
+  const railBp = new T.Filter({ frequency: 320, type: "bandpass", Q: 1 });
+  const rumbleGain = new T.Gain(0);
+  rail.chain(railBp, rumbleGain, trainBus);
+  // wheel clacks (re-homed membrane): distance-locked to rail joints, NOT time
   const wheel = new T.MembraneSynth({
     pitchDecay: 0.03,
     octaves: 2.5,
     envelope: { attack: 0.001, decay: 0.16, sustain: 0, release: 0.05 },
     volume: -8,
   });
-  wheel.connect(out);
-  const rail = new T.Noise({ type: "brown", volume: -20 });
-  const railBp = new T.Filter(320, "bandpass");
-  rail.chain(railBp, out);
-  const clock = new Stepper(RAIL_HZ);
+  wheel.connect(trainBus);
+  // traction whine: filtered saw whose pitch + level ride sp -- makes accel and
+  // decel audible (the whole reason for the rebuild)
+  const whine = new T.Oscillator({ frequency: 80, type: "sawtooth", volume: -30 });
+  const whineLp = new T.Filter(600, "lowpass");
+  const whineGain = new T.Gain(0);
+  whine.chain(whineLp, whineGain, trainBus);
+  // platform room tone: OUTSIDE the bus (the station is fixed); loudest when
+  // the train is stopped so the platform "breathes" at dwells / reduced motion
+  const platform = new T.Noise("pink");
+  const platformLp = new T.Filter(400, "lowpass");
+  const stationGain = new T.Gain(0);
+  platform.chain(platformLp, stationGain, out);
+  const panC = { v: 0 };
+  const rumbleG = { v: 0 };
+  const railF = { v: 320 };
+  const whineF = { v: 80 };
+  const whineG = { v: 0 };
+  const stationG = { v: 0 };
+  let lastJoint = NaN;
+  // monotonic guard for the mono wheel voice: next Tone time it is free to
+  // schedule. Tone throws if two starts arrive out of order on one synth.
+  let wheelFree = 0;
   return {
     out,
-    nodes: [wheel, rail, railBp, out],
+    nodes: [
+      out, trainBus, panner, rail, railBp, rumbleGain, wheel, whine, whineLp,
+      whineGain, platform, platformLp, stationGain,
+    ],
     start: () => {
-      clock.reset();
+      lastJoint = NaN;
+      wheelFree = 0;
       rail.start();
+      whine.start();
+      platform.start();
     },
-    stop: () => rail.stop(),
-    update: () => {
+    stop: () => {
+      rail.stop();
+      whine.stop();
+      platform.stop();
+    },
+    update: (tLocal) => {
       const now = T.now();
-      const s = clock.tick(now);
-      if (s < 0) return;
-      const pos = s % 8;
-      if (pos === 0) wheel.triggerAttackRelease("D2", 0.05, now, 0.3 + 0.1 * h01(s)); // ka
-      else if (pos === 1) wheel.triggerAttackRelease("A1", 0.1, now, 0.7 + 0.15 * h01(s + 4)); // thunk
+      const { reducedMotion } = useScrollStore.getState();
+      const t = S7 + tLocal * W7; // reconstruct global t
+      const sp = reducedMotion ? 0 : trainSpeed(t);
+      // pan the vehicle bus to the visible car (parked position under RM)
+      const pan = Math.max(-0.85, Math.min(0.85, trainDisplayX(t, reducedMotion) / 105));
+      moveTo(panner.pan, panC, pan, 0.1, 0.01);
+      // continuous motion beds
+      moveTo(rumbleGain.gain, rumbleG, sp * sp * 0.9, 0.09, 0.01);
+      moveTo(railBp.frequency, railF, 260 + 240 * sp, 0.1, 12);
+      moveTo(whineGain.gain, whineG, sp * 0.5, 0.09, 0.01);
+      moveTo(whine.frequency, whineF, 80 + 520 * sp, 0.1, 20);
+      moveTo(stationGain.gain, stationG, (1 - sp) * 0.28, 0.15, 0.01);
+      // wheel clacks locked to rail joints (every 6 set-units); one pair per
+      // joint crossing, no catch-up on deep jumps (compare to last joint only)
+      const j = Math.floor(trainX(t) / 6);
+      if (j !== lastJoint) {
+        const primed = !Number.isNaN(lastJoint);
+        lastJoint = j;
+        if (primed && sp > 0.05) {
+          const delay = Math.min(0.09, 0.05 / Math.max(sp, 0.2));
+          // schedule both hits at or after wheelFree so starts never invert on
+          // the mono voice; if the scheduler has backed up past +0.04 s the
+          // pair is inaudibly late -- drop it rather than crash the director.
+          const a = Math.max(now, wheelFree);
+          if (a <= now + 0.04) {
+            const b = a + delay;
+            wheel.triggerAttackRelease("D2", 0.05, a, 0.12 + 0.3 * sp);
+            wheel.triggerAttackRelease("A1", 0.1, b, 0.25 + 0.45 * sp);
+            wheelFree = b + 0.01;
+            logFire("clack");
+          }
+        }
+      }
     },
   };
 });
@@ -374,13 +682,34 @@ audioRecipes[8] = defineRecipe((T) => {
     volume: -14,
   });
   blip.connect(out);
+  // emote sparkle owns its OWN mono voice: its octave-up hit can never collide
+  // with the chat blip on one synth at the same Tone time (was a strict-time
+  // crash that the director caught by disabling ALL audio).
+  const sparkle = new T.Synth({
+    oscillator: { type: "sine" },
+    envelope: { attack: 0.001, decay: 0.05, sustain: 0, release: 0.03 },
+    volume: -20,
+  });
+  sparkle.connect(out);
+  // ON AIR hum: a soft 100 Hz sine pulsing on a 0.9 Hz LFO to match the sign
+  const onAir = new T.Oscillator({ frequency: 100, type: "sine", volume: -32 });
+  const onAirGain = new T.Gain(0.7);
+  onAir.connect(onAirGain);
+  onAirGain.connect(out);
+  const onAirLfo = new T.LFO(0.9, 0.4, 1);
+  onAirLfo.connect(onAirGain.gain);
   const clock = new Stepper(7.5);
   return {
     out,
-    nodes: [arp, blip, out],
-    start: () => clock.reset(),
+    nodes: [arp, blip, sparkle, onAir, onAirGain, onAirLfo, out],
+    start: () => {
+      clock.reset();
+      onAir.start();
+      onAirLfo.start();
+    },
     stop: () => {
-      /* one-shots only */
+      onAir.stop();
+      onAirLfo.stop();
     },
     update: () => {
       const now = T.now();
@@ -391,6 +720,11 @@ audioRecipes[8] = defineRecipe((T) => {
         arp.triggerAttackRelease(POP_NOTES[POP_PAT[s % 8]!]!, 0.06, now, 0.5);
       if (hash(s) % 29 === 11)
         blip.triggerAttackRelease(h01(s + 4) < 0.5 ? 987.77 : 1318.51, 0.05, now, 0.4);
+      // emote sparkle: the chat blip an octave up, sparse hash gate
+      if (hash(s * 3 + 8) % 11 === 2) {
+        sparkle.triggerAttackRelease((h01(s + 8) < 0.5 ? 987.77 : 1318.51) * 2, 0.05, now, 0.25);
+        logFire("sparkle");
+      }
     },
   };
 });
@@ -402,18 +736,36 @@ audioRecipes[9] = defineRecipe((T) => {
   const hp = new T.Filter(3800, "highpass");
   const g = new T.Gain(0);
   scratch.chain(hp, g, out);
+  // the little robot's trundle: soft filtered thuds, only while the reader
+  // draws (|vel| > 0.05). NOTHING else here -- this valley stays quiet.
+  const trundle = new T.NoiseSynth({
+    noise: { type: "brown" },
+    envelope: { attack: 0.001, decay: 0.015, sustain: 0 },
+    volume: -32,
+  });
+  const trundleBp = new T.Filter({ frequency: 900, type: "bandpass", Q: 1 });
+  trundle.chain(trundleBp, out);
+  const trundleClock = new Stepper(4);
   const gs = { v: 0 };
   const fs = { v: 3800 };
   return {
     out,
-    nodes: [scratch, hp, g, out],
-    start: () => scratch.start(),
+    nodes: [scratch, hp, g, trundle, trundleBp, out],
+    start: () => {
+      trundleClock.reset();
+      scratch.start();
+    },
     stop: () => scratch.stop(),
     update: (_tLocal, _dtSec, velocity) => {
       // graphite only speaks when the reader draws the page: gain ~ |v|^2
       const a = Math.min(1, Math.abs(velocity) * 1.5);
       moveTo(g.gain, gs, a * a, 0.06, 0.01);
       moveTo(hp.frequency, fs, 3200 + 2200 * a, 0.08, 120);
+      const s = trundleClock.tick(T.now());
+      if (s >= 0 && h01(s * 5 + 9) < 0.5 && Math.abs(velocity) > 0.05) {
+        trundle.triggerAttackRelease(0.02, T.now(), 0.2);
+        logFire("trundle");
+      }
     },
   };
 });
@@ -447,6 +799,14 @@ audioRecipes[10] = defineRecipe((T) => {
     modulationEnvelope: { attack: 2.5, decay: 1, sustain: 0.5, release: 3 },
     volume: -16,
   }).connect(panR);
+  // cat drift: a faint airy whisper following the cat across the arc, peaking
+  // mid-drift (source: 10-spread/shots.ts CAT_DRIFT at(0.52)..at(0.7)). By
+  // design barely-there -- the pads own the room.
+  const drift = new T.Noise("pink");
+  const driftBp = new T.Filter({ frequency: 350, type: "bandpass", Q: 0.7 });
+  const driftGain = new T.Gain(0);
+  drift.chain(driftBp, driftGain, out);
+  const dg = { v: 0 };
   const clock = new Stepper(SPREAD_RATE);
   const fire = (s: number, now: number): void => {
     const c = SPREAD_CHORDS[hash(s) % SPREAD_CHORDS.length]!;
@@ -455,19 +815,21 @@ audioRecipes[10] = defineRecipe((T) => {
   };
   return {
     out,
-    nodes: [space, panL, panR, padA, padB, out],
+    nodes: [space, panL, panR, padA, padB, drift, driftBp, driftGain, out],
     start: () => {
       clock.reset();
+      drift.start();
       // fire the current chord immediately -- the clock period is far too
       // long to wait for its first edge (still deterministic: hash of step)
       const now = T.now();
       fire(Math.floor(now * SPREAD_RATE), now);
     },
     stop: () => {
-      /* long releases decay on their own */
+      drift.stop();
     },
-    update: () => {
+    update: (tLocal) => {
       const now = T.now();
+      moveTo(driftGain.gain, dg, Math.sin(Math.PI * clamp01((tLocal - 0.52) / 0.18)) * 0.12, 0.12, 0.01);
       const s = clock.tick(now);
       if (s >= 0) fire(s, now);
     },

--- a/lib/audio/transitions.ts
+++ b/lib/audio/transitions.ts
@@ -51,6 +51,28 @@ interface Voice {
   stop(): void;
 }
 
+/**
+ * Strictly-increasing start-time gate for one mono voice (local copy of the
+ * moments.ts class -- no cross-import). at() returns an admissible start,
+ * bumped past the voice's busy tail so a re-armed crossFwd (fast scrub, or a
+ * deep jump followed by an oscillating settle across a gutter boundary) never
+ * schedules a new triggerAttack earlier than the previous fire's still-pending
+ * future release -- which throws Tone's "The time must be greater than or equal
+ * to the last scheduled time" and trips the director loop catch (global audio
+ * disable). busy = the voice's longest scheduled tail.
+ */
+class VoiceGate {
+  private free = 0;
+  at(now: number, busy: number): number {
+    const a = now <= this.free ? this.free + 0.008 : now;
+    this.free = a + busy;
+    return a;
+  }
+  reset(): void {
+    this.free = 0;
+  }
+}
+
 const bell = (p: number): number => Math.sin(Math.PI * p);
 const tri = (p: number, c: number, w: number): number => clamp01(1 - Math.abs(p - c) / w);
 /** Gutter i->j window = [range i end, range j start] (never hardcoded). */
@@ -137,6 +159,7 @@ function buildCrash(T: ToneModule, sfx: Gain): Voice {
   const g: Gate = { on: false, quiet: 0 };
   const srcs: Src[] = [burst, body];
   const cx: Cross = { init: false, armed: true, last: 0 };
+  const accGate = new VoiceGate(); // crash (0.3 dur + 0.1 rel) + chirp fire together
   const gB = { v: 0 };
   const gY = { v: 0 };
   const fB = { v: 900 };
@@ -155,7 +178,7 @@ function buildCrash(T: ToneModule, sfx: Gain): Voice {
       moveTo(burstGain.gain, gB, burstT, 0.04, 0.008);
       moveTo(bodyGain.gain, gY, bodyT, 0.04, 0.008);
       if (crossFwd(cx, p, 0.3, 0.1) && av > 0.05) {
-        const now = T.now();
+        const now = accGate.at(T.now(), 0.4);
         crash.triggerAttackRelease("C1", 0.3, now, 0.5 * av);
         chirp.triggerAttackRelease(300, 0.18, now, 0.5 * av);
         chirp.frequency.rampTo(80, 0.18, now);
@@ -164,6 +187,7 @@ function buildCrash(T: ToneModule, sfx: Gain): Voice {
     stop() {
       gB.v = 0;
       gY.v = 0;
+      accGate.reset();
       burstGain.gain.rampTo(0, 0.1);
       bodyGain.gain.rampTo(0, 0.1);
       if (g.on) {
@@ -274,6 +298,7 @@ function buildStamp(T: ToneModule, sfx: Gain): Voice {
   const g: Gate = { on: false, quiet: 0 };
   const srcs: Src[] = [chunk, air];
   const cx: Cross = { init: false, armed: true, last: 0 };
+  const metalGate = new VoiceGate(); // metal contact transient (short mono NoiseSynth)
   const gC = { v: 0 };
   const gA = { v: 0 };
   const fC = { v: 220 };
@@ -290,11 +315,12 @@ function buildStamp(T: ToneModule, sfx: Gain): Voice {
       moveTo(chunkGain.gain, gC, chunkT, 0.03, 0.008);
       moveTo(airGain.gain, gA, airT, 0.05, 0.008);
       if (crossFwd(cx, p, 0.32, 0.1) && av > 0.05)
-        metal.triggerAttackRelease(0.01, T.now(), 0.5 * av);
+        metal.triggerAttackRelease(0.01, metalGate.at(T.now(), 0.05), 0.5 * av);
     },
     stop() {
       gC.v = 0;
       gA.v = 0;
+      metalGate.reset();
       chunkGain.gain.rampTo(0, 0.1);
       airGain.gain.rampTo(0, 0.1);
       if (g.on) {
@@ -323,6 +349,7 @@ function buildTear(T: ToneModule, sfx: Gain): Voice {
   const g: Gate = { on: false, quiet: 0 };
   const srcs: Src[] = [noise];
   const cx: Cross = { init: false, armed: true, last: 0 };
+  const flapGate = new VoiceGate(); // late tear-flap (mono NoiseSynth, 0.14 tail)
   const gC = { v: 0 };
   const fC = { v: 1200 };
   const fQ = { v: 1 };
@@ -339,10 +366,11 @@ function buildTear(T: ToneModule, sfx: Gain): Voice {
       moveTo(bp.Q, fQ, 1 + 2 * p, 0.08, 0.05);
       moveTo(gain.gain, gC, target, 0.04, 0.008);
       if (crossFwd(cx, p, 0.85, 0.08) && av > 0.05)
-        flap.triggerAttackRelease(0.14, T.now(), 0.4 * av);
+        flap.triggerAttackRelease(0.14, flapGate.at(T.now(), 0.15), 0.4 * av);
     },
     stop() {
       gC.v = 0;
+      flapGate.reset();
       gain.gain.rampTo(0, 0.1);
       if (g.on) {
         noise.stop();
@@ -461,6 +489,7 @@ function buildDotMatch(T: ToneModule, sfx: Gain): Voice {
   const g: Gate = { on: false, quiet: 0 };
   const srcs: Src[] = [pa, pb, zip, shimLfo];
   const cx: Cross = { init: false, armed: true, last: 0 };
+  const resolveGate = new VoiceGate(); // cursor-resolve Synth (0.15 dur + 0.05 rel)
   const gT = { v: 0 };
   const gZ = { v: 0 };
   const fA = { v: 400 };
@@ -484,11 +513,12 @@ function buildDotMatch(T: ToneModule, sfx: Gain): Voice {
       moveTo(zipGain.gain, gZ, zpT, 0.04, 0.008);
       // collapse the twinkle onto a single held ~1600Hz sine = the cursor
       if (crossFwd(cx, p, 0.92, 0.05) && av > 0.03)
-        resolve.triggerAttackRelease(1600, 0.15, T.now(), 0.3 * (0.5 + 0.5 * av));
+        resolve.triggerAttackRelease(1600, 0.15, resolveGate.at(T.now(), 0.2), 0.3 * (0.5 + 0.5 * av));
     },
     stop() {
       gT.v = 0;
       gZ.v = 0;
+      resolveGate.reset();
       twGain.gain.rampTo(0, 0.1);
       zipGain.gain.rampTo(0, 0.1);
       if (g.on) {

--- a/lib/audio/ui.ts
+++ b/lib/audio/ui.ts
@@ -1,5 +1,6 @@
 import type { Filter, FMSynth, Gain, MembraneSynth, Noise, NoiseSynth, Synth } from "tone";
 import { useScrollStore } from "@/lib/scrollStore";
+import { logFire } from "./debug";
 import type { ToneModule } from "./types";
 import { hash } from "./util";
 
@@ -30,7 +31,8 @@ export type UiKind =
   | "keyBack"
   | "keyEsc"
   | "toggleOn"
-  | "toggleOff";
+  | "toggleOff"
+  | "hover";
 
 interface Mod {
   T: ToneModule;
@@ -50,6 +52,35 @@ interface Pool {
   swishGain: Gain;
   meowSynth: FMSynth;
 }
+
+/**
+ * Strictly-increasing start-time gate for one mono voice (local copy of the
+ * moments.ts class -- no cross-import). Bumps a new start past the voice's busy
+ * tail so a second trigger on a SHARED synth (two meows within one meow's
+ * future-scheduled triggerRelease(now+0.38): leap+softLand on a deep jump, a
+ * scene meow racing a click meow, or back-to-back cmdErr/linkPress on uiNoise)
+ * never attacks earlier than the pending release -- which throws Tone's "The
+ * time must be greater than or equal to the last scheduled time" and trips the
+ * director loop catch (global audio disable). No reset: ui.ts has no disable
+ * path (pool survives), and Tone's clock only advances, so a stale free is
+ * always in the past on re-enable.
+ */
+class VoiceGate {
+  private free = 0;
+  constructor(private maxLag = Infinity) {}
+  at(now: number, busy: number): number {
+    const a = now <= this.free ? this.free + 0.008 : now;
+    // backlog drop (wheelFree pattern): once the adjusted start would land more
+    // than maxLag past now, the voice is so far behind that the sound is already
+    // stale -- return -1 (leaving `free` untouched) so the caller skips it, else
+    // a rapid meow spam grows an ever-longer serialized tail. Infinity = no cap.
+    if (a > now + this.maxLag) return -1;
+    this.free = a + busy;
+    return a;
+  }
+}
+const meowGate = new VoiceGate(0.7); // shared meowSynth; drop once backlog > 0.7s
+const uiNoiseGate = new VoiceGate(); // shared uiNoise (cmdErr / linkPress / ctaPress)
 
 let mod: Mod | null = null;
 let pool: Pool | null = null;
@@ -161,16 +192,22 @@ export function uiSound(kind: UiKind, seed = 0): void {
       break;
     }
     case "cmdErr": {
-      // gritty descending bzzt through the fixed 800 Hz lowpass
+      // gritty descending bzzt through the fixed 800 Hz lowpass...
       p.uiBuzz.triggerAttack(200, now, 0.9);
       p.uiBuzz.frequency.rampTo(150, 0.13, now);
       p.uiBuzz.triggerRelease(now + 0.14);
+      // ...with a CRT static zap layered on (shared uiNoise voice, bp swept up
+      // then rested back to 1200 so linkPress/ctaPress snaps stay unchanged).
+      p.uiNoiseBp.frequency.rampTo(2400, 0.03, now);
+      p.uiNoise.triggerAttackRelease(0.05, uiNoiseGate.at(now, 0.06), 0.5);
+      p.uiNoiseBp.frequency.rampTo(1200, 0.08, now + 0.06);
+      logFire("cmdErr");
       break;
     }
     case "linkPress": {
       // ka-chunk (thud) + paper snap (noise) + page opening (rising beeps)
       p.uiThud.triggerAttackRelease("A1", 0.08, now, 0.8);
-      p.uiNoise.triggerAttackRelease(0.03, now, 0.5);
+      p.uiNoise.triggerAttackRelease(0.03, uiNoiseGate.at(now, 0.06), 0.5);
       p.uiBeep.triggerAttackRelease(700, 0.05, now, 0.7);
       p.uiBeep.triggerAttackRelease(1050, 0.05, now + 0.055, 0.7);
       break;
@@ -178,7 +215,7 @@ export function uiSound(kind: UiKind, seed = 0): void {
     case "ctaPress": {
       // heavier manufactured press + a downward swish hinting the scroll
       p.uiThud.triggerAttackRelease("F1", 0.1, now, 0.9);
-      p.uiNoise.triggerAttackRelease(0.03, now, 0.5);
+      p.uiNoise.triggerAttackRelease(0.03, uiNoiseGate.at(now, 0.06), 0.5);
       swish(p, m, 1100, 450, 0.18);
       break;
     }
@@ -219,6 +256,12 @@ export function uiSound(kind: UiKind, seed = 0): void {
       p.uiBeep.triggerAttackRelease(587.33, 0.05, now + 0.05, 0.55);
       break;
     }
+    case "hover": {
+      // tiny tick on button hover-in; call site latches false -> true only
+      p.uiTick.triggerAttackRelease(1800, 0.006, now, 0.3);
+      logFire("hover");
+      break;
+    }
   }
 }
 
@@ -234,6 +277,8 @@ export function fireMeowVoice(now: number, base: number, harm: number): void {
   if (!m) return;
   const p = ensure();
   if (!p) return;
+  now = meowGate.at(now, 0.55); // release scheduled at now+0.38; keep the next attack after it
+  if (now < 0) return; // backlog past maxLag -> drop this meow
   const s = p.meowSynth;
   s.harmonicity.value = harm;
   s.modulationIndex.value = 4;
@@ -260,20 +305,24 @@ export function meow(count: number): void {
   const base = 480 + (h % 200);
   if (fam === 2) {
     // CHIRP: single short pop, low modIndex, no dip
+    const gnow = meowGate.at(now, 0.55); // shared meowSynth: stagger past any pending release
+    if (gnow < 0) return; // backlog past maxLag -> drop
     s.harmonicity.value = 1.3 + fam * 0.13;
     s.modulationIndex.value = 2;
-    s.triggerAttackRelease(600 + (h % 120), 0.16, now, 0.8);
+    s.triggerAttackRelease(600 + (h % 120), 0.16, gnow, 0.8);
     return;
   }
   if (fam === 1) {
     // QUESTION: end freq ramps up, tail rises a touch more
+    const gnow = meowGate.at(now, 0.55); // shared meowSynth: stagger past any pending release
+    if (gnow < 0) return; // backlog past maxLag -> drop
     s.harmonicity.value = 1.3 + fam * 0.13;
     s.modulationIndex.value = 4;
-    s.triggerAttack(base, now, 0.8);
+    s.triggerAttack(base, gnow, 0.8);
     const top = base * 1.4;
-    s.frequency.rampTo(top, 0.24, now + 0.02);
-    s.frequency.rampTo(top * 1.06, 0.08, now + 0.26);
-    s.triggerRelease(now + 0.36);
+    s.frequency.rampTo(top, 0.24, gnow + 0.02);
+    s.frequency.rampTo(top * 1.06, 0.08, gnow + 0.26);
+    s.triggerRelease(gnow + 0.36);
     return;
   }
   // 0 ME-OW: the shared voice (also fired by moments' cat sfx)
@@ -286,7 +335,8 @@ export function catPurr(): void {
   if (!m) return;
   const p = ensure();
   if (!p) return;
-  const now = m.T.now();
+  const now = meowGate.at(m.T.now(), 0.55); // shared meowSynth: purr releases at now+0.42
+  if (now < 0) return; // backlog past maxLag -> drop
   const s = p.meowSynth;
   const base = 300;
   s.harmonicity.value = 1.6;


### PR DESCRIPTION
## What

**Sound design, all 12 scenes (synthesis only, zero asset files).** The audit finding: beds were clock-locked (the subway ka-thunk ignored trainSpeed), ~45 visible events were silent, and panning was used once in the whole project. Now sound follows the visible physics:

- **The train scene** (the user-reported example): rail rumble and traction whine gain/pitch-mapped to trainSpeed(t) (silent at dwells), wheel clacks locked to rail-joint distance not wall-clock, the whole vehicle panned with its on-screen position, platform room tone breathing at stops, brake squeal + air hiss on every arrival, hall-reverbed PA chime, door-close beep on departure, doppler whoosh + horn for the two pass-through stations.
- Per-scene: rain patter/droplets/thunder (Noir), free-fall wind + per-sign ignition buzz + post-boot city hum (Neon), conveyor rumble/roller squeak/plotter whir/energy swells (Press), ticker-quantized teletype + ink-flood crest under the KRAKA-THOOM (Newsprint), panned chat-balloon bloops + emote sparkle + ON AIR hum (Pop), pencil/robot trundle (Sketchbook), 10 fanning L/R page whooshes on the unfold (Spread), resume-drop flutter + cat hop-and-walk-off exit (Terminal), crash riser (Cover), quiet cat walk (Origin).

**Audio engine hardening** (found the hard way - 7 gate iterations): per-voice monotonic scheduling gates (VoiceGate) across every module eliminate the Tone strict-time crash class that could silently kill all audio; a deep-jump latch reset kills multi-second catch-up volleys on mode toggles and scrollbar jumps; the meow voice drops backlog on click-spam; the sidechain duck stays click-free.

**Pop stream desk** rebuilt to the owner's real setup: studio monitors on stands with woofer/tweeter detail, softboxes on the truss, widened 2-pane code monitor, Stream Deck Plus with dials, audio interface, big-knob monitor controller, mic with glow ring, LED backglow - all palette-legal, one draw call for the slabs, backs detailed for the 360 orbit.

**Bug fix:** print<->0 3D toggle now maps scroll position both ways (in-view print section + fraction -> t; activeIssue -> section anchor). The keyboard/AT reveal path intentionally does NOT reposition (focus stays visible).

## Verification
- Structural audio audit via a dev-only fire log: per-window trigger-count assertions (dwell = chime no clacks, cascade = 11 rings + sign buzzes, unfold = 10+10, cat exit = hop+8), reverse-scrub no-double, deep-jump no-volley (<8 entries), reduced-motion suppression matrix
- Stress gate with the warn-latch defeated: 28 jump/glide/oscillation crossings, zero scheduling errors, audio never disabled
- Toggle mapping verified both directions incl. reduced motion; desk verified at the front shot + 3 orbit angles
- High-effort review workflow: 10 confirmed findings, all fixed and re-gated
- typecheck, ASCII gate, production build all clean

Known minor: the mic ring glows CYAN (palette-legal) instead of the real ring's green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)