### PR TITLE
Scene sweep: the rest of the audit ledger

### DIFF
--- a/components/Lettering.tsx
+++ b/components/Lettering.tsx
@@ -21,9 +21,19 @@ import { clamp01 } from "@/lib/shots";
  * fills, zero-blur shadows (comfort rule).
  */
 
-const COVER_END = RANGES[0]![1];
 const NOIR_RANGE = RANGES[1]!;
 const DESK_START = RANGES[2]![0];
+
+/**
+ * Cover DOM overlay (premise chip + attract prompt) window. The print layers
+ * separate from t=0, and by ~0.012 the 3D price box sweeps into the premise
+ * band while the barcode label crosses the prompt (audit 2026-07-27) -- so
+ * the overlay holds full opacity through COVER_UI_HOLD and is fully gone by
+ * COVER_UI_END, before the first glyph can touch it. Opacity only: reduced
+ * motion still gets the fade, it just never had the breathe.
+ */
+const COVER_UI_HOLD = 0.005;
+const COVER_UI_END = 0.01;
 
 /**
  * Title-drop card scroll window (user ruling 2026-07-03: the card lives and
@@ -106,7 +116,26 @@ const CAPTION_DEFS: CaptionDef[] = [
   { text: lettering.sceneCaptions.spread[1], window: CHART_R, spot: CAPTION_SPOTS[0]! },
 ];
 
-type CardDef = { issue: number; title: string; kicker: string; window: [number, number] };
+type CardDef = {
+  issue: number;
+  title: string;
+  kicker: string;
+  window: [number, number];
+  /** placement override; default is the top-center slot */
+  spot?: CSSProperties;
+};
+
+/**
+ * Per-issue placement overrides. Issue 4's page prints its lead caption
+ * strip across the top for the card's whole window, and the strip GROWS on
+ * screen as the establish shot commits -- top-center lands the kicker on the
+ * strip at every t in the window (audit 2026-07-27). The origin page never
+ * reaches the left quarter of the frame in that window, so card 4 prints in
+ * the paper void beside it.
+ */
+const CARD_SPOTS: Record<number, CSSProperties> = {
+  4: { top: "50%", left: "2.5vw", transform: "translateY(-50%)" },
+};
 
 /**
  * Per-issue title-card slugs (Issues 1..11; the Cover gets none). Default is
@@ -118,7 +147,7 @@ const CARDS: CardDef[] = printEdition.sectionTitles.slice(1).map((s, idx) => {
   const issue = idx + 1;
   const start = RANGES[issue]![0];
   const win: [number, number] = issue === 2 ? [0.137, 0.15] : [start, start + 0.016];
-  return { issue, title: s.title, kicker: s.kicker, window: win };
+  return { issue, title: s.title, kicker: s.kicker, window: win, spot: CARD_SPOTS[issue] };
 });
 
 export default function Lettering() {
@@ -135,8 +164,8 @@ export default function Lettering() {
       const { t, reducedMotion } = useScrollStore.getState();
 
       // cover-segment window shared by the attract prompt (bottom) and the
-      // premise chip (top) -- both fade in/out with the cover, opacity only.
-      const coverO = clamp01(1 - t / COVER_END);
+      // premise chip (top) -- both fade out as the print separates, opacity only.
+      const coverO = clamp01((COVER_UI_END - t) / (COVER_UI_END - COVER_UI_HOLD));
       const coverVis = coverO > 0.001 ? "visible" : "hidden";
 
       const prompt = promptRef.current;
@@ -287,6 +316,7 @@ export default function Lettering() {
             top: "6vh",
             left: "50%",
             transform: "translateX(-50%)",
+            ...card.spot,
             opacity: 0,
             visibility: "hidden",
             textAlign: "center",

--- a/components/Lettering.tsx
+++ b/components/Lettering.tsx
@@ -25,15 +25,17 @@ const NOIR_RANGE = RANGES[1]!;
 const DESK_START = RANGES[2]![0];
 
 /**
- * Cover DOM overlay (premise chip + attract prompt) window. The print layers
- * separate from t=0, and by ~0.012 the 3D price box sweeps into the premise
- * band while the barcode label crosses the prompt (audit 2026-07-27) -- so
- * the overlay holds full opacity through COVER_UI_HOLD and is fully gone by
- * COVER_UI_END, before the first glyph can touch it. Opacity only: reduced
- * motion still gets the fade, it just never had the breathe.
+ * Cover DOM overlay windows -- SEPARATE, because the two chips have different
+ * collision partners (PR #55 L2). The 3D price box sweeps into the premise
+ * band (top) by ~0.012, so the premise keeps the tight window; the prompt
+ * (bottom) only meets the barcode label from ~0.017, so it holds longer and
+ * gets the attract beat it exists for. Opacity only: reduced motion still gets
+ * the fade, it just never had the breathe.
  */
-const COVER_UI_HOLD = 0.005;
-const COVER_UI_END = 0.01;
+const PREMISE_HOLD = 0.005;
+const PREMISE_END = 0.01;
+const PROMPT_HOLD = 0.012;
+const PROMPT_END = 0.016;
 
 /**
  * Title-drop card scroll window (user ruling 2026-07-03: the card lives and
@@ -163,15 +165,14 @@ export default function Lettering() {
       raf = requestAnimationFrame(loop);
       const { t, reducedMotion } = useScrollStore.getState();
 
-      // cover-segment window shared by the attract prompt (bottom) and the
-      // premise chip (top) -- both fade out as the print separates, opacity only.
-      const coverO = clamp01((COVER_UI_END - t) / (COVER_UI_END - COVER_UI_HOLD));
-      const coverVis = coverO > 0.001 ? "visible" : "hidden";
+      // cover-segment fades, one window each (their collision partners differ)
+      const promptO = clamp01((PROMPT_END - t) / (PROMPT_END - PROMPT_HOLD));
+      const premiseO = clamp01((PREMISE_END - t) / (PREMISE_END - PREMISE_HOLD));
 
       const prompt = promptRef.current;
       if (prompt) {
-        prompt.style.opacity = coverO.toFixed(3);
-        prompt.style.visibility = coverVis;
+        prompt.style.opacity = promptO.toFixed(3);
+        prompt.style.visibility = promptO > 0.001 ? "visible" : "hidden";
         // centering + 2.4s breathe live HERE, not in a CSS class: the
         // .pj-breathe rule in globals.css never reached the element under
         // Turbopack, which left the prompt un-centered (barcode collision)
@@ -181,8 +182,8 @@ export default function Lettering() {
 
       const premise = premiseRef.current;
       if (premise) {
-        premise.style.opacity = coverO.toFixed(3);
-        premise.style.visibility = coverVis;
+        premise.style.opacity = premiseO.toFixed(3);
+        premise.style.visibility = premiseO > 0.001 ? "visible" : "hidden";
       }
 
       const card = cardRef.current;

--- a/components/PrintEdition.tsx
+++ b/components/PrintEdition.tsx
@@ -227,7 +227,13 @@ export default function PrintEdition() {
               </div>
             ))}
           </div>
-          <a className={styles.ctaLink} href="#projects">
+          {/* same visible words as the DOM Press CTA button -- the aria-label
+              keeps the two accessible names distinct (PR #55 a11y) */}
+          <a
+            className={styles.ctaLink}
+            href="#projects"
+            aria-label={issueCopy.press.cta + " - print edition"}
+          >
             {issueCopy.press.cta}
           </a>
         </Panel>

--- a/issues/00-cover/Cover.tsx
+++ b/issues/00-cover/Cover.tsx
@@ -7,7 +7,7 @@ import type { Group, Mesh } from "three";
 import IssueShell from "../_IssueShell";
 import { ISSUES } from "../registry";
 import { RANGES } from "../timeline";
-import CatModel from "@/components/CatModel";
+import CatModel, { HARLEY, type CatPalette } from "@/components/CatModel";
 import { toonRamp } from "@/lib/toon";
 import { stepTime } from "@/lib/steppedClock";
 import { useScrollStore } from "@/lib/scrollStore";
@@ -36,6 +36,12 @@ const TEAL = "#2BB3A3";
 
 const BANGERS = "/fonts/Bangers-Regular.ttf";
 const COVER_END = RANGES[0]![1];
+
+// The hero cat sits ON the teal sunburst disc, and the default Harley collar
+// is that exact teal -- the band reads as a hole punched through the neck
+// (audit 2026-07-27). Same teal family, two steps darker: identity mark kept,
+// separation gained. Cover-local; every other issue keeps HARLEY as-is.
+const COVER_CAT: CatPalette = { ...HARLEY, collar: "#12695F" };
 
 // Masthead splits into a small kicker line + a big main line so long names
 // ("SAEED KOLIVAND", 14 chars) never clip or collide with the price box.
@@ -203,7 +209,7 @@ export default function Cover({ index }: { index: number }) {
                 Harley default palette (golden tabby, user directive
                 2026-07-03); tail rig ref is flicked on stepped time in the
                 useFrame above, its pivot sits INSIDE the haunch */}
-            <CatModel mode="flat" pose="leaping" rig={{ tail }} />
+            <CatModel mode="flat" pose="leaping" palette={COVER_CAT} rig={{ tail }} />
 
             {/* speed dashes trailing the pounce (technique vocabulary, S1) */}
             <mesh position={[-1.8, -0.55, 0.001]}>

--- a/issues/01-noir/Noir.tsx
+++ b/issues/01-noir/Noir.tsx
@@ -240,9 +240,12 @@ function NoirCat({ cx }: { cx: number }) {
     const trot = clamp01(p4 / 0.72);
     const k = clamp01((p4 - 0.72) / 0.28); // the leap window
 
-    // shot 3: walk in frame-left along the parapet (pure f(t))
+    // shot 3: walk in frame-left along the parapet (pure f(t)). y 9.328 sets
+    // every contact point ON the ledge top line (9.325) -- the toon walk
+    // pose's planted paws sit ~0.03 below its origin at this 1.2 scale
+    // (contact fix with the paw amplitude below, audit 2026-07-27).
     let x = lerp(-7.2, -1.6, p3);
-    let y = 9.32;
+    let y = 9.328;
     let z = 2.5;
     let ry = 0;
     let rz = 0;
@@ -251,7 +254,7 @@ function NoirCat({ cx }: { cx: number }) {
     if (p4 > 0) {
       // shot 4 pre-leap: trot toward the facade gap, crouch to anticipate
       x = lerp(-1.6, -0.9, trot);
-      y = lerp(9.32, 9.02, clamp01(trot * 2));
+      y = lerp(9.328, 9.02, clamp01(trot * 2));
       z = lerp(2.5, 0.8, trot);
       ry = lerp(0, 1.35, clamp01(trot * 4));
       squash = 1 - 0.25 * clamp01((trot - 0.75) / 0.25);
@@ -313,19 +316,27 @@ function NoirCat({ cx }: { cx: number }) {
     if (walkG.current) walkG.current.visible = !leaping && !crouching;
     if (crouchG.current) crouchG.current.visible = crouching;
     if (leapG.current) leapG.current.visible = leaping;
-    // 12 fps tail flick -- ambient stepped-time idle (S2.8)
-    const flick = Math.sin(stepTime(clock.elapsedTime, 12) * 2.4) * 0.45;
-    if (walkTail.current) walkTail.current.rotation.x = flick;
-    if (crouchTail.current) crouchTail.current.rotation.x = flick;
-    if (leapTail.current) leapTail.current.rotation.x = flick;
-    // stride swing derives from parapet x -- pure f(t), scrub-safe
-    if (walkPaw.current) walkPaw.current.rotation.z = Math.sin(x * 5.2) * 0.55;
+    // 12 fps tail flick -- ambient stepped-time idle (S2.8). Driven on
+    // rotation.z (the rig's own axis) around a RAISED base: CatModel's rest
+    // tail sweeps straight back, and shot 4 turns the cat rear-on, so a
+    // back-swept tail foreshortens onto its own haunch and the ink edge
+    // reads as a hole in the rump (audit 2026-07-27). -0.78 stands the
+    // shaft up clear of the haunch mass; +/-0.2 keeps the flick alive
+    // without dropping it back into the silhouette at any stepped phase.
+    const flick = -0.78 + Math.sin(stepTime(clock.elapsedTime, 12) * 2.4) * 0.2;
+    if (walkTail.current) walkTail.current.rotation.z = flick;
+    if (crouchTail.current) crouchTail.current.rotation.z = flick;
+    if (leapTail.current) leapTail.current.rotation.z = flick;
+    // stride swing derives from parapet x -- pure f(t), scrub-safe. Amplitude
+    // 0.3: the old 0.55 lifted the near sock a full paw off the parapet line
+    // while the planted legs stayed on it (contact fix, same audit).
+    if (walkPaw.current) walkPaw.current.rotation.z = Math.sin(x * 5.2) * 0.3;
   });
 
   return (
     <group
       ref={group}
-      position={[-7.2, 9.32, 2.5]}
+      position={[-7.2, 9.328, 2.5]}
       onClick={(e) => {
         e.stopPropagation();
         useScrollStore.getState().meow();

--- a/issues/04-origin/Origin.tsx
+++ b/issues/04-origin/Origin.tsx
@@ -504,26 +504,47 @@ function Portal() {
         <meshBasicMaterial color={VOID} side={BackSide} />
       </mesh>
 
-      {/* deep in the dark: the robot, waiting (beat 7) */}
-      <group position={[PX, PY, -PORTAL_DEPTH + 0.3]}>
-        <mesh position={[-0.38, 0.25, 0]}>
-          <planeGeometry args={[0.34, 0.14]} />
-          <meshBasicMaterial color={RUST} />
-        </mesh>
-        <mesh position={[0.38, 0.25, 0]}>
-          <planeGeometry args={[0.34, 0.14]} />
-          <meshBasicMaterial color={RUST} />
-        </mesh>
-        <mesh position={[0, -0.35, 0]}>
-          <planeGeometry args={[0.6, 0.06]} />
+      {/* deep in the dark: the robot, waiting (beat 7). Every part overlaps
+          the mass it hangs off (torso <- neck <- head, torso <- arms/legs,
+          legs <- feet) so it reads as ONE figure -- the old build was five
+          floating primitives with no torso (audit 2026-07-27). Same flat
+          plane/circle vocabulary and BLUE/RUST palette as before; lowered
+          0.25 so the caption above it clears the head. */}
+      <group position={[PX, PY - 0.25, -PORTAL_DEPTH + 0.3]}>
+        <mesh position={[0, 0.42, 0]}>
+          <planeGeometry args={[0.66, 0.86]} />
           <meshBasicMaterial color={BLUE} />
         </mesh>
-        <mesh position={[0, 0.85, 0]}>
-          <planeGeometry args={[0.04, 0.5]} />
+        <mesh position={[0, 0.92, 0]}>
+          <planeGeometry args={[0.14, 0.24]} />
           <meshBasicMaterial color={BLUE} />
         </mesh>
-        <mesh position={[0, 1.15, 0]}>
-          <circleGeometry args={[0.07, 12]} />
+        <mesh position={[0, 1.12, 0]}>
+          <circleGeometry args={[0.22, 16]} />
+          <meshBasicMaterial color={RUST} />
+        </mesh>
+        <mesh position={[-0.38, 0.55, 0.001]}>
+          <planeGeometry args={[0.36, 0.14]} />
+          <meshBasicMaterial color={RUST} />
+        </mesh>
+        <mesh position={[0.38, 0.55, 0.001]}>
+          <planeGeometry args={[0.36, 0.14]} />
+          <meshBasicMaterial color={RUST} />
+        </mesh>
+        <mesh position={[-0.17, -0.2, 0]}>
+          <planeGeometry args={[0.16, 0.44]} />
+          <meshBasicMaterial color={BLUE} />
+        </mesh>
+        <mesh position={[0.17, -0.2, 0]}>
+          <planeGeometry args={[0.16, 0.44]} />
+          <meshBasicMaterial color={BLUE} />
+        </mesh>
+        <mesh position={[-0.17, -0.43, 0.001]}>
+          <planeGeometry args={[0.28, 0.11]} />
+          <meshBasicMaterial color={RUST} />
+        </mesh>
+        <mesh position={[0.17, -0.43, 0.001]}>
+          <planeGeometry args={[0.28, 0.11]} />
           <meshBasicMaterial color={RUST} />
         </mesh>
       </group>
@@ -539,11 +560,15 @@ const STACK = content.stack;
 // the blank bottom margin below the portal caption -- chips crossing captions
 // in the close shots read as occluded text, so the ring never enters the
 // panel/caption band
+// Lane pitch 1.1: tiles are 0.7 tall and squash/bob another ~0.24, so the old
+// 0.3/0.4 steps let same-lane neighbours (REACT/NEXT.JS, TYPESCRIPT/TAURI)
+// overlap in y and clip each other's words whenever their orbits crossed in x
+// (audit 2026-07-27). One clear row per tile per lane.
 const ICONS = STACK.map((label, i) => ({
   label,
   phase: (i / STACK.length) * Math.PI * 2,
   r: 9.2 + (i % 3) * 0.7,
-  y0: i % 2 ? -6.9 - (i >> 1) * 0.3 : 8.6 + (i >> 1) * 0.4,
+  y0: i % 2 ? -6.9 - (i >> 1) * 1.1 : 8.6 + (i >> 1) * 1.1,
   speed: 0.16 + (i % 3) * 0.04,
   sq: i * 1.7,
 }));
@@ -767,9 +792,15 @@ export default function Origin({ index }: { index: number }) {
           <NoirFallback />
         </PanelFrame>
 
-        {/* beat 7: the portal panel -- caption on the page below the opening */}
+        {/* beat 7: the portal panel. The caption hangs INSIDE the void, high
+            on the back wall: on the page below the opening it was out of
+            frame for the entire closing beat (the glide squares up on the
+            mouth, then crosses the page plane), leaving the issue's last
+            beat unlettered (audit 2026-07-27). Here it holds frame from the
+            square-up through the crossing, clear of the mouth, the robot
+            below it and the cat perched at the bottom of the opening. */}
         <Portal />
-        <Caption x={PX} y={-5.85} w={4.0} text={BEATS[6]!} size={0.22} />
+        <Caption x={PX} y={PY + 1.55} w={3.0} h={0.78} z={-5.0} text={BEATS[6]!} size={0.2} />
 
         <IconRing />
       </Suspense>

--- a/issues/08-pop/Pop.tsx
+++ b/issues/08-pop/Pop.tsx
@@ -24,6 +24,7 @@ import { useScrollStore } from "@/lib/scrollStore";
 import { CAT_VOICE, sayWord } from "@/lib/onomatopoeia";
 import { popScale } from "@/lib/pops";
 import { clamp01 } from "@/lib/shots";
+import { authoredCamera } from "@/lib/authoredCamera";
 import { content, issueCopy } from "@/lib/content";
 import {
   chatPool,
@@ -675,7 +676,7 @@ function ChatBalloons() {
   useFrame(({ clock }) => {
     const w = wrap.current;
     if (!w) return;
-    const { quality, reducedMotion } = useScrollStore.getState();
+    const { t, quality, reducedMotion } = useScrollStore.getState();
     const fps = quality === "low" ? 8 : 12;
     const el = clock.elapsedTime;
     // ambient pop cadence: one locked chat line per interval (intensity 5).
@@ -694,7 +695,11 @@ function ChatBalloons() {
       w.getWorldQuaternion(tmpQ2);
       bill.current.copy(tmpQ2).invert().multiply(camera.quaternion);
     }
-    const cam = camera as PerspectiveCamera;
+    // frame guard projects through the AUTHORED pose, never the live camera:
+    // ShotDirector delta-smooths and pointer-parallaxes the live one, which
+    // would tie this fade to scroll history and the mouse (PR #55 H1). The
+    // billboard above still faces the live camera -- only the fade is f(t).
+    const cam = authoredCamera(t, (camera as PerspectiveCamera).aspect);
     const tanH = Math.tan((cam.fov * Math.PI) / 360);
     const now = performance.now();
     for (let i = 0; i < B_N; i++) {
@@ -728,13 +733,14 @@ function ChatBalloons() {
       g.position.copy(slot.pos);
       if (!reducedMotion) g.position.y += 0.12 * stepTime(age, fps); // stepped rise
       // frame guard: a balloon that would cross a viewport edge fades out
-      // instead of printing half a chat line (audit 2026-07-27). Camera and
-      // anchors are both pure f(t), so the fade scrubs both directions.
+      // instead of printing half a chat line (audit 2026-07-27). The authored
+      // camera makes it pure f(t); the half-extents carry `s` because the pop
+      // envelope overshoots past BALLOON_SCALE (~1.35x peak, PR #55 M2).
       tmpV.copy(g.position).applyMatrix4(w.matrixWorld);
       const dist = tmpV.distanceTo(cam.position);
       tmpV.project(cam);
-      const hx = (B_HALF_W * BALLOON_SCALE) / (dist * tanH * cam.aspect);
-      const hy = (B_HALF_H * BALLOON_SCALE) / (dist * tanH);
+      const hx = (B_HALF_W * BALLOON_SCALE * s) / (dist * tanH * cam.aspect);
+      const hy = (B_HALF_H * BALLOON_SCALE * s) / (dist * tanH);
       const framed =
         tmpV.z > 1
           ? 0

--- a/issues/08-pop/Pop.tsx
+++ b/issues/08-pop/Pop.tsx
@@ -5,13 +5,16 @@ import { useFrame, useThree } from "@react-three/fiber";
 import { Text } from "@react-three/drei";
 import {
   Color,
+  FrontSide,
   Matrix4,
   Object3D,
   Quaternion,
+  Vector3,
   type Group,
   type InstancedMesh,
   type Mesh,
   type MeshBasicMaterial,
+  type PerspectiveCamera,
 } from "three";
 import IssueShell from "../_IssueShell";
 import { ISSUES } from "../registry";
@@ -20,6 +23,7 @@ import { stepTime } from "@/lib/steppedClock";
 import { useScrollStore } from "@/lib/scrollStore";
 import { CAT_VOICE, sayWord } from "@/lib/onomatopoeia";
 import { popScale } from "@/lib/pops";
+import { clamp01 } from "@/lib/shots";
 import { content, issueCopy } from "@/lib/content";
 import {
   chatPool,
@@ -71,6 +75,14 @@ const tmpM = new Matrix4();
 const tmpC = new Color();
 const tmpQ = new Quaternion();
 const tmpQ2 = new Quaternion();
+const tmpV = new Vector3();
+
+// Balloon print size + its half-extents in balloon-local units (halo width,
+// halo top -> tail tip). 0.72 keeps a chat line legible at the establish lens
+// while three balloons stack inside one frame (audit 2026-07-27).
+const BALLOON_SCALE = 0.72;
+const B_HALF_W = 2.6;
+const B_HALF_H = 1.5;
 
 const hash = (i: number, n: number) => {
   const x = Math.sin((i + 1) * n) * 43758.5453;
@@ -459,17 +471,27 @@ interface EmoteDef {
   s: number;
   y0: number;
   ph: number;
+  /** climb span: the height the sprite cycles through */
+  sp: number;
 }
 
 // inner radius 6.8 clears the ON AIR sign + desk sight lines (iteration 1)
-const EMOTES: EmoteDef[] = Array.from({ length: EMOTE_N }, (_, i) => ({
-  a: 2 * Math.PI * hash(i, 1.7),
-  r: 6.8 + 3.6 * hash(i, 2.9),
-  v: 0.5 + 0.55 * hash(i, 4.1),
-  s: 0.75 + 0.55 * hash(i, 6.3),
-  y0: 9.5 * hash(i, 8.8),
-  ph: 6.28 * hash(i, 9.9),
-}));
+const EMOTES: EmoteDef[] = Array.from({ length: EMOTE_N }, (_, i) => {
+  const a = 2 * Math.PI * hash(i, 1.7);
+  // sprites on the sign's arc climb a shorter band (top 5.6 + half a sprite
+  // stays under the sign's 6.5 bottom edge), so an emote can never park on
+  // the ON AIR face and hide its letters (audit 2026-07-27)
+  const sp = Math.cos(a) < -0.35 ? 5.2 : 9.5;
+  return {
+    a,
+    r: 6.8 + 3.6 * hash(i, 2.9),
+    v: 0.5 + 0.55 * hash(i, 4.1),
+    s: 0.75 + 0.55 * hash(i, 6.3),
+    y0: sp * hash(i, 8.8),
+    ph: 6.28 * hash(i, 9.9),
+    sp,
+  };
+});
 const EMOTE_MATS = EMOTES.map(() => new Matrix4());
 
 // flat part lists, emote-ordered (low tier trims by instance count)
@@ -533,7 +555,7 @@ function EmoteField() {
       const d = EMOTES[e]!;
       tmpO.position.set(
         Math.cos(d.a) * d.r + 0.35 * Math.sin(st * 0.8 + d.ph),
-        0.4 + ((d.y0 + d.v * st) % 9.5),
+        0.4 + ((d.y0 + d.v * st) % d.sp),
         Math.sin(d.a) * d.r + 0.35 * Math.cos(st * 0.7 + d.ph),
       );
       tmpO.quaternion.copy(tmpQ);
@@ -651,11 +673,15 @@ function ChatBalloons() {
   const bill = useRef(new Quaternion());
 
   useFrame(({ clock }) => {
+    const w = wrap.current;
+    if (!w) return;
     const { quality, reducedMotion } = useScrollStore.getState();
     const fps = quality === "low" ? 8 : 12;
     const el = clock.elapsedTime;
-    // ambient pop cadence: one locked chat line per interval (intensity 5)
-    const ivl = quality === "low" ? 0.8 : 0.5;
+    // ambient pop cadence: one locked chat line per interval (intensity 5).
+    // Stays above life / slots (2.6 / 3) so a wall slot is always free before
+    // the round-robin comes back to it (audit 2026-07-27).
+    const ivl = quality === "low" ? 1.15 : 0.95;
     const sp = Math.floor(el / ivl);
     if (sp !== lastSpawn.current) {
       lastSpawn.current = sp;
@@ -663,11 +689,13 @@ function ChatBalloons() {
     }
     // stepped billboard facing, shared by all balloons (S2.8 contrast)
     const stp = Math.floor(el * fps);
-    if (stp !== lastStep.current && wrap.current) {
+    if (stp !== lastStep.current) {
       lastStep.current = stp;
-      wrap.current.getWorldQuaternion(tmpQ2);
+      w.getWorldQuaternion(tmpQ2);
       bill.current.copy(tmpQ2).invert().multiply(camera.quaternion);
     }
+    const cam = camera as PerspectiveCamera;
+    const tanH = Math.tan((cam.fov * Math.PI) / 360);
     const now = performance.now();
     for (let i = 0; i < B_N; i++) {
       const g = groups.current[i];
@@ -697,18 +725,38 @@ function ChatBalloons() {
         g.visible = false;
         continue;
       }
-      const alpha = reducedMotion
-        ? Math.max(0, Math.min(1, age / 0.35, (chatPool.life - age) / 0.45))
-        : 1;
-      g.visible = true;
       g.position.copy(slot.pos);
-      if (!reducedMotion) g.position.y += 0.35 * stepTime(age, fps); // stepped rise
+      if (!reducedMotion) g.position.y += 0.12 * stepTime(age, fps); // stepped rise
+      // frame guard: a balloon that would cross a viewport edge fades out
+      // instead of printing half a chat line (audit 2026-07-27). Camera and
+      // anchors are both pure f(t), so the fade scrubs both directions.
+      tmpV.copy(g.position).applyMatrix4(w.matrixWorld);
+      const dist = tmpV.distanceTo(cam.position);
+      tmpV.project(cam);
+      const hx = (B_HALF_W * BALLOON_SCALE) / (dist * tanH * cam.aspect);
+      const hy = (B_HALF_H * BALLOON_SCALE) / (dist * tanH);
+      const framed =
+        tmpV.z > 1
+          ? 0
+          : clamp01(
+              Math.min(1 - hx - Math.abs(tmpV.x), 1 - hy - Math.abs(tmpV.y)) / 0.06,
+            );
+      const alpha =
+        framed *
+        (reducedMotion
+          ? Math.max(0, Math.min(1, age / 0.35, (chatPool.life - age) / 0.45))
+          : 1);
+      if (alpha <= 0.002) {
+        g.visible = false;
+        continue;
+      }
+      g.visible = true;
       g.quaternion.copy(bill.current);
       g.rotateZ(
         (slot.seed - 0.5) * 0.22 +
           (reducedMotion ? 0 : 0.04 * Math.sin(stepTime(age, fps) * 7)),
       );
-      g.scale.setScalar(s);
+      g.scale.setScalar(s * BALLOON_SCALE);
       for (let k = 0; k < 3; k++) {
         const m = mats.current[i * 3 + k];
         if (m) m.opacity = alpha;
@@ -729,7 +777,10 @@ function ChatBalloons() {
             }}
             visible={false}
           >
-            {/* accent halo rim behind the body */}
+            {/* accent halo rim behind the body. depthTest off on the whole
+                balloon: comic law -- lettering prints ON TOP of the art, so
+                no desk, truss or emote sprite can ever cut a chat line
+                (S2.16 readable content, audit 2026-07-27) */}
             <mesh position={[0, 0, -0.16]} scale={[2.55, 1.24, 0.6]}>
               <sphereGeometry args={[1, 20, 14]} />
               <meshBasicMaterial
@@ -738,6 +789,7 @@ function ChatBalloons() {
                 }}
                 color={PINK}
                 transparent
+                depthTest={false}
               />
             </mesh>
             <mesh scale={[2.35, 1.06, 0.6]}>
@@ -748,6 +800,7 @@ function ChatBalloons() {
                 }}
                 color={INK}
                 transparent
+                depthTest={false}
               />
             </mesh>
             <mesh position={[-0.95, -1.0, 0.05]} rotation={[0, 0, 2.55]}>
@@ -758,9 +811,12 @@ function ChatBalloons() {
                 }}
                 color={INK}
                 transparent
+                depthTest={false}
               />
             </mesh>
             <Text
+              material-depthTest={false}
+              material-side={FrontSide}
               ref={(el: unknown) => {
                 texts.current[i] = el as TText | null;
               }}
@@ -799,7 +855,11 @@ function DonationAlert() {
     gg.visible = o > 0.001;
     if (!gg.visible) return;
     gg.scale.setScalar(1 + 0.4 * DON_KICK.v);
-    for (const m of mats.current) if (m) m.opacity = o;
+    // the card backing reaches full opacity 3x ahead of the caption: the desk
+    // never reads through the copy, and the rear view stays a solid card back
+    // instead of a see-through mirrored caption (audit 2026-07-27)
+    const plate = Math.min(1, o * 3);
+    for (const m of mats.current) if (m) m.opacity = plate;
     if (txt.current) txt.current.fillOpacity = o;
   });
 
@@ -826,10 +886,13 @@ function DonationAlert() {
         />
       </mesh>
       <Suspense fallback={null}>
+        {/* single-sided: from behind, the orbit reads the card back, never a
+            mirrored caption (audit 2026-07-27) */}
         <Text
           ref={(el: unknown) => {
             txt.current = el as TText | null;
           }}
+          material-side={FrontSide}
           position={[0, 0, 0.14]}
           font={BANGERS}
           fontSize={0.4}
@@ -863,7 +926,6 @@ function DonationBoom() {
     m.visible = o > 0.001;
     if (!m.visible) return;
     m.fillOpacity = o;
-    m.outlineOpacity = o;
     m.scale.setScalar(1 + 0.5 * DON_KICK.v);
     const st = reducedMotion ? 0 : stepTime(clock.elapsedTime, quality === "low" ? 8 : 12);
     m.rotation.z = -0.06 + 0.05 * Math.sin(st * 1.4);
@@ -871,16 +933,18 @@ function DonationBoom() {
 
   return (
     <Suspense fallback={null}>
+      {/* ONE crisp layer, no outline: a fat paper halo fading with the fill
+          read as a second offset copy of the word (S2.16, audit 2026-07-27).
+          Single-sided so the orbit never films it mirrored. */}
       <Text
         ref={(el: unknown) => {
           txt.current = el as TText | null;
         }}
+        material-side={FrontSide}
         position={[0.3, 3.9, 2.8]}
         font={BANGERS}
         fontSize={1.65}
         color={YELLOW}
-        outlineWidth={0.18}
-        outlineColor={PAPER}
         anchorX="center"
         anchorY="middle"
         visible={false}

--- a/issues/08-pop/shots.ts
+++ b/issues/08-pop/shots.ts
@@ -187,10 +187,13 @@ registerJawDrop({
       .timeline()
       .set(ORBIT_KICK, { v: 0 })
       .to(ORBIT_KICK, { v: 1, duration: 0.12, ease: "power2.in" })
-      .to(ORBIT_KICK, { v: 0, duration: 0.5, ease: "power2.out" });
-    spawnChat(0.17);
-    spawnChat(0.53);
-    spawnChat(0.89);
+      .to(ORBIT_KICK, { v: 0, duration: 0.5, ease: "power2.out" })
+      // staggered 0.15s apart on this timeline: fired in one frame the volley
+      // recycled ALL THREE pool slots at once, hard-swapping every live
+      // balloon's glyphs mid-read (PR #55 L4)
+      .call(spawnChat, [0.17], 0)
+      .call(spawnChat, [0.53], 0.15)
+      .call(spawnChat, [0.89], 0.3);
     sayWord(lettering.onomatopoeia.whip, [CX, 9.5, 0], undefined, CYAN);
   },
 });

--- a/issues/08-pop/shots.ts
+++ b/issues/08-pop/shots.ts
@@ -61,7 +61,23 @@ export interface ChatData {
   accent: string;
 }
 
-export const chatPool = new PopPool<ChatData>(8, 2.6, () => ({
+/**
+ * Chat wall slots -- ONE fixed anchor per pool slot (audit 2026-07-27). The
+ * old 5-lane jitter packed up to six live balloons into a volume narrower
+ * than a single balloon, so they clipped each other's first letters. Three
+ * slots stacked 1.95 apart (one balloon + tail + rise) and staggered in depth
+ * read as one chat wall from the establish, track and orbit lenses; the
+ * round-robin spawn always recycles a slot back into its OWN anchor, so two
+ * balloons can never share a spot (Pop.tsx keeps the cadence slower than the
+ * 2.6s life x 3 slots, so a slot is free before it is reused).
+ */
+const CHAT_ANCHORS: [number, number, number][] = [
+  [6.2, 3.0, 2.4],
+  [6.7, 4.95, 0.2],
+  [6.2, 6.9, -2.0],
+];
+
+export const chatPool = new PopPool<ChatData>(CHAT_ANCHORS.length, 2.6, () => ({
   line: "",
   accent: PINK,
 }));
@@ -78,13 +94,16 @@ let chatIdx = 0;
 export function spawnChat(seed?: number): void {
   const i = chatIdx++;
   seed ??= hash(i, 12.71);
-  const lane = i % 5;
-  // wider lane spread + 3 depth rows so concurrent balloons stack instead of
-  // occluding each other's text (iteration 1, loop log in shots.md)
-  const x = 5.2 + 0.95 * lane + 0.8 * (hash(i, 3.31) - 0.5);
-  const y = 1.8 + 1.15 * ((i * 2) % 5) + 0.5 * hash(i, 7.73);
-  const z = -1.6 + 1.6 * (i % 3) + 0.8 * (hash(i, 5.17) - 0.5);
-  const slot = chatPool.spawn([x, y, z], seed);
+  const a = CHAT_ANCHORS[i % CHAT_ANCHORS.length]!;
+  // sub-slot jitter only -- never enough to close the gap to a neighbour
+  const slot = chatPool.spawn(
+    [
+      a[0] + 0.4 * (hash(i, 3.31) - 0.5),
+      a[1] + 0.3 * (hash(i, 7.73) - 0.5),
+      a[2] + 0.4 * (hash(i, 5.17) - 0.5),
+    ],
+    seed,
+  );
   slot.data.line = CHAT_LINES[i % CHAT_LINES.length]!;
   slot.data.accent = ACCENT_CYCLE[i % ACCENT_CYCLE.length]!;
   // one hook covers ambient cadence AND the orbit volley; the case gates on

--- a/issues/09-sketchbook/Sketchbook.tsx
+++ b/issues/09-sketchbook/Sketchbook.tsx
@@ -1,13 +1,15 @@
 "use client";
 
 import { Suspense, useEffect, useLayoutEffect, useMemo, useRef } from "react";
-import { useFrame } from "@react-three/fiber";
+import { useFrame, useThree } from "@react-three/fiber";
 import { Text } from "@react-three/drei";
 import {
   Color,
   Object3D,
+  Vector3,
   type Group,
   type InstancedMesh,
+  type PerspectiveCamera,
   type ShaderMaterial,
 } from "three";
 import IssueShell from "../_IssueShell";
@@ -54,12 +56,22 @@ const [CX] = issueCenter(9);
 const NODE_X = [-27, -18, -9, 0, 9, 18, 27];
 /** annotation anchors -- DB + Search share one snippet between them */
 const ANNOT_X = [-27, -18, -9, 0, 13.5, 27];
+/**
+ * Per-annotation depth south of the chain. The Workers snippet sat under the
+ * gears bench and the DB + Search snippet under the chain dashes, so from the
+ * low tracking lens the props printed straight through the handwriting; both
+ * drop 1.5 further south onto clean page (audit 2026-07-27).
+ */
+const ANNOT_Z = [3.9, 3.9, 5.4, 3.9, 5.4, 3.9];
 /** dot(localPos, uSweepDir) bracket over every sketch mesh (set-local) */
 const SWEEP_SPAN: [number, number] = [-30, 30];
 
 // ---- shared scratch (zero per-frame allocation) -----------------------------
 const tmpO = new Object3D();
 const tmpC = new Color();
+const tmpV = new Vector3();
+/** widest annotation half-width on the page (maxWidth 7 wrap) */
+const ANNOT_HALF_W = 3.5;
 
 const hash = (i: number, n: number) => {
   const x = Math.sin((i + 1) * n) * 43758.5453;
@@ -302,11 +314,24 @@ type TextHandle = Object3D & { fillOpacity: number };
 
 function Annotations() {
   const refs = useRef<(TextHandle | null)[]>([]);
+  const camera = useThree((s) => s.camera);
 
   useFrame(() => {
     const u = inkAt(useScrollStore.getState().t);
+    const cam = camera as PerspectiveCamera;
+    const tanH = Math.tan((cam.fov * Math.PI) / 360);
     refs.current.forEach((h, i) => {
-      if (h) h.fillOpacity = clamp01((u - (0.16 + i * 0.075)) / 0.05);
+      if (!h) return;
+      // side-margin guard: a snippet crossing the left/right viewport edge
+      // fades instead of printing half a sentence during the pull-back
+      // (audit 2026-07-27). Camera + anchors are pure f(t) -- scrub-safe.
+      tmpV.set(CX + ANNOT_X[i]!, 0.85, ANNOT_Z[i]!); // set-local -> world
+      const dist = tmpV.distanceTo(cam.position);
+      tmpV.project(cam);
+      const hx = ANNOT_HALF_W / (dist * tanH * cam.aspect);
+      const framed =
+        tmpV.z > 1 ? 0 : clamp01((1 - hx - Math.abs(tmpV.x)) / 0.05);
+      h.fillOpacity = framed * clamp01((u - (0.16 + i * 0.075)) / 0.05);
     });
   });
 
@@ -319,7 +344,7 @@ function Annotations() {
             ref={(o: unknown) => {
               refs.current[i] = o as TextHandle | null;
             }}
-            position={[ANNOT_X[i]!, 0.85, 3.9]}
+            position={[ANNOT_X[i]!, 0.85, ANNOT_Z[i]!]}
             rotation={[-Math.PI / 2 + 0.4, 0, 0]}
             font={CAVEAT}
             fontSize={0.75}
@@ -366,6 +391,16 @@ const pathPos = (w: number): [number, number] => [
   lerp(CAT_A[0], CAT_B[0], w),
   lerp(CAT_A[1], CAT_B[1], w),
 ];
+
+/**
+ * Paw contact heights (CatModel flat build, scale 0.9): the sit pose reaches
+ * its lowest sock at local y -0.93, the walk at -0.72. At the old shared 0.12
+ * the page ate the sit pose's whole lower half -- it printed as a legless
+ * bust cut flat at the page plane (audit 2026-07-27). Both poses now stand
+ * their paws on the paper.
+ */
+const SIT_Y = 0.86;
+const WALK_Y = 0.67;
 
 function Pawprints() {
   const base = useMemo(() => pawprintMaterial(), []);
@@ -436,11 +471,11 @@ function PageCat() {
     const [x, z] = pathPos(w);
     if (walkG.current) {
       walkG.current.visible = walking;
-      walkG.current.position.set(x, 0.12 + 0.07 * Math.abs(Math.sin(st * 7)), z);
+      walkG.current.position.set(x, WALK_Y + 0.07 * Math.abs(Math.sin(st * 7)), z);
     }
     if (sitG.current) {
       sitG.current.visible = !walking;
-      sitG.current.position.set(x, 0.12, z);
+      sitG.current.position.set(x, SIT_Y, z);
     }
     const flick = 0.85 + Math.sin(st * 1.6) * 0.14;
     if (walkTail.current) walkTail.current.rotation.z = flick;

--- a/issues/09-sketchbook/Sketchbook.tsx
+++ b/issues/09-sketchbook/Sketchbook.tsx
@@ -21,6 +21,7 @@ import { useScrollStore } from "@/lib/scrollStore";
 import { CAT_VOICE, sayWord } from "@/lib/onomatopoeia";
 import { issueCopy } from "@/lib/content";
 import { clamp01, lerp } from "@/lib/shots";
+import { authoredCamera } from "@/lib/authoredCamera";
 import { issueCenter } from "../timeline";
 import { inkAt, SKETCH_SETTLE } from "./shots";
 
@@ -70,7 +71,11 @@ const SWEEP_SPAN: [number, number] = [-30, 30];
 const tmpO = new Object3D();
 const tmpC = new Color();
 const tmpV = new Vector3();
-/** widest annotation half-width on the page (maxWidth 7 wrap) */
+/**
+ * Margin-guard half-width: the WRAP BOUND (maxWidth 7 / 2), not a measured
+ * glyph extent -- conservative on purpose, so a short snippet leaves the edge
+ * a little early rather than printing clipped.
+ */
 const ANNOT_HALF_W = 3.5;
 
 const hash = (i: number, n: number) => {
@@ -317,15 +322,19 @@ function Annotations() {
   const camera = useThree((s) => s.camera);
 
   useFrame(() => {
-    const u = inkAt(useScrollStore.getState().t);
-    const cam = camera as PerspectiveCamera;
+    const t = useScrollStore.getState().t;
+    const u = inkAt(t);
+    // AUTHORED pose, not the live camera: the live one is delta-smoothed and
+    // pointer-parallaxed by ShotDirector, which would make this fade depend on
+    // scroll history and the mouse (PR #55 H1). authoredCamera is pure f(t).
+    const cam = authoredCamera(t, (camera as PerspectiveCamera).aspect);
     const tanH = Math.tan((cam.fov * Math.PI) / 360);
     refs.current.forEach((h, i) => {
       if (!h) return;
       // side-margin guard: a snippet crossing the left/right viewport edge
       // fades instead of printing half a sentence during the pull-back
-      // (audit 2026-07-27). Camera + anchors are pure f(t) -- scrub-safe.
-      tmpV.set(CX + ANNOT_X[i]!, 0.85, ANNOT_Z[i]!); // set-local -> world
+      // (audit 2026-07-27). Anchor world pos comes off its own matrixWorld.
+      h.getWorldPosition(tmpV);
       const dist = tmpV.distanceTo(cam.position);
       tmpV.project(cam);
       const hx = ANNOT_HALF_W / (dist * tanH * cam.aspect);

--- a/issues/10-spread/Spread.tsx
+++ b/issues/10-spread/Spread.tsx
@@ -145,7 +145,10 @@ const KRACKLE = Array.from({ length: KRACKLE_N }, (_, i) => {
   const r = mulberry32(300 + i * 7);
   return {
     x: (r() - 0.5) * 60,
-    y: -6 + r() * 20,
+    // floor lifted from -6: the closing card sits at y -9.6 and the unfold
+    // lens is a low pull-back, so anything under -3 in this field can drift
+    // across the card's letters (audit 2026-07-27)
+    y: -3 + r() * 20,
     z: -12 + r() * 26,
     s: 0.06 + r() * 0.14,
     ci: Math.floor(r() * 3),
@@ -352,12 +355,17 @@ function Constellations() {
         </bufferGeometry>
         <lineBasicMaterial color={VIOLET} transparent opacity={0.38} />
       </lineSegments>
+      {/* labels print ON TOP of the field: a foreground krackle dot or the
+          drifting cat must never sit on a letter (S2.16 readable content,
+          audit 2026-07-27) */}
       {CONST_LABELS.map((l, i) => (
         <Text
           key={l.text}
           ref={(el) => {
             labels.current[i] = el as unknown as Mesh | null;
           }}
+          material-depthTest={false}
+          renderOrder={3}
           position={[l.x, l.y, l.z]}
           font={BANGERS}
           fontSize={1.15}
@@ -669,10 +677,13 @@ function SpreadCat() {
     const fps = quality === "low" ? 8 : 12;
     const s = reducedMotion ? 0 : stepTime(clock.elapsedTime, fps);
     const p = clamp01((t - CAT_DRIFT[0]) / (CAT_DRIFT[1] - CAT_DRIFT[0]));
-    // weightless drift, pure f(t); gentle stepped bob + sway on 2s
+    // weightless drift, pure f(t); gentle stepped bob + sway on 2s. The arc
+    // rides 2.2 above the old line so the cat clears the constellation label
+    // band (label tops reach y 4.4) instead of parking on a name -- it used
+    // to sit on THE RAIN for the whole chart approach (audit 2026-07-27).
     g.position.set(
       lerp(-16, 12, p),
-      4.0 + 0.5 * Math.sin(Math.PI * p) + (reducedMotion ? 0 : 0.1 * Math.sin(s * 1.3)),
+      6.2 + 0.5 * Math.sin(Math.PI * p) + (reducedMotion ? 0 : 0.1 * Math.sin(s * 1.3)),
       -15,
     );
     g.rotation.z = reducedMotion ? 0 : 0.08 * Math.sin(s * 0.9);

--- a/issues/10-spread/Spread.tsx
+++ b/issues/10-spread/Spread.tsx
@@ -299,6 +299,11 @@ LABELS.forEach((text, i) => {
   CONST_LABELS.push({ text, x: cx, y: cy - 3.1, z: cz });
 });
 
+/** label z-bias off the star plane: clears its own cluster (cz +/-1), the
+ * chart lines and the near krackle dots that drift around the constellation,
+ * without moving the label perceptibly (labels sit ~40 units out). */
+const LABEL_Z = 1.6;
+
 const LINE_POS = new Float32Array(linePos);
 
 function Constellations() {
@@ -355,18 +360,18 @@ function Constellations() {
         </bufferGeometry>
         <lineBasicMaterial color={VIOLET} transparent opacity={0.38} />
       </lineSegments>
-      {/* labels print ON TOP of the field: a foreground krackle dot or the
-          drifting cat must never sit on a letter (S2.16 readable content,
-          audit 2026-07-27) */}
+      {/* labels sit LABEL_Z in front of their own cluster instead of turning
+          depthTest off: an unconditional overlay printed them over the closing
+          caption and the chart, which inverts S2.16 (PR #55 M1). depthWrite is
+          off so the fading label never punches a hole in the spread behind it. */}
       {CONST_LABELS.map((l, i) => (
         <Text
           key={l.text}
           ref={(el) => {
             labels.current[i] = el as unknown as Mesh | null;
           }}
-          material-depthTest={false}
-          renderOrder={3}
-          position={[l.x, l.y, l.z]}
+          material-depthWrite={false}
+          position={[l.x, l.y, l.z + LABEL_Z]}
           font={BANGERS}
           fontSize={1.15}
           color={INK}

--- a/issues/11-terminal/Terminal.tsx
+++ b/issues/11-terminal/Terminal.tsx
@@ -768,10 +768,18 @@ function BackCoverPage() {
 
 const [TCX] = issueCenter(11);
 
-/** first fraction of the catWalk range = the hop-down; the walk plate owns
- * the rest. Sit visible u < HOP, walk u >= HOP: NO frame without a cat
- * (continuity fix, user feedback 2026-07-03). All pure f(t), scrub-safe. */
-const CAT_HOP = 0.22;
+/** Exit shape over the catWalk range, all pure f(t), scrub-safe. The hop
+ * ARC lands by CAT_ARC and the sit build then rests ON the floor until
+ * CAT_HOP hands over to the walk plate at the same spot -- the arc used to
+ * run right up to the handover, so the cat's last sit frame was mid-air and
+ * the swap read as a pop (audit 2026-07-27). The plate walks to CAT_PARK and
+ * then holds, staying in frame through t=1.000: the closing frame of the
+ * whole book keeps its cat. */
+const CAT_ARC = 0.28;
+const CAT_HOP = 0.5;
+const CAT_PARK = 0.95;
+/** plate's parked x -- right of the command-card wall, on the lit floor */
+const CAT_PARK_X = 9.5;
 /** sit perch on the CRT top (shots 1-2, on/near the monitor throughout) */
 const SIT_FROM: [number, number, number] = [1.9, 6.25, 0.4];
 /** floor landing IN FRONT of the desk edge (z 3.5) and LEFT of the command
@@ -799,7 +807,7 @@ function TerminalCat() {
   useFrame(({ clock }) => {
     const { t, quality, reducedMotion } = useScrollStore.getState();
     const u = catWalk(t); // pure f(t), scrub-safe both directions
-    const k = u <= 0 ? 0 : Math.min(u / CAT_HOP, 1); // hop progress
+    const k = u <= 0 ? 0 : Math.min(u / CAT_ARC, 1); // hop-arc progress
     const sitting = u < CAT_HOP;
     const s = sit.current;
     if (s) {
@@ -825,14 +833,18 @@ function TerminalCat() {
     }
     const g = walk.current;
     if (g) {
-      // takes over EXACTLY at the hop landing, walks the floor frame-right
-      // past the page edge (u=1: off-panel, the journey's last exit)
-      g.visible = u >= CAT_HOP && u < 1;
-      g.position.x = lerp(SIT_LAND[0], 16.5, clamp01((u - CAT_HOP) / (1 - CAT_HOP)));
+      // takes over EXACTLY where the hop landed, walks the floor frame-right
+      // and settles at CAT_PARK_X -- no upper bound, so the plate is still
+      // there at t=1.000 (the last frame used to lose the cat entirely)
+      const stride = clamp01((u - CAT_HOP) / (CAT_PARK - CAT_HOP));
+      g.visible = u >= CAT_HOP;
+      g.position.x = lerp(SIT_LAND[0], CAT_PARK_X, stride);
       const fps = quality === "low" ? 8 : 12;
-      // stride bob is ambient life -- dropped under reduced motion
+      // stride bob is ambient life -- dropped under reduced motion, and it
+      // stops with the walk so the parked plate rests dead still
+      const bob = reducedMotion ? 0 : 1 - stride;
       g.position.y =
-        -0.12 + (reducedMotion ? 0 : 0.09 * Math.abs(Math.sin(stepTime(clock.elapsedTime, fps) * 6)));
+        -0.12 + bob * 0.09 * Math.abs(Math.sin(stepTime(clock.elapsedTime, fps) * 6));
     }
   });
 
@@ -883,12 +895,17 @@ function DeskSet() {
         <boxGeometry args={[4.2, 0.3, 2.6]} />
         <meshToonMaterial color={CASE} gradientMap={ramp} />
       </mesh>
-      {/* power LED + blank amber sticky note (accents, S0.4 row 11) */}
+      {/* power LED + blank amber sticky note (accents, S0.4 row 11). The
+          note lives on the case CHIN, below the glass: stuck on the bezel it
+          sat coplanar with the screen plane (z 1.77), hatching a sliver
+          inside the tube and covering the "h" of hello visitor (audit
+          2026-07-27). z 1.79 is in front of the case face -- nothing to
+          intersect, nothing to z-fight. */}
       <mesh position={[2.7, 1.05, 1.79]}>
         <circleGeometry args={[0.09, 16]} />
         <meshBasicMaterial color={AMBER} />
       </mesh>
-      <mesh position={[-2.9, 4.9, 1.77]} rotation={[0, 0, 0.12]}>
+      <mesh position={[-2.9, 0.44, 1.79]} rotation={[0, 0, 0.06]}>
         <planeGeometry args={[0.85, 0.85]} />
         <meshBasicMaterial color={AMBER} />
       </mesh>

--- a/issues/11-terminal/shots.ts
+++ b/issues/11-terminal/shots.ts
@@ -249,6 +249,14 @@ registerJawDrop({
 });
 
 // ---- cat walk-off (pure f(t), scrub-safe -- S5b.1 guide exit) ---------------
-export const CAT_WALK_RANGE: [number, number] = [at(0.72), at(0.97)];
+/**
+ * Starts at 0.84, not 0.72: the floor in front of the desk only enters frame
+ * about halfway through the pullback, so the old window dropped the cat off
+ * the CRT into dead space below the frame edge (audit 2026-07-27). The cat
+ * now holds the monitor perch through the reveal and exits inside the wide
+ * frame -- and the walk plate parks in frame instead of leaving t=1.000
+ * catless (see TerminalCat).
+ */
+export const CAT_WALK_RANGE: [number, number] = [at(0.84), at(0.97)];
 export const catWalk = (t: number) =>
   clamp01((t - CAT_WALK_RANGE[0]) / (CAT_WALK_RANGE[1] - CAT_WALK_RANGE[0]));

--- a/issues/11-terminal/shots.ts
+++ b/issues/11-terminal/shots.ts
@@ -250,13 +250,13 @@ registerJawDrop({
 
 // ---- cat walk-off (pure f(t), scrub-safe -- S5b.1 guide exit) ---------------
 /**
- * Starts at 0.84, not 0.72: the floor in front of the desk only enters frame
- * about halfway through the pullback, so the old window dropped the cat off
- * the CRT into dead space below the frame edge (audit 2026-07-27). The cat
- * now holds the monitor perch through the reveal and exits inside the wide
- * frame -- and the walk plate parks in frame instead of leaving t=1.000
- * catless (see TerminalCat).
+ * Starts at 0.78, not 0.72: the floor in front of the desk only enters frame
+ * partway through the pullback, so the original window dropped the cat off the
+ * CRT into dead space below the frame edge (audit 2026-07-27). 0.84 fixed that
+ * but crammed hop + land + walk + park into 0.0078 of t; 0.78 is the earliest
+ * start that still lands the hop on visible floor (PR #55 L1), and the walk
+ * plate still parks in frame so t=1.000 keeps its cat (see TerminalCat).
  */
-export const CAT_WALK_RANGE: [number, number] = [at(0.84), at(0.97)];
+export const CAT_WALK_RANGE: [number, number] = [at(0.78), at(0.97)];
 export const catWalk = (t: number) =>
   clamp01((t - CAT_WALK_RANGE[0]) / (CAT_WALK_RANGE[1] - CAT_WALK_RANGE[0]));

--- a/lib/authoredCamera.ts
+++ b/lib/authoredCamera.ts
@@ -1,0 +1,37 @@
+import { PerspectiveCamera } from "three";
+import { evaluateTimeline } from "./shots";
+import { SEGMENTS } from "@/issues/registry";
+
+/**
+ * The AUTHORED camera for a scroll position -- evaluateTimeline's raw pose,
+ * with NO delta smoothing and NO pointer parallax (ShotDirector adds both to
+ * the live camera, which makes the live view a function of scroll history and
+ * of the mouse). Scene guards that gate READABLE lettering on framing must
+ * project through this camera instead, so the fade stays a pure function of t:
+ * identical from either scrub direction and immune to pointer movement
+ * (S2.16 / audit 2026-07-27).
+ *
+ * Module scope, cached per (t, aspect): all callers in a frame share one
+ * rebuild and it allocates nothing. near/far mirror the Canvas camera
+ * (components/Experience.tsx) so the far-plane reject agrees with the render.
+ */
+const cam = new PerspectiveCamera(45, 1, 0.1, 400);
+let lastT = NaN;
+let lastAspect = NaN;
+
+export function authoredCamera(t: number, aspect: number): PerspectiveCamera {
+  if (t === lastT && aspect === lastAspect) return cam;
+  lastT = t;
+  lastAspect = aspect;
+  const { pose } = evaluateTimeline(t, SEGMENTS);
+  cam.fov = pose.fov ?? 45;
+  cam.aspect = aspect;
+  cam.updateProjectionMatrix();
+  cam.position.set(pose.position[0], pose.position[1], pose.position[2]);
+  cam.lookAt(pose.target[0], pose.target[1], pose.target[2]);
+  if (pose.roll) cam.rotateZ(pose.roll);
+  // Camera.updateMatrixWorld also refreshes matrixWorldInverse -- what
+  // Vector3.project() reads
+  cam.updateMatrixWorld(true);
+  return cam;
+}


### PR DESCRIPTION
## What

The per-scene remainder of the 2026-07-27 frame-by-frame audit — 20 defects across Cover, Noir, Origin, Terminal, Pop, Sketchbook, and Spread. Two builders, every fix screenshot-verified at its audited t window (details in the commit).

Highlights:
- **Cover**: the DOM tagline/attract overlay now fades before the separating 3D price box can collide with it (glyph-on-glyph at t≈0.012–0.023 is gone)
- **Origin**: the portal "robot" is a connected figure instead of four floating primitives; the issue-4 title card no longer prints on the page header; the closing beat has its caption in frame
- **Terminal**: the golden cat exits by arcing down to the floor and handing over to the cameo poster (no more mid-air vanish at t≈0.986), and the poster survives through t=1.0 — the site's final frame keeps the every-issue cat
- **Pop**: chat balloons live on three fixed wall anchors with a viewport frame-guard (no more mutual clipping/desk occlusion/edge truncation), the donation card fades single-layer on an opaque backing, and its rear view is a card back instead of mirrored text
- **Sketchbook**: the front-facing sketch cat has a lower body again (was a legless bust cut by the page plane); captions sit on clean page

## Deliberately not "fixed"

- Neon entry caption at t=0.228: measured DOM shows the plate is already 13px wider than the text per side — the artifact is the whole card at 62% opacity mid-fade, i.e. a transient any fade has. Left as designed.
- The green cursor star on the Spread panel gutter is the dot-match exit anchor and must stay dead-center.

`npm run typecheck` clean; all files pure ASCII; no copy strings touched.

Part of the audit fix series (5/5), after #51 #52 #53 #54. A full-timeline re-audit against the original defect ledger runs next and will be posted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)