### PR TITLE
iPad: size the stage to the visible viewport, not the toolbar-hidden one

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -7,6 +7,45 @@ body {
   background: #f2ead9;
 }
 
+/*
+ * The WebGL stage, shared by the canvas and every full-screen overlay that has
+ * to stay registered with it. NOT `inset: 0`.
+ *
+ * On iOS the layout viewport a fixed element resolves against is the LARGE
+ * viewport -- the one with the browser toolbar hidden. Measured on an iPad Pro
+ * 11 in Chrome, that toolbar is 168 CSS px: the screen is 834 tall but
+ * innerHeight is 666. So `inset: 0` sized the stage a quarter taller than what
+ * was on screen, and the bottom of every scene sat below the fold until the
+ * user scrolled far enough to collapse the toolbar.
+ *
+ * `dvh` tracks the visible height, so the scene always fills exactly what is
+ * there. `svh` would also stop the clipping, but at 168 px it would leave a
+ * quarter of the screen as dead paper whenever the toolbar hid -- which is
+ * most of the time while scrolling down.
+ *
+ * The cost of dvh is that the canvas resizes when the toolbar animates, which
+ * reallocates the live render targets. That is handled where it belongs, by
+ * debouncing R3F's resize observer (see Experience.tsx) rather than by picking
+ * a worse height.
+ */
+.stage {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100vh;
+}
+/*
+ * @supports, not a second `height` in the rule above: the CSS minifier dedupes
+ * duplicate properties, which drops the fallback and leaves a browser without
+ * dvh with no height at all -- a collapsed stage and a blank canvas.
+ */
+@supports (height: 100dvh) {
+  .stage {
+    height: 100dvh;
+  }
+}
+
 /* Lenis recommended styles */
 html.lenis,
 html.lenis body {

--- a/components/Experience.tsx
+++ b/components/Experience.tsx
@@ -15,9 +15,14 @@ import { useScrollStore } from "@/lib/scrollStore";
 export default function Experience() {
   const quality = useScrollStore((s) => s.quality);
   return (
-    <div className="fixed inset-0" aria-hidden>
+    <div className="stage" aria-hidden>
       <Canvas
         frameloop="always"
+        // The stage is sized in dvh, so the mobile toolbar collapsing resizes
+        // the canvas mid-scroll and reallocates every live render target.
+        // Debounced so one toolbar animation costs one reallocation at the end
+        // rather than one per frame of it.
+        resize={{ debounce: 200 }}
         dpr={quality === "high" ? [1, 2] : [1, 1.5]}
         gl={{ antialias: false, stencil: false, depth: true, powerPreference: "high-performance" }}
         camera={{ fov: 45, near: 0.1, far: 400, position: [0, 2, 10] }}

--- a/components/JumpCover.tsx
+++ b/components/JumpCover.tsx
@@ -41,9 +41,8 @@ export default function JumpCover() {
     <div
       ref={el}
       aria-hidden
+      className="stage"
       style={{
-        position: "fixed",
-        inset: 0,
         zIndex: 30, // above the canvas and Lettering (z-20)
         opacity: 0,
         pointerEvents: "none",

--- a/components/Lettering.tsx
+++ b/components/Lettering.tsx
@@ -221,8 +221,11 @@ export default function Lettering() {
     return () => cancelAnimationFrame(raf);
   }, []);
 
+  // `stage`, not `inset-0`: the lettering is composed against the canvas and
+  // must share its exact box, or the two drift apart by the toolbar height on
+  // iOS.
   return (
-    <div className="pointer-events-none fixed inset-0 z-20 select-none" aria-hidden>
+    <div className="stage pointer-events-none z-20 select-none" aria-hidden>
       {/* premise chip -- cover segment only, top-center ABOVE the cover art.
           Solid INK chip (legible over anything), opacity via the shared
           cover window in the rAF loop (no breathe/transform). */}

--- a/components/PressCta.tsx
+++ b/components/PressCta.tsx
@@ -60,7 +60,9 @@ export default function PressCta() {
       }}
       className="fixed left-1/2 z-30"
       style={{
-        bottom: "9vh",
+        // dvh, not vh: vh is the LARGE viewport on iOS, so a vh offset is
+        // measured against a box 168 px taller than what is on screen.
+        bottom: "9dvh",
         opacity: 0,
         visibility: "hidden",
         pointerEvents: "none",

--- a/lib/device.ts
+++ b/lib/device.ts
@@ -31,7 +31,7 @@ const MIN_WIDTH = 820;
  * The short side separates the two classes with a wide margin and needs no
  * per-device list.
  *
- * The threshold sits at 560 rather than something nearer the raw device sizes
+ * The threshold sits at 500 rather than something nearer the raw device sizes
  * because this is measured against innerWidth/innerHeight, which EXCLUDE the
  * browser's tab bar and toolbar. In landscape the short side is innerHeight, so
  * an iPad mini's 744 screen height arrives here as roughly 664. Meanwhile a
@@ -44,7 +44,7 @@ const MIN_WIDTH = 820;
  * but would also not shrink in iPad Split View, so every pane would read as a
  * full tablet and get the cropped compositions the 390px audit rejected.
  */
-const MIN_SHORT_SIDE = 560;
+const MIN_SHORT_SIDE = 500;
 
 /**
  * Width floor for coarse devices, on top of the short side. The short side


### PR DESCRIPTION
Fixes the bug reported from a real iPad Pro 11 in Chrome: **the scene was cut off at the bottom** and only came fully into view after scrolling far enough to collapse the browser toolbar.

## Cause, measured on the device

The stage was `fixed inset-0`, and on iOS a fixed element resolves against the **large** viewport - the one with the toolbar hidden.

| | landscape | portrait |
|---|---|---|
| `screen` | 834 x 1194 | 834 x 1194 |
| `innerWidth x innerHeight` | 1194 x **666** | 834 x **1026** |
| chrome taken | **168 px** | **168 px** |

So the stage was sized a quarter taller than what was on screen, and the bottom quarter of every scene sat below the fold until the toolbar collapsed.

## Fix: `dvh`, not `svh`

`svh` would also stop the clipping, but at 168 px it leaves a **quarter of the screen as dead paper** whenever the toolbar hides - which is most of the time while scrolling down. `dvh` tracks the visible height so the scene always fills exactly what is there.

The cost of `dvh` is that the canvas resizes as the toolbar animates, reallocating the live render targets. That is handled where it belongs - `resize={{ debounce: 200 }}` on the Canvas, so one toolbar animation costs one reallocation at the end rather than one per frame of it.

**The fallback is in `@supports`, deliberately.** A second `height` in the same rule gets deduped by the minifier, which drops it and leaves a browser without `dvh` with *no height at all* - a collapsed stage and a blank canvas. Verified both survive the build:

```css
.stage{width:100%;height:100vh;position:fixed;top:0;left:0}
@supports (height:100dvh){.stage{height:100dvh}}
```

`Lettering` and `JumpCover` share the same box. Lettering especially - it is composed against the canvas and would otherwise drift from it by exactly the toolbar height.

## `MIN_SHORT_SIDE` 560 -> 500

The same measurement invalidates the number set in #56. Real chrome is **168 px, not the ~80 assumed** - at 560 an iPad mini in landscape (744 - 168 = 576) cleared by only 16 px, and at the 700 this branch briefly carried, **this very iPad would have been thrown into Print Edition in landscape** (666 < 700).

500 centres the band: phones cap at 440 on the short side and chrome only lowers that; tablets bottom out near 576.

Re-verified against the measured viewports:

| device | viewport | result |
|---|---|---|
| **iPad Pro 11 landscape** | **1194x666 (measured)** | **3D** |
| **iPad Pro 11 portrait** | **834x1026 (measured)** | **3D** |
| iPad mini landscape | 1133x576 | 3D |
| iPad mini portrait | 744x965 | 3D |
| iPhone 16 Pro Max landscape | 956x272 | Print |
| iPhone 16 Pro Max portrait | 440x744 | Print |
| Split View 11" half | 570x586 | Print |

`PressCta`'s offset moves from `vh` to `dvh` for the same reason. `AudioToggle` is left alone - modern iOS already keeps bottom-fixed elements above the toolbar, and nothing reported otherwise, so changing it would have been speculative.

## Verification

`npm run typecheck` and `npm run build` pass; source is pure ASCII; both CSS rules confirmed present in the built output. Still needs a look on the device once deployed.

Generated with [Claude Code](https://claude.com/claude-code)