### PR TITLE
Post pipeline: ink line stops drawing over snapshots and lettering

### DIFF
--- a/components/PostPipeline.tsx
+++ b/components/PostPipeline.tsx
@@ -76,15 +76,23 @@ function whipAxis(a: Pose, b: Pose): [number, number] {
  * file registers anything. Captions and labels stay below WORD_MIN_AREA:
  * they sit on panels that already occlude the line, so they need nothing.
  */
-const WORD_MIN_AREA = 0.05; // viewport share that counts as word art, not a label
+// projected viewport share that counts as word art, not a label. Compared
+// against pure AREA, never area * opacity: a fading word must not cross the
+// threshold mid-fade and pop the exemption on in one frame (uWordEdge rides
+// the opacity instead, so the exemption itself fades).
+const WORD_MIN_AREA = 0.05;
 
-/** blockBounds is the glyph box; the SDF outline sits just outside it */
+/** visibleBounds is the glyph box; the SDF outline sits just outside it */
 const WORD_PAD = 1.06;
 
 type TroikaMaterial = { isTroikaTextMaterial?: boolean };
 type TroikaMesh = Object3D & {
   material?: TroikaMaterial | TroikaMaterial[];
-  textRenderInfo?: { blockBounds: ArrayLike<number> } | null;
+  textRenderInfo?: {
+    blockBounds: ArrayLike<number>;
+    /** tighter glyph extents; absent on older troika builds */
+    visibleBounds?: ArrayLike<number>;
+  } | null;
   fillOpacity?: number;
 };
 
@@ -103,16 +111,26 @@ const wv2 = new Vector3();
 /** winner of the last scan: rect in screen uv + the word plane's buffer depth */
 const word = { score: 0, cx: 0.5, cy: 0.5, ux: 0, uy: 0, vx: 0, vy: 0, depth: 1, strength: 0 };
 
+/**
+ * Known limit: ONE rect is exempt per frame (the biggest block wins), which is
+ * why off-screen candidates are rejected below -- a neighbour set's lettering
+ * must never take the single slot from the block actually in shot.
+ */
 function scanWordRect(scene: Object3D, camera: Camera): void {
   word.score = 0;
   word.strength = 0;
-  // the camera matrices are one frame stale until the renderer refreshes them
+  // matrices are one frame stale until the renderer refreshes them. ONE walk
+  // for the whole scene beats updateWorldMatrix(true) per troika node (that
+  // re-walks every ancestor chain); Camera.updateMatrixWorld also refreshes
+  // matrixWorldInverse, which is what project() reads.
   camera.updateMatrixWorld();
-  camera.matrixWorldInverse.copy(camera.matrixWorld).invert();
+  scene.updateMatrixWorld();
   scene.traverseVisible((o) => {
     const m = o as TroikaMesh;
     if (!isTroikaText(m)) return;
-    const b = m.textRenderInfo?.blockBounds; // [minX, minY, maxX, maxY], anchored
+    // [minX, minY, maxX, maxY], anchored. visibleBounds is the glyph extent,
+    // tighter than the line box -> a smaller hole in the ink line
+    const b = m.textRenderInfo?.visibleBounds ?? m.textRenderInfo?.blockBounds;
     if (!b) return;
     const op = typeof m.fillOpacity === "number" ? m.fillOpacity : 1;
     if (op < 0.02) return; // faded out: the glyphs are not there to protect
@@ -120,8 +138,8 @@ function scanWordRect(scene: Object3D, camera: Camera): void {
     const cy = (b[1]! + b[3]!) * 0.5;
     const hu = (b[2]! - b[0]!) * 0.5 * WORD_PAD;
     const hv = (b[3]! - b[1]!) * 0.5 * WORD_PAD;
-    if (hu <= 0 || hv <= 0) return;
-    m.updateWorldMatrix(true, false);
+    // empty text reports infinite visibleBounds; a NaN rect would win forever
+    if (!(hu > 0) || !(hv > 0) || !Number.isFinite(cx + cy + hu + hv)) return;
     wv0.set(cx, cy, 0).applyMatrix4(m.matrixWorld).project(camera);
     if (wv0.z < -1 || wv0.z > 1) return; // behind the camera or past the far plane
     wv1.set(cx + hu, cy, 0).applyMatrix4(m.matrixWorld).project(camera);
@@ -130,11 +148,20 @@ function scanWordRect(scene: Object3D, camera: Camera): void {
     const uy = (wv1.y - wv0.y) * 0.5;
     const vx = (wv2.x - wv0.x) * 0.5;
     const vy = (wv2.y - wv0.y) * 0.5;
-    const score = Math.abs(ux * vy - uy * vx) * 4 * op;
+    const cu = wv0.x * 0.5 + 0.5;
+    const cv = wv0.y * 0.5 + 0.5;
+    // screen-overlap reject: the parallelogram's bounding box must touch the
+    // viewport, else an off-screen block could silently hold the one slot
+    const hx = Math.abs(ux) + Math.abs(vx);
+    const hy = Math.abs(uy) + Math.abs(vy);
+    if (cu + hx < -0.02 || cu - hx > 1.02 || cv + hy < -0.02 || cv - hy > 1.02) return;
+    // PURE projected area (F2): opacity drives uWordEdge, not the threshold,
+    // so a fading word leaves the exemption smoothly instead of snapping
+    const score = Math.abs(ux * vy - uy * vx) * 4;
     if (score <= word.score) return;
     word.score = score;
-    word.cx = wv0.x * 0.5 + 0.5;
-    word.cy = wv0.y * 0.5 + 0.5;
+    word.cx = cu;
+    word.cy = cv;
     word.ux = ux;
     word.uy = uy;
     word.vx = vx;
@@ -161,6 +188,8 @@ export default function PostPipeline() {
     composer.addPass(normalPass);
     const print = new PrintEffect(normalPass.texture);
     const transition = new TransitionEffect();
+    // MUST stay one EffectPass: PrintEffect reads the pjtCovered global that
+    // TransitionEffect declares, so splitting them fails to compile
     composer.addPass(new EffectPass(camera, print, transition));
     return { composer, print, transition };
   }, [gl, scene, camera]);
@@ -251,8 +280,11 @@ export default function PostPipeline() {
       print.u<Vector3>("uSpotV").value.fromArray(spotRect.halfV);
       print.u<number>("uSpotDepth").value = spotRect.depth;
     }
-    // word rect: exempts the ink line over the frame's biggest lettering
-    scanWordRect(scene, camera);
+    // word rect: exempts the ink line over the frame's biggest lettering.
+    // No line in the cross-faded recipe -> nothing to exempt, so skip the
+    // whole scene walk (the exemption is a no-op at uEdge 0 anyway)
+    if (c.edge < 0.005) word.strength = 0;
+    else scanWordRect(scene, camera);
     print.u<number>("uWordEdge").value = word.strength;
     if (word.strength > 0) {
       print.u<Vector2>("uWordCenter").value.set(word.cx, word.cy);

--- a/components/PostPipeline.tsx
+++ b/components/PostPipeline.tsx
@@ -3,7 +3,16 @@
 import { useEffect, useMemo, useRef } from "react";
 import { useFrame, useThree } from "@react-three/fiber";
 import { EffectComposer, EffectPass, NormalPass, RenderPass } from "postprocessing";
-import { Color, HalfFloatType, Matrix4, Vector3, type Texture } from "three";
+import {
+  Color,
+  HalfFloatType,
+  Matrix4,
+  Vector2,
+  Vector3,
+  type Camera,
+  type Object3D,
+  type Texture,
+} from "three";
 import { PrintEffect } from "@/shaders/PrintEffect";
 import { TransitionEffect } from "@/shaders/TransitionEffect";
 import { colorWindow, spotRect } from "@/shaders/colorWindow";
@@ -55,6 +64,88 @@ function whipAxis(a: Pose, b: Pose): [number, number] {
   }
   const l = Math.hypot(x, y);
   return l < 1e-4 ? [1, 0] : [x / l, y / l];
+}
+
+/**
+ * WORD-ART INK EXEMPTION (frame audit 2026-07-27, S2.16). troika SDF
+ * lettering writes neither depth nor normals, so PrintEffect's ink line --
+ * the one term that samples the geometry buffers -- draws whatever stands
+ * BEHIND a word straight over its glyphs. Every troika mesh tags its material
+ * with isTroikaTextMaterial, so the largest block of lettering in frame is
+ * found generically here and handed to the shader as a screen rect; no scene
+ * file registers anything. Captions and labels stay below WORD_MIN_AREA:
+ * they sit on panels that already occlude the line, so they need nothing.
+ */
+const WORD_MIN_AREA = 0.05; // viewport share that counts as word art, not a label
+
+/** blockBounds is the glyph box; the SDF outline sits just outside it */
+const WORD_PAD = 1.06;
+
+type TroikaMaterial = { isTroikaTextMaterial?: boolean };
+type TroikaMesh = Object3D & {
+  material?: TroikaMaterial | TroikaMaterial[];
+  textRenderInfo?: { blockBounds: ArrayLike<number> } | null;
+  fillOpacity?: number;
+};
+
+/** outlined troika text reports material as [fill, outline], plain text as one */
+function isTroikaText(m: TroikaMesh): boolean {
+  const mat = m.material;
+  if (!mat) return false;
+  return Array.isArray(mat)
+    ? mat.some((x) => x?.isTroikaTextMaterial === true)
+    : mat.isTroikaTextMaterial === true;
+}
+
+const wv0 = new Vector3();
+const wv1 = new Vector3();
+const wv2 = new Vector3();
+/** winner of the last scan: rect in screen uv + the word plane's buffer depth */
+const word = { score: 0, cx: 0.5, cy: 0.5, ux: 0, uy: 0, vx: 0, vy: 0, depth: 1, strength: 0 };
+
+function scanWordRect(scene: Object3D, camera: Camera): void {
+  word.score = 0;
+  word.strength = 0;
+  // the camera matrices are one frame stale until the renderer refreshes them
+  camera.updateMatrixWorld();
+  camera.matrixWorldInverse.copy(camera.matrixWorld).invert();
+  scene.traverseVisible((o) => {
+    const m = o as TroikaMesh;
+    if (!isTroikaText(m)) return;
+    const b = m.textRenderInfo?.blockBounds; // [minX, minY, maxX, maxY], anchored
+    if (!b) return;
+    const op = typeof m.fillOpacity === "number" ? m.fillOpacity : 1;
+    if (op < 0.02) return; // faded out: the glyphs are not there to protect
+    const cx = (b[0]! + b[2]!) * 0.5;
+    const cy = (b[1]! + b[3]!) * 0.5;
+    const hu = (b[2]! - b[0]!) * 0.5 * WORD_PAD;
+    const hv = (b[3]! - b[1]!) * 0.5 * WORD_PAD;
+    if (hu <= 0 || hv <= 0) return;
+    m.updateWorldMatrix(true, false);
+    wv0.set(cx, cy, 0).applyMatrix4(m.matrixWorld).project(camera);
+    if (wv0.z < -1 || wv0.z > 1) return; // behind the camera or past the far plane
+    wv1.set(cx + hu, cy, 0).applyMatrix4(m.matrixWorld).project(camera);
+    wv2.set(cx, cy + hv, 0).applyMatrix4(m.matrixWorld).project(camera);
+    const ux = (wv1.x - wv0.x) * 0.5; // ndc delta -> uv delta
+    const uy = (wv1.y - wv0.y) * 0.5;
+    const vx = (wv2.x - wv0.x) * 0.5;
+    const vy = (wv2.y - wv0.y) * 0.5;
+    const score = Math.abs(ux * vy - uy * vx) * 4 * op;
+    if (score <= word.score) return;
+    word.score = score;
+    word.cx = wv0.x * 0.5 + 0.5;
+    word.cy = wv0.y * 0.5 + 0.5;
+    word.ux = ux;
+    word.uy = uy;
+    word.vx = vx;
+    word.vy = vy;
+    // a word turned away from the camera is nearer on one side: take the
+    // NEAREST corner so the whole plane counts as "in front of the scene"
+    const dz = Math.abs(wv1.z - wv0.z) + Math.abs(wv2.z - wv0.z);
+    word.depth = (wv0.z - dz) * 0.5 + 0.5;
+    word.strength = op;
+  });
+  if (word.score < WORD_MIN_AREA) word.strength = 0;
 }
 
 export default function PostPipeline() {
@@ -160,6 +251,16 @@ export default function PostPipeline() {
       print.u<Vector3>("uSpotV").value.fromArray(spotRect.halfV);
       print.u<number>("uSpotDepth").value = spotRect.depth;
     }
+    // word rect: exempts the ink line over the frame's biggest lettering
+    scanWordRect(scene, camera);
+    print.u<number>("uWordEdge").value = word.strength;
+    if (word.strength > 0) {
+      print.u<Vector2>("uWordCenter").value.set(word.cx, word.cy);
+      print.u<Vector2>("uWordU").value.set(word.ux, word.uy);
+      print.u<Vector2>("uWordV").value.set(word.vx, word.vy);
+      print.u<number>("uWordDepth").value = word.depth;
+    }
+
     if (colorWindow.enabled > 0 || spotRect.enabled > 0) {
       camera.updateMatrixWorld();
       print

--- a/shaders/PrintEffect.ts
+++ b/shaders/PrintEffect.ts
@@ -38,7 +38,11 @@ import { Color, Matrix4, Uniform, Vector2, Vector3, type Texture } from "three";
  *    effects by attributes, CONVOLUTION before DEPTH, so the transition
  *    composites FIRST and this pass prints the result -- without the gate
  *    the incoming issue's ink line drew as a wireframe over every snapshot
- *    gutter. See shaders/TransitionEffect.ts for the shared global.
+ *    gutter, and doubled edges beside every DISPLACED frame (whip smear,
+ *    crash punch, stamp descent). See shaders/TransitionEffect.ts for the
+ *    shared global -- which only exists if both effects stay merged into
+ *    ONE EffectPass (components/PostPipeline.tsx); split, this will not
+ *    compile.
  *  - uWord*, the WORD RECT: troika SDF lettering writes neither depth nor
  *    normals, so the geometry BEHIND a word inks straight over its glyphs
  *    (S2.16: lettering is a crisp single layer, exempt from post). The

--- a/shaders/PrintEffect.ts
+++ b/shaders/PrintEffect.ts
@@ -1,5 +1,5 @@
 import { Effect, EffectAttribute } from "postprocessing";
-import { Color, Matrix4, Uniform, Vector3, type Texture } from "three";
+import { Color, Matrix4, Uniform, Vector2, Vector3, type Texture } from "three";
 
 /**
  * The shared "print" pass (S2.6): color-window mask -> mono grade ->
@@ -29,6 +29,25 @@ import { Color, Matrix4, Uniform, Vector3, type Texture } from "three";
  * with it per-frame (shaders/colorWindow.ts spotRect/setSpotRect).
  * uSpotStrength < 1 keeps partial mono/hatch on the subject; halftone and
  * ink line stay full (S2.16 clean, single-layer color op).
+ *
+ * INK-LINE EXEMPTIONS (2026-07-27 frame audit). The ink line is the only
+ * term here that samples the LIVE scene's geometry buffers (tNormal +
+ * readDepth), so it is wrong wherever the pixel's colour no longer comes
+ * from that geometry:
+ *  - pjtCovered, written by TransitionEffect. EffectPass sorts merged
+ *    effects by attributes, CONVOLUTION before DEPTH, so the transition
+ *    composites FIRST and this pass prints the result -- without the gate
+ *    the incoming issue's ink line drew as a wireframe over every snapshot
+ *    gutter. See shaders/TransitionEffect.ts for the shared global.
+ *  - uWord*, the WORD RECT: troika SDF lettering writes neither depth nor
+ *    normals, so the geometry BEHIND a word inks straight over its glyphs
+ *    (S2.16: lettering is a crisp single layer, exempt from post). The
+ *    screen-space rect + plane depth come from PostPipeline, which picks
+ *    the largest troika block in frame each frame. The depth test is the
+ *    inverse of the window/spot rects: those match geometry AT the plane,
+ *    a word has no depth of its own, so the exemption applies where the
+ *    depth buffer sits BEHIND the word plane -- anything in FRONT of the
+ *    lettering keeps its line.
  *
  * verified 2026-07 (postprocessing v6.39): uniforms must be a Map of
  * three.Uniform; mainImage signature with EffectAttribute.DEPTH gains a
@@ -62,6 +81,11 @@ const fragment = /* glsl */ `
   uniform vec3 uSpotV;
   uniform float uSpotDepth;
   uniform mat4 uInvViewProjection;
+  uniform float uWordEdge;
+  uniform vec2 uWordCenter;
+  uniform vec2 uWordU;
+  uniform vec2 uWordV;
+  uniform float uWordDepth;
 
   float pjLuma(const in vec3 c) { return dot(c, vec3(0.299, 0.587, 0.114)); }
 
@@ -129,6 +153,24 @@ const fragment = /* glsl */ `
     return edge * (1.0 - step(1.0, n));
   }
 
+  // WORD RECT mask: the lettering block already projected to screen space by
+  // PostPipeline (center + two half-axes in uv), so no world reconstruction
+  // and no ray/plane intersect here. Perspective turns a world rect into a
+  // general quad; the parallelogram through the projected half-axes is the
+  // cheap approximation, which is enough for a block that faces the camera.
+  // "sceneDepth >= uWordDepth" keeps anything standing IN FRONT of the word
+  // fully inked -- only the geometry the glyphs hide loses its line.
+  float pjWordMask(const in vec2 uv, const in float sceneDepth) {
+    if (uWordEdge < 0.001) return 0.0;
+    float det = uWordU.x * uWordV.y - uWordU.y * uWordV.x;
+    if (abs(det) < 1e-7) return 0.0;
+    vec2 q = uv - uWordCenter;
+    float a = (q.x * uWordV.y - q.y * uWordV.x) / det;
+    float b = (uWordU.x * q.y - uWordU.y * q.x) / det;
+    float inside = 1.0 - smoothstep(0.86, 1.0, max(abs(a), abs(b)));
+    return inside * step(uWordDepth, sceneDepth) * uWordEdge;
+  }
+
   void mainImage(const in vec4 inputColor, const in vec2 uv, const in float depth, out vec4 outputColor) {
     vec3 col = inputColor.rgb;
     vec2 fragPx = uv * resolution;
@@ -180,7 +222,12 @@ const fragment = /* glsl */ `
     // 1-texel radius is the old modulation's mean, so line weight is
     // unchanged; the sub-texel offset keeps the hand-drawn wobble.
     float e = pjEdge(uv + uBoilJitter * texelSize, texelSize);
-    col = mix(col, uEdgeColor, e * uEdge);
+    // ...but only where the pixel still SHOWS that geometry: transition
+    // composites (pjtCovered) and troika lettering (word rect) both replace
+    // the colour without touching the normal/depth buffers this line reads.
+    // Both are exactly 0.0 on settled frames -- no-op outside gutters/words.
+    float inkEx = max(pjtCovered, pjWordMask(uv, depth));
+    col = mix(col, uEdgeColor, e * uEdge * (1.0 - inkEx));
 
     // 4 -- paper fiber + stepped grain, multiplicative (never a color fringe)
     float fiber = pjHash(floor(fragPx * 0.5) / 0.5 * 0.013);
@@ -231,6 +278,11 @@ export class PrintEffect extends Effect {
         ["uSpotV", new Uniform(new Vector3(0, 1, 0))],
         ["uSpotDepth", new Uniform(0.6)],
         ["uInvViewProjection", new Uniform(new Matrix4())],
+        ["uWordEdge", new Uniform(0)],
+        ["uWordCenter", new Uniform(new Vector2(0.5, 0.5))],
+        ["uWordU", new Uniform(new Vector2(0, 0))],
+        ["uWordV", new Uniform(new Vector2(0, 0))],
+        ["uWordDepth", new Uniform(1)],
       ]),
     });
   }

--- a/shaders/TransitionEffect.ts
+++ b/shaders/TransitionEffect.ts
@@ -31,6 +31,13 @@ import { Color, Uniform, type Texture } from "three";
  * S2.16: every mode is a single-layer color op -- no channel offsets, no
  * ghosting; page-flip's backside is flat paper (no mirrored content);
  * stamp's impact frame is one paper-tone pop, same class as cut's blink.
+ *
+ * PASS ORDER (verified 2026-07-27, postprocessing EffectPass source: the
+ * merged effects are sorted by `b.attributes - a.attributes`): CONVOLUTION
+ * outranks DEPTH, so THIS effect runs FIRST and PrintEffect prints the
+ * composite afterwards. That is what makes inputBuffer pre-print -- and it
+ * means the print pass would otherwise stamp the LIVE issue's ink line over
+ * the outgoing snapshot. pjtCovered is the channel that stops it.
  */
 const fragment = /* glsl */ `
   uniform sampler2D uSnapshot;
@@ -44,6 +51,17 @@ const fragment = /* glsl */ `
   uniform float uSmearHalftone;
   uniform float uSmearScale;
   uniform vec3 uSmearPaper;
+
+  // COVERAGE CHANNEL -> PrintEffect. 1.0 where this pass replaced the live
+  // frame with the outgoing snapshot or an authored paper/ink fill, 0.0 where
+  // the incoming frame survives. Both effects are merged into ONE fragment
+  // shader and this one is emitted first, so the print pass reads this global
+  // and skips the only term that samples the LIVE scene's geometry buffers
+  // (the ink line) over pixels that no longer show that geometry. EffectPass
+  // prefixes function/uniform/define names only, so a plain global keeps the
+  // same name in both halves -- it is the cheapest legal channel between two
+  // merged effects (no extra RT, no varying, no second pass).
+  float pjtCovered = 0.0;
 
   float pjtLuma(const in vec3 c) { return dot(c, vec3(0.299, 0.587, 0.114)); }
 
@@ -109,6 +127,10 @@ const fragment = /* glsl */ `
   void mainImage(const in vec4 inputColor, const in vec2 uv, out vec4 outputColor) {
     vec3 col = inputColor.rgb;
     float p = clamp(uP, 0.0, 1.0);
+    // explicit reset: global initializers run once per invocation, but the
+    // modes below are the only writers and mode 0 (none / drift) must leave
+    // the print pass bit-identical to the pre-fix build
+    pjtCovered = 0.0;
 
     // whip intensity peaks mid-gutter; velocity lines fade in on hard scroll
     float whipK = uMode == 1.0 ? sin(p * 3.14159) : 0.0;
@@ -143,10 +165,13 @@ const fragment = /* glsl */ `
       float aa = fwidth(d) + 1e-4;
       float cover = 1.0 - smoothstep(r - aa, r + aa, d);
       col = mix(col, pjtSnap(uv), cover);
+      pjtCovered = cover;
     } else if (uMode == 3.0) {
       // cut: quick paper-tone page blink centered on the pose jump
       float q = 1.0 - abs(2.0 * p - 1.0);
-      col = mix(col, uFallback, smoothstep(0.62, 0.95, q));
+      float blink = smoothstep(0.62, 0.95, q);
+      col = mix(col, uFallback, blink);
+      pjtCovered = blink;
     } else if (uMode == 4.0) {
       // crash-through: the live incoming frame takes a settling zoom punch
       // while the printed cover bursts center-out into paper fragments.
@@ -176,7 +201,9 @@ const fragment = /* glsl */ `
         vec2 e2 = min(fract(cell), 1.0 - fract(cell));
         float torn = smoothstep(0.10, 0.02, min(e2.x, e2.y)) * step(0.001, f);
         snap = mix(snap, uFallback, torn * 0.9);
-        col = mix(col, snap, 1.0 - smoothstep(0.85, 1.0, f));
+        float held = 1.0 - smoothstep(0.85, 1.0, f);
+        col = mix(col, snap, held);
+        pjtCovered = held;
       }
     } else if (uMode == 5.0) {
       // panel-wipe: paper gutter bars sweep in over the outgoing page,
@@ -197,6 +224,9 @@ const fragment = /* glsl */ `
       float rim = 1.0 - smoothstep(0.005, 0.005 + aaR * 2.0, abs(rd));
       rim *= step(0.001, g) * (1.0 - smoothstep(0.8, 0.95, p));
       col = mix(col, vec3(0.10, 0.09, 0.08), rim);
+      // outside the growing panel the page is snapshot, and the ink rim is
+      // authored -- neither belongs to the incoming issue's geometry
+      pjtCovered = max(1.0 - inside, rim);
     } else if (uMode == 6.0) {
       // paper-tear: the outgoing page rips left to right with a fibered
       // white edge, dragged slightly as it goes; the incoming page sits
@@ -210,6 +240,7 @@ const fragment = /* glsl */ `
         float fiberN = pjtHash(uv * vec2(240.0, 900.0));
         float band = 1.0 - smoothstep(0.0, 0.014 + fiberN * 0.02, dd);
         col = mix(page, mix(uFallback, vec3(1.0), 0.55), band);
+        pjtCovered = 1.0; // un-torn side: outgoing page + its fibered edge
       } else {
         col *= 1.0 - (1.0 - smoothstep(0.0, 0.06, -dd)) * 0.22;
       }
@@ -227,6 +258,7 @@ const fragment = /* glsl */ `
       if (d < 0.0) {
         // paper coord of the turned-over tail lying face-down on top
         float s3 = 2.0 * c + 3.14159 * R - uv.x;
+        pjtCovered = 1.0; // turned page: backside paper or outgoing face
         if (s3 <= 1.0) {
           col = back * (0.88 + 0.12 * smoothstep(0.0, 0.4, -d));
           col *= 1.0 - (1.0 - smoothstep(0.0, 0.012, 1.0 - s3)) * 0.3;
@@ -244,8 +276,10 @@ const fragment = /* glsl */ `
           if (s2 <= 1.0) {
             col = back * (0.72 + 0.28 * sin(theta));
             col *= 1.0 - (1.0 - smoothstep(0.0, 0.012, 1.0 - s2)) * 0.3;
+            pjtCovered = 1.0; // backside paper riding over the roll
           } else if (s1 <= 1.0) {
             col = pjtSnap(vec2(s1, uv.y)) * (1.0 - 0.38 * sin(theta));
+            pjtCovered = 1.0; // outgoing face still rising on the curl
           }
         }
       }
@@ -267,6 +301,8 @@ const fragment = /* glsl */ `
       col = mix(page, mix(col, face, disp), appear);
       float hit = smoothstep(0.53, 0.57, p) * (1.0 - smoothstep(0.60, 0.70, p));
       col = mix(col, uFallback, hit * 0.55);
+      // before the stamp lands the page is snapshot; the impact pop is paper
+      pjtCovered = max(1.0 - appear, hit * 0.55);
       col = mix(col, vec3(1.0), pjtSpeedLines(uv, hit * 0.9) * 0.85);
       float ed = min(min(uv.x, 1.0 - uv.x), min(uv.y, 1.0 - uv.y));
       float ring = smoothstep(0.02, 0.05, ed) - smoothstep(0.05, 0.12, ed);
@@ -286,6 +322,7 @@ const fragment = /* glsl */ `
       float rim = 1.0 - smoothstep(0.005, 0.005 + aa * 2.0, abs(rad - r));
       rim *= smoothstep(0.02, 0.08, p) * (1.0 - smoothstep(0.85, 0.97, p));
       col = mix(col, vec3(0.10, 0.09, 0.08), rim);
+      pjtCovered = max(1.0 - inside, rim); // outside the iris + the inked rim
     } else if (uMode == 10.0) {
       // ink-flood: ink pours from the top and swallows the page around
       // mid-gutter (full cover hides the camera cut like cut's blink --
@@ -298,6 +335,7 @@ const fragment = /* glsl */ `
       float front = smoothstep(0.0, 0.82, q) * (length(vec2(0.5 * aspect, 1.15)) * 1.38 + 0.08);
       float m = 1.0 - smoothstep(front - 0.05, front, radn);
       col = mix(col, vec3(0.07, 0.06, 0.05), m);
+      pjtCovered = m; // flooded ink is authored, not printed geometry
     }
 
     outputColor = vec4(col, inputColor.a);

--- a/shaders/TransitionEffect.ts
+++ b/shaders/TransitionEffect.ts
@@ -37,7 +37,11 @@ import { Color, Uniform, type Texture } from "three";
  * outranks DEPTH, so THIS effect runs FIRST and PrintEffect prints the
  * composite afterwards. That is what makes inputBuffer pre-print -- and it
  * means the print pass would otherwise stamp the LIVE issue's ink line over
- * the outgoing snapshot. pjtCovered is the channel that stops it.
+ * the outgoing snapshot. pjtCovered is the channel that stops it -- and it
+ * covers DISPLACED live frames too (whip smear, crash punch, stamp descent):
+ * there the pixel comes from a tapped uv while the ink line would still be
+ * computed at its own uv, i.e. doubled edges (S2.16). Every writer fades
+ * with the effect that caused it, so the line always returns smoothly.
  */
 const fragment = /* glsl */ `
   uniform sampler2D uSnapshot;
@@ -146,7 +150,13 @@ const fragment = /* glsl */ `
         float s = (float(i) + j) / 7.0 - 0.5;
         acc += texture2D(inputBuffer, uv + uWhipDir * spread * s).rgb;
       }
-      col = mix(col, pjtGrade(acc * 0.125), smoothstep(0.0, 0.35, whipK));
+      float smear = smoothstep(0.0, 0.35, whipK);
+      col = mix(col, pjtGrade(acc * 0.125), smear);
+      // a smeared pixel no longer shows the geometry under it, so the print
+      // pass's ink line -- computed from the UN-displaced normal/depth
+      // buffers -- would land beside the smeared edge (doubled edges,
+      // S2.16). Rides the smear itself: the line fades back, never pops.
+      pjtCovered = max(pjtCovered, smear);
     }
 
     float velK = clamp((abs(uVelocity) - 0.35) * 1.2, 0.0, 0.6);
@@ -180,7 +190,11 @@ const fragment = /* glsl */ `
       // pjtPrint re-grades the pre-print tap so the punch frames match the
       // printed frame they settle into (PR #22 ruling 3 polish, zero RTs)
       vec3 live = pjtPrint(texture2D(inputBuffer, zuv).rgb, uv);
-      col = mix(col, live, clamp(punch * 2.5, 0.0, 1.0));
+      float punchK = clamp(punch * 2.5, 0.0, 1.0);
+      col = mix(col, live, punchK);
+      // zuv != uv: the punched frame is displaced, same doubled-edge case as
+      // the whip smear. Fades out with the punch, so the line returns smoothly
+      pjtCovered = max(pjtCovered, punchK);
 
       // polar fragment grid: each cell departs when p passes its threshold
       // (radius + hash), so the tear opens at the center and races outward
@@ -203,7 +217,9 @@ const fragment = /* glsl */ `
         snap = mix(snap, uFallback, torn * 0.9);
         float held = 1.0 - smoothstep(0.85, 1.0, f);
         col = mix(col, snap, held);
-        pjtCovered = held;
+        // max, not assign: where a fragment has mostly left (held low) the
+        // punched live frame underneath still needs its coverage
+        pjtCovered = max(pjtCovered, held);
       }
     } else if (uMode == 5.0) {
       // panel-wipe: paper gutter bars sweep in over the outgoing page,
@@ -301,8 +317,11 @@ const fragment = /* glsl */ `
       col = mix(page, mix(col, face, disp), appear);
       float hit = smoothstep(0.53, 0.57, p) * (1.0 - smoothstep(0.60, 0.70, p));
       col = mix(col, uFallback, hit * 0.55);
-      // before the stamp lands the page is snapshot; the impact pop is paper
-      pjtCovered = max(1.0 - appear, hit * 0.55);
+      // before the stamp lands the page is snapshot; the impact pop is paper;
+      // and while the face is still scaled (disp) it is a DISPLACED live
+      // frame, so the un-displaced ink line would double its edges (S2.16).
+      // All three terms fade, so the line fades back as the stamp settles.
+      pjtCovered = max(max(1.0 - appear, hit * 0.55), appear * disp);
       col = mix(col, vec3(1.0), pjtSpeedLines(uv, hit * 0.9) * 0.85);
       float ed = min(min(uv.x, 1.0 - uv.x), min(uv.y, 1.0 - uv.y));
       float ring = smoothstep(0.02, 0.05, ed) - smoothstep(0.05, 0.12, ed);


### PR DESCRIPTION
## Root cause (one mechanism, two symptoms)

PrintEffect's ink line is the only post term that samples the live scene's geometry buffers (NormalPass + depth). It was applied to pixels whose colour no longer came from that geometry:

1. **Every snapshot gutter** — `postprocessing`'s `EffectPass` sorts merged effects by attribute flags, so CONVOLUTION (TransitionEffect) runs **before** DEPTH (PrintEffect) regardless of argument order. The transition composites the outgoing snapshot first, then the print pass stamped the *incoming* issue's Sobel edges over it — the "white wireframe over the previous scene" visible at t=0.216 / 0.426 / 0.566 / 0.657 / 0.842 in the 2026-07-27 audit (and three of the user's five bug screenshots), including a doubled-lettering S2.16 violation at 0.426.
2. **Word art** — troika SDF text writes neither depth nor normals, so geometry behind a word inked straight across its glyphs ("KA-CHING!", t=0.707–0.735).

## Fix

- `TransitionEffect` publishes a `pjtCovered` GLSL global per mode (1.0 where the pixel is snapshot/authored fill; explicit reset for mode 0/drift). EffectPass prefixes only function/uniform/define names, so a plain global is legally shared between the merged halves — no extra RT, uniform, or pass. `PrintEffect` gates the edge term by it. **No mix factor or reveal shape changed** — tear still tears, flip still flips, bit-identical minus the stray ink.
- `PrintEffect` gains a third screen-rect exemption (`uWord*`) beside the existing noir window and mascot spot rects, fed per frame by `scanWordRect()` in PostPipeline: largest visible troika block (`isTroikaTextMaterial`; outlined text reports `material` as an **array**, which is why naive detection misses it), CPU-projected, with the depth test inverted — anything standing in *front* of the lettering keeps its line. Labels/captions stay under `WORD_MIN_AREA` and are untouched.

## Verified (before/after pairs, 1920x975)

All five gutter windows clean with reveal shapes intact; 0.426 zoom crops show single-copy lettering (S2.16); KA-CHING window clean; CLANK 0.437 / SLAM 0.470 / Desk caption 0.204 regressions pass; scrub determinism at 0.566 from both directions; settled frames (0.15/0.30/0.45/0.60/0.75/0.90) diff at the same-build revisit noise floor. `npm run typecheck` clean; pure ASCII.

Known approximation: the word exemption is the projected block rect (not per-glyph); invisible in practice because the lettering covers the rect. `scanWordRect` is one `traverseVisible` per frame with a single property test per node.

Part of the audit fix series (4/5), after #51 #52 #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)