### PR TITLE
Cat clicks: voice words only, comic-accent fills

### DIFF
--- a/issues/06-newsprint/Newsprint.tsx
+++ b/issues/06-newsprint/Newsprint.tsx
@@ -10,7 +10,7 @@ import { ArtPanel } from "../04-origin/Origin";
 import { toonRamp } from "@/lib/toon";
 import { stepTime } from "@/lib/steppedClock";
 import { useScrollStore } from "@/lib/scrollStore";
-import { sayWord } from "@/lib/onomatopoeia";
+import { CAT_VOICE, sayWord } from "@/lib/onomatopoeia";
 import { uiSound } from "@/lib/audio/ui";
 import { issueCopy, lettering, links } from "@/lib/content";
 import { colorWindow } from "@/shaders/colorWindow";
@@ -197,7 +197,7 @@ function CatPhoto() {
       onClick={(e) => {
         e.stopPropagation();
         useScrollStore.getState().meow();
-        sayWord(lettering.onomatopoeia.cat, [issueCenter(6)[0] + 5.9, 7.7, -4], undefined, INK);
+        sayWord(CAT_VOICE, [issueCenter(6)[0] + 5.9, 7.7, -4], undefined, RED);
       }}
     >
       <PhotoFrame w={3.05} h={3.55} />

--- a/issues/06-newsprint/Newsprint.tsx
+++ b/issues/06-newsprint/Newsprint.tsx
@@ -12,7 +12,7 @@ import { stepTime } from "@/lib/steppedClock";
 import { useScrollStore } from "@/lib/scrollStore";
 import { CAT_VOICE, sayWord } from "@/lib/onomatopoeia";
 import { uiSound } from "@/lib/audio/ui";
-import { issueCopy, lettering, links } from "@/lib/content";
+import { issueCopy, links } from "@/lib/content";
 import { colorWindow } from "@/shaders/colorWindow";
 import { issueCenter } from "../timeline";
 import { NEWS_FLOOD_POP, NEWS_PANEL_POS, NEWS_TICKER_Y, NEWS_TICKER_Z, newsFlood } from "./shots";
@@ -197,7 +197,8 @@ function CatPhoto() {
       onClick={(e) => {
         e.stopPropagation();
         useScrollStore.getState().meow();
-        sayWord(CAT_VOICE, [issueCenter(6)[0] + 5.9, 7.7, -4], undefined, RED);
+        const n = useScrollStore.getState().meowCount;
+        sayWord(CAT_VOICE, [issueCenter(6)[0] + 5.9, 7.7, -4], (n * 0.618) % 1, RED);
       }}
     >
       <PhotoFrame w={3.05} h={3.55} />

--- a/issues/07-screentone/Screentone.tsx
+++ b/issues/07-screentone/Screentone.tsx
@@ -519,7 +519,8 @@ function PlatformCat() {
       onClick={(e) => {
         e.stopPropagation();
         useScrollStore.getState().meow();
-        sayWord(CAT_VOICE, [CX + CAT_BENCH_X, 4.2, -2], undefined, "#FFFFFF");
+        const n = useScrollStore.getState().meowCount;
+        sayWord(CAT_VOICE, [CX + CAT_BENCH_X, 4.2, -2], (n * 0.618) % 1, "#FFFFFF");
       }}
     >
       <CatModel mode="flat" pose="sitting" palette={CAT_PALETTE} rig={{ tail }} />

--- a/issues/07-screentone/Screentone.tsx
+++ b/issues/07-screentone/Screentone.tsx
@@ -9,7 +9,7 @@ import { ISSUES } from "../registry";
 import CatModel, { HARLEY, type CatPalette } from "@/components/CatModel";
 import { stepNoise, stepTime } from "@/lib/steppedClock";
 import { useScrollStore } from "@/lib/scrollStore";
-import { sayWord } from "@/lib/onomatopoeia";
+import { CAT_VOICE, sayWord } from "@/lib/onomatopoeia";
 import { content, issueCopy, lettering } from "@/lib/content";
 import { issueCenter } from "../timeline";
 import {
@@ -519,7 +519,7 @@ function PlatformCat() {
       onClick={(e) => {
         e.stopPropagation();
         useScrollStore.getState().meow();
-        sayWord(lettering.onomatopoeia.cat, [CX + CAT_BENCH_X, 4.2, -2], undefined, INK);
+        sayWord(CAT_VOICE, [CX + CAT_BENCH_X, 4.2, -2], undefined, "#FFFFFF");
       }}
     >
       <CatModel mode="flat" pose="sitting" palette={CAT_PALETTE} rig={{ tail }} />

--- a/issues/08-pop/Pop.tsx
+++ b/issues/08-pop/Pop.tsx
@@ -18,9 +18,9 @@ import { ISSUES } from "../registry";
 import CatModel, { HARLEY, type CatPalette } from "@/components/CatModel";
 import { stepTime } from "@/lib/steppedClock";
 import { useScrollStore } from "@/lib/scrollStore";
-import { sayWord } from "@/lib/onomatopoeia";
+import { CAT_VOICE, sayWord } from "@/lib/onomatopoeia";
 import { popScale } from "@/lib/pops";
-import { content, issueCopy, lettering } from "@/lib/content";
+import { content, issueCopy } from "@/lib/content";
 import {
   chatPool,
   CYAN,
@@ -929,7 +929,7 @@ function DeskCat() {
         e.stopPropagation();
         useScrollStore.getState().meow();
         sayWord(
-          lettering.onomatopoeia.cat,
+          CAT_VOICE,
           [e.point.x, e.point.y + 1.1, e.point.z],
           undefined,
           INK,

--- a/issues/08-pop/Pop.tsx
+++ b/issues/08-pop/Pop.tsx
@@ -928,10 +928,11 @@ function DeskCat() {
       onClick={(e) => {
         e.stopPropagation();
         useScrollStore.getState().meow();
+        const n = useScrollStore.getState().meowCount;
         sayWord(
           CAT_VOICE,
           [e.point.x, e.point.y + 1.1, e.point.z],
-          undefined,
+          (n * 0.618) % 1,
           INK,
         );
       }}

--- a/issues/09-sketchbook/Sketchbook.tsx
+++ b/issues/09-sketchbook/Sketchbook.tsx
@@ -449,7 +449,8 @@ function PageCat() {
 
   const meow = (x: number, z: number) => {
     useScrollStore.getState().meow();
-    sayWord(CAT_VOICE, [CX + x, 3.4, z], undefined, WASH);
+    const n = useScrollStore.getState().meowCount;
+    sayWord(CAT_VOICE, [CX + x, 3.4, z], (n * 0.618) % 1, WASH);
   };
 
   return (

--- a/issues/09-sketchbook/Sketchbook.tsx
+++ b/issues/09-sketchbook/Sketchbook.tsx
@@ -16,8 +16,8 @@ import CatModel, { HARLEY, type CatPalette } from "@/components/CatModel";
 import { pawprintMaterial, sketchMaterial, SKETCH_PALETTE } from "@/shaders/sketchMaterials";
 import { stepTime } from "@/lib/steppedClock";
 import { useScrollStore } from "@/lib/scrollStore";
-import { sayWord } from "@/lib/onomatopoeia";
-import { issueCopy, lettering } from "@/lib/content";
+import { CAT_VOICE, sayWord } from "@/lib/onomatopoeia";
+import { issueCopy } from "@/lib/content";
 import { clamp01, lerp } from "@/lib/shots";
 import { issueCenter } from "../timeline";
 import { inkAt, SKETCH_SETTLE } from "./shots";
@@ -449,7 +449,7 @@ function PageCat() {
 
   const meow = (x: number, z: number) => {
     useScrollStore.getState().meow();
-    sayWord(lettering.onomatopoeia.cat, [CX + x, 3.4, z], undefined, INK);
+    sayWord(CAT_VOICE, [CX + x, 3.4, z], undefined, WASH);
   };
 
   return (

--- a/lib/onomatopoeia.ts
+++ b/lib/onomatopoeia.ts
@@ -1,5 +1,15 @@
 import type { Vector3 } from "three";
+import { lettering } from "./content";
 import { PopPool } from "./pops";
+
+/**
+ * Vocal-only cat words (S0.5: derive, don't re-type). THUMP/PADD are physical
+ * landing/step sounds Desk uses deliberately; a click is a vocal response, so
+ * the click sites fire from CAT_VOICE, never the full onomatopoeia.cat pool.
+ */
+export const CAT_VOICE = lettering.onomatopoeia.cat.filter(
+  (w) => w !== "THUMP" && w !== "PADD",
+);
 
 /**
  * Pooled comic onomatopoeia (S5b) -- a PopPool of word sprites. Scenes call


### PR DESCRIPTION
## What

Clicking a cat could pop **THUMP** or **PADD** - the physical landing/step words - rendered in dark INK that blobbed against the word sprite's dark outline (user screenshot: a black THUMP blob in the Sketchbook).

- New `CAT_VOICE` pool derived from the cat onomatopoeia pool (S0.5 - filtered, not re-typed): clicks now draw only MEW / PRRR / MRRP / MROW.
- Click-word fills switched from dark INK to bright scene accents so the built-in dark outline reads as a comic pop word: Sketchbook wash-blue, Newsprint spot-red, Screentone white. Pop and Noir already used bright fills and are untouched.
- Deliberate THUMP/PADD usage (desk landing, dot bat) and the noir leap word are untouched.

## Verification
Code-chain verified (pool contents, fill constants, outline) + console clean under click testing; the 0.9s pop sprite outruns the screenshot roundtrip, so the visual is a one-click check on the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)