### PR TITLE
Six-bus mix and per-scene convolution rooms

### DIFF
--- a/lib/audio/buses.ts
+++ b/lib/audio/buses.ts
@@ -16,7 +16,8 @@ import type { ToneModule } from "./types";
  *   ui     ------------------ uiOut ---------+
  *   sub    --> subLp(120) --> subComp -> ... +
  *
- *   sends: duckGain, foleyOut, hardOut --> roomIn   (ui and sub never)
+ *   sends: duckGain (BOTH beds), foleyOut, hardOut --> roomIn
+ *          ui and sub never reach the room at all
  *
  * WHY pulseBus EXISTS -- do not "simplify" it away. director.ts writes
  * fx.audioPulse from this meter, and PostPipeline reads it into uAudioPulse to
@@ -53,15 +54,18 @@ export interface Buses {
   roomIn: Gain;
 }
 
-/** Room send per bus, as a linear gain. */
-const SEND: Record<BusName, number> = {
-  music: 0.1,
-  ambience: 0.16,
-  foley: 0.22,
-  hardfx: 0.28,
-  ui: 0,
-  sub: 0,
-};
+/**
+ * Room send per bus, as a linear gain.
+ *
+ * There is deliberately NO `ambience` entry. music and ambience merge into
+ * duckGain before the send is tapped, so a separate ambience value would be
+ * dead weight -- ambience already reaches the room through the bed send. Giving
+ * it its own send while keeping that send POST-duck (so the room tail ducks
+ * with the bed, behaviour worth preserving) would need a second duck node
+ * automated in lockstep, which is not worth building while the ambience bus
+ * still has zero sources. Revisit when Phase 4 re-homes room tones onto it.
+ */
+const SEND = { bed: 0.1, foley: 0.22, hardfx: 0.28 } as const;
 
 export function buildBuses(T: ToneModule): Buses {
   // Master chain, unchanged from the shipped one: same EQ3, same compressor,
@@ -109,7 +113,7 @@ export function buildBuses(T: ToneModule): Buses {
   // Sends. Music feeds the room POST-duck so the tail ducks with the bed,
   // which is the behaviour the shipped graph had and is worth keeping.
   const roomIn = new T.Gain(1);
-  duckGain.connect(new T.Gain(SEND.music).connect(roomIn));
+  duckGain.connect(new T.Gain(SEND.bed).connect(roomIn));
   foleyOut.connect(new T.Gain(SEND.foley).connect(roomIn));
   hardOut.connect(new T.Gain(SEND.hardfx).connect(roomIn));
 

--- a/lib/audio/buses.ts
+++ b/lib/audio/buses.ts
@@ -1,0 +1,124 @@
+import type { Gain, Meter, ToneAudioNode } from "tone";
+import type { ToneModule } from "./types";
+
+/**
+ * The mix graph. Replaces the single music/sfx split with six named buses, so
+ * a slam, a room tone and a button click stop sharing one compressor and one
+ * reverb send.
+ *
+ *   beds ------> music ----+---> pulseBus ---> meter      (TAP ONLY, no output)
+ *   room tone -> ambience -+
+ *                music ----+---> duckGain ---+
+ *                ambience -+                 |
+ *                                            +--> mixIn --> EQ3 --> comp
+ *   foley  --> foleyComp --> foleyOut -------+                   --> limiter
+ *   hardfx --> hardComp  --> hardOut --------+                   --> destination
+ *   ui     ------------------ uiOut ---------+
+ *   sub    --> subLp(120) --> subComp -> ... +
+ *
+ *   sends: duckGain, foleyOut, hardOut --> roomIn   (ui and sub never)
+ *
+ * WHY pulseBus EXISTS -- do not "simplify" it away. director.ts writes
+ * fx.audioPulse from this meter, and PostPipeline reads it into uAudioPulse to
+ * breathe the halftone dots. The old graph metered `music` PRE-duck on purpose:
+ * "a duck must not move a visual". Splitting the beds across two buses would
+ * otherwise show the analyser only half the bed energy, so pulseBus sums music
+ * and ambience back together and feeds the meter alone. Same total, still
+ * pre-duck, still excluding every sfx bus, so the visual is unchanged by
+ * construction.
+ *
+ * `ui` gets no room send: interface sound has to stay legible when the room is
+ * a subway tunnel. `sub` gets none either -- reverberating a sub only smears it.
+ */
+
+export type BusName = "music" | "ambience" | "foley" | "hardfx" | "ui" | "sub";
+
+export interface Buses {
+  T: ToneModule;
+  /** the single fade node: enable ramps it to 1, disable to 0 */
+  out: Gain;
+
+  /**
+   * Bus INPUTS, keyed by name. Callers only ever connect to these; whether a
+   * compressor or a filter sits in front is an implementation detail, which is
+   * why these are ToneAudioNode rather than Gain.
+   */
+  in: Readonly<Record<BusName, ToneAudioNode>>;
+
+  /** ducked node music+ambience pass through; the beat sidechain rides here */
+  duckGain: Gain;
+  /** metering tap -- summed pre-duck, connected to nothing downstream */
+  meter: Meter;
+  /** convolution room input; rooms.ts owns everything past it */
+  roomIn: Gain;
+}
+
+/** Room send per bus, as a linear gain. */
+const SEND: Record<BusName, number> = {
+  music: 0.1,
+  ambience: 0.16,
+  foley: 0.22,
+  hardfx: 0.28,
+  ui: 0,
+  sub: 0,
+};
+
+export function buildBuses(T: ToneModule): Buses {
+  // Master chain, unchanged from the shipped one: same EQ3, same compressor,
+  // same limiter, same -9 dB ceiling, same single fade node.
+  const eq = new T.EQ3({ low: 0, mid: 0, high: -3 });
+  const comp = new T.Compressor({ threshold: -18, ratio: 3 });
+  const limiter = new T.Limiter(-1);
+  const out = new T.Gain(0);
+  const mixIn = new T.Gain(1).connect(out);
+  out.chain(eq, comp, limiter, T.getDestination());
+  T.getDestination().volume.value = -9;
+
+  const duckGain = new T.Gain(1).connect(mixIn);
+
+  const music = new T.Gain(1).connect(duckGain);
+  const ambience = new T.Gain(0.9).connect(duckGain);
+
+  // Metering tap: sums BOTH bed buses, pre-duck, and goes nowhere else.
+  const pulseBus = new T.Gain(1);
+  const meter = new T.Meter({ smoothing: 0.9, normalRange: true });
+  music.connect(pulseBus);
+  ambience.connect(pulseBus);
+  pulseBus.connect(meter);
+
+  // Percussive buses get their own compression so a slam stops squashing a
+  // button click. Attacks stay fast enough not to eat the transients this
+  // whole rebuild exists to create.
+  const foleyIn = new T.Compressor({ threshold: -20, ratio: 3, attack: 0.003, release: 0.12 });
+  const foleyOut = new T.Gain(0.8).connect(mixIn);
+  foleyIn.connect(foleyOut);
+
+  const hardIn = new T.Compressor({ threshold: -14, ratio: 4, attack: 0.001, release: 0.2 });
+  const hardOut = new T.Gain(1).connect(mixIn);
+  hardIn.connect(hardOut);
+
+  const uiOut = new T.Gain(0.7).connect(mixIn);
+
+  // Sub is band-limited so an impact's weight cannot leak into the mids, and
+  // sits behind its own compressor so it can never pump the master.
+  const subIn = new T.Filter(120, "lowpass");
+  const subComp = new T.Compressor({ threshold: -18, ratio: 6, attack: 0.005, release: 0.15 });
+  const subOut = new T.Gain(0.7).connect(mixIn);
+  subIn.chain(subComp, subOut);
+
+  // Sends. Music feeds the room POST-duck so the tail ducks with the bed,
+  // which is the behaviour the shipped graph had and is worth keeping.
+  const roomIn = new T.Gain(1);
+  duckGain.connect(new T.Gain(SEND.music).connect(roomIn));
+  foleyOut.connect(new T.Gain(SEND.foley).connect(roomIn));
+  hardOut.connect(new T.Gain(SEND.hardfx).connect(roomIn));
+
+  return {
+    T,
+    out,
+    in: { music, ambience, foley: foleyIn, hardfx: hardIn, ui: uiOut, sub: subIn },
+    duckGain,
+    meter,
+    roomIn,
+  };
+}

--- a/lib/audio/buses.ts
+++ b/lib/audio/buses.ts
@@ -16,7 +16,7 @@ import type { ToneModule } from "./types";
  *   ui     ------------------ uiOut ---------+
  *   sub    --> subLp(120) --> subComp -> ... +
  *
- *   sends: duckGain (BOTH beds), foleyOut, hardOut --> roomIn
+ *   sends: duckGain (BOTH beds), foleyOut, hardOut --> roomIn --> HP 250
  *          ui and sub never reach the room at all
  *
  * WHY pulseBus EXISTS -- do not "simplify" it away. director.ts writes
@@ -50,8 +50,10 @@ export interface Buses {
   duckGain: Gain;
   /** metering tap -- summed pre-duck, connected to nothing downstream */
   meter: Meter;
-  /** convolution room input; rooms.ts owns everything past it */
+  /** convolution room send input */
   roomIn: Gain;
+  /** post-highpass node the room actually taps; rooms.ts owns everything past it */
+  roomOut: ToneAudioNode;
 }
 
 /**
@@ -112,7 +114,13 @@ export function buildBuses(T: ToneModule): Buses {
 
   // Sends. Music feeds the room POST-duck so the tail ducks with the bed,
   // which is the behaviour the shipped graph had and is worth keeping.
-  const roomIn = new T.Gain(1);
+  // 250 Hz highpass in front of the room, as main had. LF buildup in a reverb
+  // send is the classic mud mechanism, and it compounds here: bandDecay[0] runs
+  // to 1.5 on spread and 1.4 on origin, so the longest rooms hold low-frequency
+  // energy for four to five seconds. The lowpass band inside ir.ts is a band OF
+  // the IR -- it keeps lows in the tail, it does not keep them out of the send.
+  const roomHp = new T.Filter(250, "highpass");
+  const roomIn = new T.Gain(1).connect(roomHp);
   duckGain.connect(new T.Gain(SEND.bed).connect(roomIn));
   foleyOut.connect(new T.Gain(SEND.foley).connect(roomIn));
   hardOut.connect(new T.Gain(SEND.hardfx).connect(roomIn));
@@ -120,6 +128,7 @@ export function buildBuses(T: ToneModule): Buses {
   return {
     T,
     out,
+    roomOut: roomHp,
     in: { music, ambience, foley: foleyIn, hardfx: hardIn, ui: uiOut, sub: subIn },
     duckGain,
     meter,

--- a/lib/audio/director.ts
+++ b/lib/audio/director.ts
@@ -1,10 +1,12 @@
-import type { EQ3, Filter, Gain, MembraneSynth, Meter, Reverb, Synth } from "tone";
+import type { Gain, MembraneSynth, Meter, Synth } from "tone";
 import { useScrollStore } from "@/lib/scrollStore";
 import { fx } from "@/lib/fx";
 import { setBeatSound } from "@/lib/beats";
 import { clamp01 } from "@/lib/shots";
 import { RANGES } from "@/issues/timeline";
 import { audioRecipes, type AudioRecipe, type ToneModule } from "./types";
+import { buildBuses, type Buses } from "./buses";
+import { buildRooms, updateRooms } from "./rooms";
 import { scoreTransitions, stopTransitions } from "./transitions";
 import { scoreMoments, beatMoment, stopMoments } from "./moments";
 import { wireUi, uiSound } from "./ui";
@@ -17,11 +19,9 @@ import "./recipes"; // Wave B: fills the audioRecipes slots (side effect)
  * first enable so it never rides the server/initial bundle. Every Tone call
  * is wrapped: failure degrades to silence with a single console.warn.
  *
- * Chain: per-issue crossfade gains -> music bus \
- *                                                out gain -> EQ3(high -3) ->
- *        one-shots (thump/chime/meow) -> sfx bus /  Compressor -> Limiter(-1)
- *        -> destination (ceiling -9 dB). Both buses also SEND to a shared
- *        highpass -> Reverb whose return sums back into out (dry paths intact).
+ * The mix graph lives in buses.ts (six named buses -> one master chain) and
+ * the per-scene convolution rooms in rooms.ts. This file owns lifecycle and
+ * the frame loop only.
  *
  * Beat sounds ride lib/beats.ts setBeatSound, which only fires from
  * BeatRunner crossings -- reduced motion already suppresses those, so the
@@ -30,14 +30,10 @@ import "./recipes"; // Wave B: fills the audioRecipes slots (side effect)
 
 interface Master {
   T: ToneModule;
+  B: Buses;
+  /** the single fade node; enable ramps it to 1, disable to 0 */
   out: Gain;
-  eq: EQ3;
-  verbSend: Gain;
-  verbHp: Filter;
-  verb: Reverb;
-  music: Gain;
   duckGain: Gain;
-  sfx: Gain;
   meter: Meter;
   thump: MembraneSynth;
   chime: Synth;
@@ -143,49 +139,23 @@ export function disableAudio(): void {
 }
 
 function buildMaster(T: ToneModule): Master {
-  const eq = new T.EQ3({ low: 0, mid: 0, high: -3 }); // head: tame brittle square highs
-  const comp = new T.Compressor({ threshold: -18, ratio: 3 });
-  const limiter = new T.Limiter(-1);
-  const out = new T.Gain(0);
-  out.chain(eq, comp, limiter, T.getDestination());
-  T.getDestination().volume.value = -9; // master ceiling
-
-  // duckGain sits between music and out so the sidechain duck rides HERE, not
-  // on music.gain: the meter taps music PRE-duck, so ducking never pumps
-  // fx.audioPulse (the halftone-breathe shader) -- a duck must not move a visual.
-  const duckGain = new T.Gain(1).connect(out);
-  const music = new T.Gain(1).connect(duckGain);
-  const sfx = new T.Gain(1).connect(out);
-  const meter = new T.Meter({ smoothing: 0.9, normalRange: true });
-  music.connect(meter); // pre-duck tap: visual meter stays clean
-
-  // Shared reverb SEND (not insert): both buses also feed a common send whose
-  // return sums back into `out`; the dry music/sfx -> out paths are untouched.
-  // Music feeds the send POST-duck (from duckGain) so the reverb tail ducks
-  // with the bed; sfx feeds it dry. Send gain rides at 0 until the async IR
-  // generates, then eases to 0.18; if generation fails we warn and stay fully
-  // dry (mix unaffected either way).
-  const verbSend = new T.Gain(0);
-  duckGain.connect(verbSend);
-  sfx.connect(verbSend);
-  const verbHp = new T.Filter(250, "highpass");
-  const verb = new T.Reverb({ decay: 2.2, preDelay: 0.02, wet: 1 });
-  verbSend.chain(verbHp, verb, out);
-  void verb.ready.then(() => verbSend.gain.rampTo(0.18, 0.5)).catch(warn);
+  const B = buildBuses(T);
+  buildRooms(B);
 
   const thump = new T.MembraneSynth({
     pitchDecay: 0.08,
     octaves: 5,
     envelope: { attack: 0.002, decay: 0.4, sustain: 0, release: 0.1 },
     volume: -6,
-  }).connect(sfx);
+  }).connect(B.in.hardfx);
   const chime = new T.Synth({
     oscillator: { type: "fattriangle", count: 3, spread: 14 },
     envelope: { attack: 0.02, decay: 0.25, sustain: 0, release: 0.3 },
     volume: -18,
-  }).connect(sfx);
+  }).connect(B.in.ui);
+
   channels = audioRecipes.map(() => null);
-  return { T, out, eq, verbSend, verbHp, verb, music, duckGain, sfx, meter, thump, chime };
+  return { T, B, out: B.out, duckGain: B.duckGain, meter: B.meter, thump, chime };
 }
 
 /** One-time subscriptions (survive disable; guarded by `enabled`). */
@@ -232,7 +202,7 @@ function wire(): void {
   });
   // package C (ui) installs the meow-variety + jump-land subscriptions on the
   // sfx bus; both inherit the gesture gate (mod set here, post-enable).
-  wireUi(m0.T, m0.sfx);
+  wireUi(m0.T, m0.B.in.ui);
 }
 
 /** 1 inside the issue's range, linear falloff to 0 across FALLOFF outside. */
@@ -267,7 +237,7 @@ function loop(now: number): void {
       if (Math.abs(i - activeIssue) <= 1) {
         if (!ch) {
           // lazy build on first entry into the active window
-          const gain = new m.T.Gain(0).connect(m.music);
+          const gain = new m.T.Gain(0).connect(m.B.in.music);
           recipe.build(m.T).connect(gain);
           ch = { recipe, gain, started: false, lastG: 0 };
           channels[i] = ch;
@@ -287,9 +257,11 @@ function loop(now: number): void {
       }
     }
     // scored transitions: pure f(t, velocity) on the sfx bus (single call site)
-    scoreTransitions(m.T, m.sfx, t, dt, velocity);
+    scoreTransitions(m.T, m.B.in.hardfx, t, dt, velocity);
     // scene reactions (package B): diegetic moments, single call site
-    scoreMoments(m.T, m.sfx, t, dt, velocity);
+    scoreMoments(m.T, m.B.in.foley, t, dt, velocity);
+    // per-scene room morph: pure f(t), crossfaded across each gutter
+    updateRooms(t, now);
     // music-bus envelope for the halftone breathe (consumers scale it down)
     const v = m.meter.getValue();
     fx.audioPulse = Math.min(1, Math.max(0, typeof v === "number" ? v : (v[0] ?? 0)));

--- a/lib/audio/ir.ts
+++ b/lib/audio/ir.ts
@@ -31,6 +31,20 @@ export interface RoomSpec {
   seed: number;
 }
 
+/**
+ * Wet level for every room, as an L2 norm.
+ *
+ * 0.53 is the post-normalize L2 a ConvolverNode produces for a ~2.2 s stereo IR
+ * at 48k under the Web Audio normalization algorithm, i.e. what the shipped
+ * Tone.Reverb was actually running at. Matching it keeps the SEND values in
+ * buses.ts reading as ordinary send amounts against a normalised reverb, and
+ * keeps the fallback and Freeverb paths comparable rather than 40 dB apart.
+ *
+ * Net against the shipped mix this is a few dB drier on the beds. Deliberate
+ * starting point, and the first thing to move once these rooms get an ear.
+ */
+const L2_TARGET = 0.53;
+
 /** Crossover points for the three decay bands. */
 const LOW_HZ = 300;
 const MID_HZ = 1600;
@@ -154,10 +168,20 @@ export async function renderIR(spec: RoomSpec, sampleRate: number): Promise<Audi
   //
   // For a stationary input, convolution output power is proportional to
   // sum(h[i]^2), and sum(h^2) = n * rms^2 -- so pinning RMS leaves the wet
-  // level scaling with sqrt(IR length). Across this table that is sqrt(3.27 /
-  // 0.354) = 3.04, nearly +10 dB more wet on the cosmos room than on the
-  // sketchbook, purely from the decay difference. Pinning sum(h^2) instead is
-  // what actually holds the send level constant as decay changes.
+  // level scaling with sqrt(IR length), nearly +10 dB more wet on the 3.27 s
+  // cosmos than the 0.354 s sketchbook. Pinning sum(h^2) is what actually
+  // holds the send level constant as decay changes.
+  //
+  // THE TARGET IS DERIVED, not chosen. For white input the convolution output
+  // RMS gain is exactly ||h||_2, so the target sets the wet level outright.
+  // L2_TARGET is what a ConvolverNode with normalize = true produces for a
+  // mid-length IR, which makes this path directly comparable to any normalised
+  // convolver -- including the Tone.Reverb fallback hanging off the same send.
+  // An earlier value of 18 was calibrated against the old fixed-RMS 0.06 path,
+  // which was never audible: main shipped Tone.Reverb with normalize at its
+  // default of TRUE. That put the wet return at 1.8x the dry bed RMS, roughly
+  // +25 dB hotter than shipped, and left the three reverb paths on this send
+  // 40-45 dB apart.
   let energy = 0;
   for (let c = 0; c < rendered.numberOfChannels; c++) {
     const d = rendered.getChannelData(c);
@@ -167,11 +191,7 @@ export async function renderIR(spec: RoomSpec, sampleRate: number): Promise<Audi
     }
   }
   if (energy > 1e-12) {
-    // 18 is calibrated near the `cover` room, whose L2 under the old fixed-RMS
-    // 0.06 was about that. Relative to the shipped level that is roughly
-    // +4 dB on the sketchbook and -5 dB on the cosmos -- i.e. the ~10 dB of
-    // decay-dependent drift this normalise exists to remove.
-    const g = 18 / Math.sqrt(energy);
+    const g = L2_TARGET / Math.sqrt(energy);
     for (let c = 0; c < rendered.numberOfChannels; c++) {
       const d = rendered.getChannelData(c);
       for (let i = 0; i < d.length; i++) d[i] = d[i]! * g;

--- a/lib/audio/ir.ts
+++ b/lib/audio/ir.ts
@@ -1,4 +1,4 @@
-import { noise01 } from "./util";
+import { mix32, noise01 } from "./util";
 
 /**
  * Impulse response generation. Zero bytes ship: every room is rendered in an
@@ -10,7 +10,10 @@ import { noise01 } from "./util";
  * of every single sound convolved with it.
  *
  * Determinism: the noise is drawn from a seeded avalanche mixer, so a room is
- * byte-identical across sessions and machines. No Math.random (engine law).
+ * identical across sessions ON A GIVEN MACHINE. Not byte-identical ACROSS
+ * machines -- BiquadFilterNode and setValueCurveAtTime are implementation-
+ * defined, and sampleRate is 44.1k or 48k by device. Do not hash this output
+ * in a gate. No Math.random either way (engine law).
  */
 
 export interface RoomSpec {
@@ -41,20 +44,34 @@ const HIGH_HZ = 4000;
  */
 export async function renderIR(spec: RoomSpec, sampleRate: number): Promise<AudioBuffer> {
   const len = Math.max(1, Math.ceil((spec.preDelay + spec.decay) * sampleRate));
-  const ctx = new OfflineAudioContext(2, len, sampleRate);
+  const Ctor =
+    typeof OfflineAudioContext !== "undefined"
+      ? OfflineAudioContext
+      : (globalThis as unknown as { webkitOfflineAudioContext: typeof OfflineAudioContext })
+          .webkitOfflineAudioContext;
+  const ctx = new Ctor(2, len, sampleRate);
 
-  // Deterministic stereo noise. Left and right draw from disjoint streams so
-  // width is a tunable rather than an accident -- and at width 0 they collapse
-  // to the same signal, which is correct for a narrow space like a tunnel.
+  // Deterministic stereo noise.
+  //
+  // Stream starts are SCATTERED through the 2^32 space rather than spaced by
+  // the seed value. Seeds ~100 apart against IRs of 17k-157k samples would make
+  // every room a window onto the same sequence at a ~100-sample lag -- and
+  // since both convolvers share roomIn, a gutter crossfade would then sum two
+  // near-identical noise realisations ~2 ms apart and comb-filter, at exactly
+  // the moment the crossfade exists to serve.
   const noise = ctx.createBuffer(2, len, sampleRate);
-  const rShift = Math.round(spec.width * 1e6);
-  for (let c = 0; c < 2; c++) {
-    const data = noise.getChannelData(c);
-    const base = spec.seed + (c === 1 ? rShift : 0);
-    // noise01, NOT h01: h01 is linear in its argument, so over consecutive
-    // sample indices it degenerates into a sawtooth near 0.38 * rate -- a
-    // whistle rather than a tail. See the note in util.ts.
-    for (let i = 0; i < len; i++) data[i] = noise01(base + i) * 2 - 1;
+  const shared = mix32(spec.seed * 2);
+  const indep = mix32(spec.seed * 2 + 1);
+  const left = noise.getChannelData(0);
+  const right = noise.getChannelData(1);
+  for (let i = 0; i < len; i++) {
+    const a = noise01(shared + i) * 2 - 1;
+    const b = noise01(indep + i) * 2 - 1;
+    left[i] = a;
+    // width interpolates between the two streams rather than merely offsetting
+    // one, so it is the continuous 0..1 knob the table treats it as: 0 is a
+    // mono point source, 1 is fully decorrelated.
+    right[i] = a * (1 - spec.width) + b * spec.width;
   }
 
   const src = ctx.createBufferSource();
@@ -94,7 +111,10 @@ export async function renderIR(spec: RoomSpec, sampleRate: number): Promise<Audi
     for (let i = 0; i < steps; i++) {
       curve[i] = Math.exp((-6.907755 * (i / (steps - 1)) * spec.decay) / t60);
     }
-    g.gain.setValueCurveAtTime(curve, 0, spec.decay);
+    // Starts at preDelay, not 0: the signal does not arrive until then, and
+    // running the envelope on the wall clock would shorten the effective tail
+    // to decay - preDelay and leave a step where the buffer ends.
+    g.gain.setValueCurveAtTime(curve, spec.preDelay, spec.decay);
     preDelayNode.connect(f);
     f.connect(g);
     g.connect(ctx.destination);
@@ -123,22 +143,24 @@ export async function renderIR(spec: RoomSpec, sampleRate: number): Promise<Audi
   src.start(0);
   const rendered = await ctx.startRendering();
 
-  // Fixed-RMS normalise. Convolvers run with normalize = false so RoomSpec
-  // controls level explicitly; without this, changing a room's decay would
-  // also change how loud the whole scene is.
-  let sum = 0;
-  let n = 0;
+  // Normalise to a fixed L2 NORM, not a fixed RMS.
+  //
+  // For a stationary input, convolution output power is proportional to
+  // sum(h[i]^2), and sum(h^2) = n * rms^2 -- so pinning RMS leaves the wet
+  // level scaling with sqrt(IR length). Across this table that is sqrt(3.27 /
+  // 0.354) = 3.04, nearly +10 dB more wet on the cosmos room than on the
+  // sketchbook, purely from the decay difference. Pinning sum(h^2) instead is
+  // what actually holds the send level constant as decay changes.
+  let energy = 0;
   for (let c = 0; c < rendered.numberOfChannels; c++) {
     const d = rendered.getChannelData(c);
     for (let i = 0; i < d.length; i++) {
       const v = d[i]!;
-      sum += v * v;
-      n++;
+      energy += v * v;
     }
   }
-  const rms = Math.sqrt(sum / Math.max(1, n));
-  if (rms > 1e-9) {
-    const g = 0.06 / rms;
+  if (energy > 1e-12) {
+    const g = 18 / Math.sqrt(energy);
     for (let c = 0; c < rendered.numberOfChannels; c++) {
       const d = rendered.getChannelData(c);
       for (let i = 0; i < d.length; i++) d[i] = d[i]! * g;
@@ -147,7 +169,11 @@ export async function renderIR(spec: RoomSpec, sampleRate: number): Promise<Audi
   return rendered;
 }
 
-/** Feature check -- Safari private modes and old engines have surprised us before. */
+/** Feature check. Safari shipped this prefixed for years, hence the fallback. */
 export function canRenderIR(): boolean {
-  return typeof OfflineAudioContext !== "undefined";
+  return (
+    typeof OfflineAudioContext !== "undefined" ||
+    typeof (globalThis as { webkitOfflineAudioContext?: unknown }).webkitOfflineAudioContext !==
+      "undefined"
+  );
 }

--- a/lib/audio/ir.ts
+++ b/lib/audio/ir.ts
@@ -1,4 +1,4 @@
-import { h01 } from "./util";
+import { noise01 } from "./util";
 
 /**
  * Impulse response generation. Zero bytes ship: every room is rendered in an
@@ -9,9 +9,8 @@ import { h01 } from "./util";
  * introduce pre-echo, and pre-echo INSIDE an impulse response smears the attack
  * of every single sound convolved with it.
  *
- * Determinism: the noise is drawn from h01, the same hash the runtime uses
- * everywhere else, so a room is byte-identical across sessions and machines.
- * No Math.random (engine law).
+ * Determinism: the noise is drawn from a seeded avalanche mixer, so a room is
+ * byte-identical across sessions and machines. No Math.random (engine law).
  */
 
 export interface RoomSpec {
@@ -52,7 +51,10 @@ export async function renderIR(spec: RoomSpec, sampleRate: number): Promise<Audi
   for (let c = 0; c < 2; c++) {
     const data = noise.getChannelData(c);
     const base = spec.seed + (c === 1 ? rShift : 0);
-    for (let i = 0; i < len; i++) data[i] = h01(base + i) * 2 - 1;
+    // noise01, NOT h01: h01 is linear in its argument, so over consecutive
+    // sample indices it degenerates into a sawtooth near 0.38 * rate -- a
+    // whistle rather than a tail. See the note in util.ts.
+    for (let i = 0; i < len; i++) data[i] = noise01(base + i) * 2 - 1;
   }
 
   const src = ctx.createBufferSource();

--- a/lib/audio/ir.ts
+++ b/lib/audio/ir.ts
@@ -62,16 +62,23 @@ export async function renderIR(spec: RoomSpec, sampleRate: number): Promise<Audi
   const noise = ctx.createBuffer(2, len, sampleRate);
   const shared = mix32(spec.seed * 2);
   const indep = mix32(spec.seed * 2 + 1);
+  // EQUAL-POWER blend, not linear. `a` and `b` are independent unit-variance
+  // streams, so a linear crossfade gives var(right) = (1-w)^2 + w^2, which is
+  // below 1 everywhere strictly between 0 and 1 -- up to -3 dB at w = 0.5. That
+  // pulls the reverb image left, and because width differs per room the image
+  // would WALK across every gutter. Linear crossfades only preserve level for
+  // correlated sources; cos/sin is the same law the gutter crossfade in
+  // rooms.ts already uses. L/R correlation still falls as cos(w * pi/2): 1 at
+  // width 0, 0 at width 1.
+  const cw = Math.cos((spec.width * Math.PI) / 2);
+  const sw = Math.sin((spec.width * Math.PI) / 2);
   const left = noise.getChannelData(0);
   const right = noise.getChannelData(1);
   for (let i = 0; i < len; i++) {
     const a = noise01(shared + i) * 2 - 1;
     const b = noise01(indep + i) * 2 - 1;
     left[i] = a;
-    // width interpolates between the two streams rather than merely offsetting
-    // one, so it is the continuous 0..1 knob the table treats it as: 0 is a
-    // mono point source, 1 is fully decorrelated.
-    right[i] = a * (1 - spec.width) + b * spec.width;
+    right[i] = a * cw + b * sw;
   }
 
   const src = ctx.createBufferSource();
@@ -160,6 +167,10 @@ export async function renderIR(spec: RoomSpec, sampleRate: number): Promise<Audi
     }
   }
   if (energy > 1e-12) {
+    // 18 is calibrated near the `cover` room, whose L2 under the old fixed-RMS
+    // 0.06 was about that. Relative to the shipped level that is roughly
+    // +4 dB on the sketchbook and -5 dB on the cosmos -- i.e. the ~10 dB of
+    // decay-dependent drift this normalise exists to remove.
     const g = 18 / Math.sqrt(energy);
     for (let c = 0; c < rendered.numberOfChannels; c++) {
       const d = rendered.getChannelData(c);

--- a/lib/audio/ir.ts
+++ b/lib/audio/ir.ts
@@ -1,0 +1,151 @@
+import { h01 } from "./util";
+
+/**
+ * Impulse response generation. Zero bytes ship: every room is rendered in an
+ * OfflineAudioContext on the client, in a few milliseconds, from parameters
+ * that stay reviewable as a table in rooms.ts.
+ *
+ * Encoding IRs as files would be actively worse, not just bigger: lossy codecs
+ * introduce pre-echo, and pre-echo INSIDE an impulse response smears the attack
+ * of every single sound convolved with it.
+ *
+ * Determinism: the noise is drawn from h01, the same hash the runtime uses
+ * everywhere else, so a room is byte-identical across sessions and machines.
+ * No Math.random (engine law).
+ */
+
+export interface RoomSpec {
+  id: string;
+  /** tail length in seconds */
+  decay: number;
+  /** direct-to-reverberant gap in seconds */
+  preDelay: number;
+  /** decay multipliers for low / mid / high, relative to `decay` */
+  bandDecay: readonly [number, number, number];
+  /** early reflections as [timeSec, gain, pan]; sparse early, dense late */
+  taps: readonly (readonly [number, number, number])[];
+  /** 0..1 left/right decorrelation */
+  width: number;
+  seed: number;
+}
+
+/** Crossover points for the three decay bands. */
+const LOW_HZ = 300;
+const MID_HZ = 1600;
+const HIGH_HZ = 4000;
+
+/**
+ * A tail is not one noise burst with one envelope. Real rooms absorb high
+ * frequencies fastest (air plus soft surfaces), so the top of the spectrum has
+ * to die well before the bottom -- that difference is most of what makes a
+ * space read as a specific place rather than generic mush.
+ */
+export async function renderIR(spec: RoomSpec, sampleRate: number): Promise<AudioBuffer> {
+  const len = Math.max(1, Math.ceil((spec.preDelay + spec.decay) * sampleRate));
+  const ctx = new OfflineAudioContext(2, len, sampleRate);
+
+  // Deterministic stereo noise. Left and right draw from disjoint streams so
+  // width is a tunable rather than an accident -- and at width 0 they collapse
+  // to the same signal, which is correct for a narrow space like a tunnel.
+  const noise = ctx.createBuffer(2, len, sampleRate);
+  const rShift = Math.round(spec.width * 1e6);
+  for (let c = 0; c < 2; c++) {
+    const data = noise.getChannelData(c);
+    const base = spec.seed + (c === 1 ? rShift : 0);
+    for (let i = 0; i < len; i++) data[i] = h01(base + i) * 2 - 1;
+  }
+
+  const src = ctx.createBufferSource();
+  src.buffer = noise;
+
+  // Density ramp: early reflections are sparse and late reverb is Gaussian.
+  // Gating the noise sparsely at the start and densely later is what stops a
+  // decaying-noise IR sounding like a burst of static.
+  const dense = ctx.createGain();
+  const rampLen = Math.min(len, Math.ceil(0.08 * sampleRate));
+  const densityCurve = new Float32Array(64);
+  for (let i = 0; i < densityCurve.length; i++) {
+    densityCurve[i] = 0.25 + 0.75 * Math.pow(i / (densityCurve.length - 1), 0.6);
+  }
+  dense.gain.setValueCurveAtTime(densityCurve, 0, rampLen / sampleRate);
+  src.connect(dense);
+
+  const preDelayNode = ctx.createDelay(Math.max(0.001, spec.preDelay + 0.001));
+  preDelayNode.delayTime.value = spec.preDelay;
+  dense.connect(preDelayNode);
+
+  // Three parallel bands, each with its own exponential decay.
+  const bands: [BiquadFilterType, number, number][] = [
+    ["lowpass", LOW_HZ, spec.bandDecay[0]],
+    ["bandpass", MID_HZ, spec.bandDecay[1]],
+    ["highpass", HIGH_HZ, spec.bandDecay[2]],
+  ];
+  for (const [type, freq, mult] of bands) {
+    const f = ctx.createBiquadFilter();
+    f.type = type;
+    f.frequency.value = freq;
+    f.Q.value = type === "bandpass" ? 0.7 : 0.5;
+    const g = ctx.createGain();
+    const t60 = Math.max(0.02, spec.decay * mult);
+    const steps = 128;
+    const curve = new Float32Array(steps);
+    for (let i = 0; i < steps; i++) {
+      curve[i] = Math.exp((-6.907755 * (i / (steps - 1)) * spec.decay) / t60);
+    }
+    g.gain.setValueCurveAtTime(curve, 0, spec.decay);
+    preDelayNode.connect(f);
+    f.connect(g);
+    g.connect(ctx.destination);
+  }
+
+  // Early reflections. These are what tell the ear a wall exists, and their
+  // absence is exactly why a pure decaying-noise tail reads as "no room" --
+  // which is why the cosmos room below deliberately ships zero taps.
+  for (const [time, tapGain, pan] of spec.taps) {
+    const tap = ctx.createBufferSource();
+    tap.buffer = noise;
+    const g = ctx.createGain();
+    g.gain.value = 0;
+    const at = spec.preDelay + time;
+    g.gain.setValueAtTime(0, at);
+    g.gain.linearRampToValueAtTime(tapGain, at + 0.0006);
+    g.gain.linearRampToValueAtTime(0, at + 0.012);
+    const p = ctx.createStereoPanner();
+    p.pan.value = Math.max(-1, Math.min(1, pan));
+    tap.connect(g);
+    g.connect(p);
+    p.connect(ctx.destination);
+    tap.start(0);
+  }
+
+  src.start(0);
+  const rendered = await ctx.startRendering();
+
+  // Fixed-RMS normalise. Convolvers run with normalize = false so RoomSpec
+  // controls level explicitly; without this, changing a room's decay would
+  // also change how loud the whole scene is.
+  let sum = 0;
+  let n = 0;
+  for (let c = 0; c < rendered.numberOfChannels; c++) {
+    const d = rendered.getChannelData(c);
+    for (let i = 0; i < d.length; i++) {
+      const v = d[i]!;
+      sum += v * v;
+      n++;
+    }
+  }
+  const rms = Math.sqrt(sum / Math.max(1, n));
+  if (rms > 1e-9) {
+    const g = 0.06 / rms;
+    for (let c = 0; c < rendered.numberOfChannels; c++) {
+      const d = rendered.getChannelData(c);
+      for (let i = 0; i < d.length; i++) d[i] = d[i]! * g;
+    }
+  }
+  return rendered;
+}
+
+/** Feature check -- Safari private modes and old engines have surprised us before. */
+export function canRenderIR(): boolean {
+  return typeof OfflineAudioContext !== "undefined";
+}

--- a/lib/audio/moments.ts
+++ b/lib/audio/moments.ts
@@ -14,6 +14,7 @@ import type {
 import { clamp01 } from "@/lib/shots";
 import { useScrollStore } from "@/lib/scrollStore";
 import { RANGES } from "@/issues/timeline";
+import type { ToneAudioNode } from "tone";
 import type { ToneModule } from "./types";
 import { h01, hash, moveTo } from "./util";
 import { fireMeowVoice } from "./ui";
@@ -261,7 +262,7 @@ interface Kit {
   boopSyn: Synth;
 }
 
-function buildKit(T: ToneModule, sfx: Gain): Kit {
+function buildKit(T: ToneModule, sfx: ToneAudioNode): Kit {
   // -- desk keycap clacks
   const clackNoise = new T.NoiseSynth({
     noise: { type: "white" },
@@ -1004,7 +1005,7 @@ function fireBoop(k: Kit, now: number): void {
 /** Called once per director rAF tick while audio is enabled. */
 export function scoreMoments(
   T: ToneModule,
-  sfx: Gain,
+  sfx: ToneAudioNode,
   t: number,
   dtSec: number,
   velocity: number,

--- a/lib/audio/rooms.ts
+++ b/lib/audio/rooms.ts
@@ -19,9 +19,10 @@ import { moveTo } from "./util";
  * gutter joins consecutive issues, which always differ in parity, so the two
  * rooms are guaranteed to land in different slots and no gutter ever needs a
  * mid-crossfade reassignment. That holds in both scroll directions, which is
- * what makes the whole thing scrub-safe: the gains are a pure function of t
- * with no latches, and which buffer lives in which slot is a pure function of
- * the issue index.
+ * what makes the whole thing scrub-safe: the gain TARGETS are a pure function
+ * of t with no latches, and which buffer lives in which slot is a pure
+ * function of the issue index. The AUDIBLE gain lags its target by the ramp,
+ * so it is not itself f(t) -- fine here, because no visual reads it.
  */
 
 const ROOMS: readonly RoomSpec[] = [
@@ -92,6 +93,7 @@ const SILENT_MS = 220;
 const QUIET_STOP_MS = 300;
 
 interface Slot {
+  /** replaced wholesale on every swap; see the normalize note in updateRooms */
   conv: Convolver;
   gain: Gain;
   /** issue whose IR is currently loaded, -1 when empty */
@@ -156,7 +158,9 @@ export function buildRooms(buses: Buses): void {
     conv.connect(gain);
     return {
       conv, gain, issue: -1, committed: 0,
-      zeroSince: 0, moveState: { v: 0 }, connected: false,
+      // Stamped at build rather than left 0: on frame 1 there is no ramp to
+      // wait out, and a 0 here makes the FIRST room stall SILENT_MS for nothing.
+      zeroSince: 1, moveState: { v: 0 }, connected: false,
     };
   };
   slots = [mk(), mk()];
@@ -236,11 +240,31 @@ export function updateRooms(t: number, now: number): void {
   // halves the convolution cost at exactly the moment it would otherwise
   // double, and a gutter is the one place a hard room change is masked anyway.
   const tier = useScrollStore.getState().audioTier;
+
+  // Rung A2: no convolution at all. Detach both slots and hand over to the
+  // shared algorithmic reverb, which is exactly the shipped pre-refactor
+  // behaviour. Latching keeps it off for the session, matching how the
+  // render-failure path degrades.
+  if (tier <= 0) {
+    silenceSlots();
+    disabled = true;
+    useFallback();
+    return;
+  }
+
   const x = tier >= 2 ? blend.x : blend.x < 0.5 ? 0 : 1;
 
   const sr = T.getContext().sampleRate;
   ensureIR(from, sr);
   if (to !== from) ensureIR(to, sr);
+  // Prefetch neighbours while settled INSIDE a scene. renderIR is async, but its
+  // noise fill and normalise passes run on the main thread, and firing them on
+  // the first frame of a gutter puts a few hundred thousand ops exactly where
+  // the frame budget is tightest and a dropped frame is most visible.
+  if (to === from) {
+    if (from + 1 < ROOMS.length) ensureIR(from + 1, sr);
+    if (from - 1 >= 0) ensureIR(from - 1, sr);
+  }
 
   const gFrom = Math.cos((x * Math.PI) / 2);
   const gTo = Math.sin((x * Math.PI) / 2);
@@ -259,19 +283,33 @@ export function updateRooms(t: number, now: number): void {
       const buf = cache?.get(want);
       if (buf) {
         try {
-          slot.conv.buffer = new T.ToneAudioBuffer(buf);
-          // Tone's `set buffer` CREATES A NEW ConvolverNode whenever the old one
-          // already had a buffer, and a fresh ConvolverNode defaults
-          // normalize = true. So the constructor's normalize:false only ever
-          // held for the first assignment; every swap after that silently
-          // re-enabled equal-power normalisation and undid the fixed-RMS level
-          // control in ir.ts. Re-assert it after every set.
-          slot.conv.normalize = false;
+          // A FRESH Convolver per swap, deliberately. Reassigning .buffer on an
+          // existing one CANNOT work.
+          //
+          // Tone's `set buffer` REPLACES its internal ConvolverNode whenever the
+          // old one already had a buffer, and a fresh ConvolverNode defaults
+          // normalize = true. Per the Web Audio spec, normalize is only read
+          // WHEN the buffer is assigned -- so setting it afterwards is a no-op
+          // until the next swap, and setting it beforehand is discarded along
+          // with the node Tone throws away. The one reachable ordering is a
+          // virgin Convolver: its constructor applies normalize to a node that
+          // has no buffer yet, and that first assignment does not trigger the
+          // replace. Without this, every room after the first is equal-power
+          // normalised, undoing the fixed-L2 level control in ir.ts.
+          const fresh = new T.Convolver({ normalize: false });
+          fresh.buffer = new T.ToneAudioBuffer(buf);
+          if (slot.connected) {
+            B.roomIn.disconnect(slot.conv);
+            slot.connected = false;
+          }
+          slot.conv.dispose();
+          slot.conv = fresh;
+          fresh.connect(slot.gain);
           slot.issue = want;
         } catch {
           // A rejected buffer must not reach the director's rAF catch, which
-          // would disable all audio site-wide. Leave the slot silent instead;
-          // the next frame retries.
+          // would disable all audio site-wide. Leave the slot silent; the next
+          // frame retries.
           slot.issue = -1;
         }
       }
@@ -299,6 +337,7 @@ export function updateRooms(t: number, now: number): void {
   }
 }
 
+/** No call sites yet: nothing tears the audio engine down mid-session. */
 export function disposeRooms(): void {
   if (slots) {
     for (const s of slots) {

--- a/lib/audio/rooms.ts
+++ b/lib/audio/rooms.ts
@@ -178,6 +178,12 @@ export function buildRooms(buses: Buses): void {
 function silenceSlots(): void {
   if (!slots || !B) return;
   for (const slot of slots) {
+    // Idempotent. Rung A2 is reversible, so this runs EVERY frame while the
+    // tier stays at 0 -- and rung A2 is the rung the ladder drops to because
+    // the device cannot keep up. Without this early-out it would issue two raw
+    // AudioParam ramps per frame forever, which is the per-frame automation
+    // write banned in util.ts, on the one rung that can least afford it.
+    if (slot.issue === -1 && slot.committed === 0 && !slot.connected) continue;
     try {
       slot.gain.gain.rampTo(0, FADE_S);
       slot.moveState.v = 0;
@@ -185,7 +191,7 @@ function silenceSlots(): void {
       slot.zeroSince = 0;
       slot.issue = -1;
       if (slot.connected) {
-        B.roomIn.disconnect(slot.conv);
+        B.roomOut.disconnect(slot.conv);
         slot.connected = false;
       }
     } catch {
@@ -210,20 +216,24 @@ function buildAlgorithmic(): void {
   const T = B.T;
   algo = new T.Freeverb({ roomSize: 0.7, dampening: 3000 });
   algoGain = new T.Gain(0).connect(B.out);
-  B.roomIn.connect(algo);
+  B.roomOut.connect(algo);
   algo.connect(algoGain);
 }
 
 function useFallback(): void {
   if (!B || fallback) return;
-  // Exactly the shipped behaviour: one shared algorithmic reverb. The worst
-  // case for the whole room system is "we are back where we started".
+  // The shipped node, level-matched into the new send structure. Not bit-exact
+  // with main -- that had its own send topology -- but the same reverb at the
+  // same wet level, so the worst case stays close to where we started.
   const T = B.T;
   fallback = new T.Reverb({ decay: 2.2, preDelay: 0.02, wet: 1 });
   const ret = new T.Gain(0).connect(B.out);
-  B.roomIn.connect(fallback);
+  B.roomOut.connect(fallback);
   fallback.connect(ret);
-  void fallback.ready.then(() => ret.gain.rampTo(0.18, 0.5)).catch(() => {});
+  // Level-matched to the convolution path: L2_TARGET is what a normalised
+  // convolver gives, and Tone.Reverb IS a normalised convolver, so unity here
+  // puts the fallback within a dB of the rooms instead of 45 dB below them.
+  void fallback.ready.then(() => ret.gain.rampTo(1, 0.5)).catch(() => {});
 }
 
 function ensureIR(issue: number, sampleRate: number): void {
@@ -267,7 +277,7 @@ export function updateRooms(t: number, now: number): void {
   // swaps at the gutter midpoint, so only ONE convolver is ever audible. That
   // halves the convolution cost at exactly the moment it would otherwise
   // double, and a gutter is the one place a hard room change is masked anyway.
-  const tier = useScrollStore.getState().audioTier;
+  const { audioTier: tier, velocity } = useScrollStore.getState();
 
   // Rung A2: no convolution at all. Detach both slots and hand over to Freeverb.
   //
@@ -277,7 +287,9 @@ export function updateRooms(t: number, now: number): void {
   // permanent by design.
   if (tier <= 0) {
     if (!algo) buildAlgorithmic();
-    if (algoGain) moveTo(algoGain.gain, algoState, 0.18, 0.3, 0.01);
+    // 0.53 matches L2_TARGET, so dropping to this rung changes the room, not
+    // the amount of room.
+    if (algoGain) moveTo(algoGain.gain, algoState, 0.53, 0.3, 0.01);
     silenceSlots();
     return;
   }
@@ -314,8 +326,12 @@ export function updateRooms(t: number, now: number): void {
     // fresh-Convolver requirement made it slightly more expensive still.
     // Silent target, so this never affects what is audible at any t.
     if (want === -1 && to === from) {
-      const next = from + 1;
-      if (next < ROOMS.length && next % 2 === s) want = next;
+      // Direction-aware: preloading only forward would make every BACKWARD
+      // gutter strictly more expensive than before this optimisation, since
+      // the slot would then be holding the wrong neighbour. Velocity is
+      // already read above for the tier.
+      const next = velocity < 0 ? from - 1 : from + 1;
+      if (next >= 0 && next < ROOMS.length && ((next % 2) + 2) % 2 === s) want = next;
     }
 
     // Silent means the TARGET has been zero long enough for the ramp to have
@@ -348,7 +364,7 @@ export function updateRooms(t: number, now: number): void {
           const fresh = new T.Convolver({ normalize: false });
           fresh.buffer = new T.ToneAudioBuffer(buf);
           if (slot.connected) {
-            B.roomIn.disconnect(slot.conv);
+            B.roomOut.disconnect(slot.conv);
             slot.connected = false;
           }
           slot.conv.dispose();
@@ -378,11 +394,11 @@ export function updateRooms(t: number, now: number): void {
     // turned down. Steady state is one convolver running; only gutters pay two.
     if (g > 0) {
       if (!slot.connected) {
-        B.roomIn.connect(slot.conv);
+        B.roomOut.connect(slot.conv);
         slot.connected = true;
       }
     } else if (slot.connected && slot.zeroSince !== 0 && now - slot.zeroSince > QUIET_STOP_MS) {
-      B.roomIn.disconnect(slot.conv);
+      B.roomOut.disconnect(slot.conv);
       slot.connected = false;
     }
   }

--- a/lib/audio/rooms.ts
+++ b/lib/audio/rooms.ts
@@ -1,4 +1,4 @@
-import type { Convolver, Gain, Reverb } from "tone";
+import type { Convolver, Freeverb, Gain, Reverb } from "tone";
 import { RANGES } from "@/issues/timeline";
 import { useScrollStore } from "@/lib/scrollStore";
 import { clamp01 } from "@/lib/shots";
@@ -78,7 +78,11 @@ const ROOMS: readonly RoomSpec[] = [
            [0.02, 0.24, 0.4], [0.027, 0.18, -0.15]] },
 ];
 
-/** Longest tail we will render. Convolver cost scales with IR length. */
+/**
+ * Longest tail we will render; convolver cost scales with IR length. Equal to
+ * the longest room in the table, so the clamp is a guard rail against a future
+ * edit rather than something that currently bites.
+ */
 const MAX_DECAY = 3.2;
 /** Crossfade ramp for a room slot's gain. */
 const FADE_S = 0.12;
@@ -115,6 +119,9 @@ let slots: [Slot, Slot] | null = null;
 let cache: Map<number, AudioBuffer> | null = null;
 let pending: Set<number> | null = null;
 let fallback: Reverb | null = null;
+let algo: Freeverb | null = null;
+let algoGain: Gain | null = null;
+const algoState = { v: 0 };
 let B: Buses | null = null;
 let disabled = false;
 
@@ -151,8 +158,9 @@ export function buildRooms(buses: Buses): void {
   }
 
   const mk = (): Slot => {
-    // normalize FALSE: RoomSpec controls level via the fixed-RMS normalise in
-    // ir.ts, so changing a room's decay never changes how loud the scene is.
+    // normalize FALSE: level is controlled by the fixed-L2 normalise in ir.ts,
+    // which is the one that actually holds the wet level constant as decay
+    // changes. (Fixed RMS does not -- output power goes as sum(h^2) = n*rms^2.)
     const conv = new T.Convolver({ normalize: false });
     const gain = new T.Gain(0).connect(buses.out);
     conv.connect(gain);
@@ -184,6 +192,26 @@ function silenceSlots(): void {
       // best effort; this runs on an already-failing path
     }
   }
+}
+
+/**
+ * Rung A2's reverb. Freeverb is comb + allpass -- genuinely algorithmic, with
+ * NO ConvolverNode.
+ *
+ * Tone.Reverb would be the wrong node here: it generates a decaying-noise IR
+ * with Tone.Offline and feeds a ConvolverNode, so it IS convolution. Since
+ * convolver cost scales with IR length and Reverb is fixed at 2.2 s, routing
+ * A2 through it would cost MORE than A1 in the seven rooms whose decay is
+ * under 2.2 s -- a ladder rung that increases cost on most of the timeline,
+ * which is the one shape a degradation ladder must not have.
+ */
+function buildAlgorithmic(): void {
+  if (!B || algo) return;
+  const T = B.T;
+  algo = new T.Freeverb({ roomSize: 0.7, dampening: 3000 });
+  algoGain = new T.Gain(0).connect(B.out);
+  B.roomIn.connect(algo);
+  algo.connect(algoGain);
 }
 
 function useFallback(): void {
@@ -241,16 +269,19 @@ export function updateRooms(t: number, now: number): void {
   // double, and a gutter is the one place a hard room change is masked anyway.
   const tier = useScrollStore.getState().audioTier;
 
-  // Rung A2: no convolution at all. Detach both slots and hand over to the
-  // shared algorithmic reverb, which is exactly the shipped pre-refactor
-  // behaviour. Latching keeps it off for the session, matching how the
-  // render-failure path degrades.
+  // Rung A2: no convolution at all. Detach both slots and hand over to Freeverb.
+  //
+  // REVERSIBLE, unlike the render-failure path: tier is re-read every frame, so
+  // a perf probe that drops to A2 and recovers gets its rooms back. That is why
+  // this does NOT set `disabled`, which means "IR rendering is broken" and is
+  // permanent by design.
   if (tier <= 0) {
+    if (!algo) buildAlgorithmic();
+    if (algoGain) moveTo(algoGain.gain, algoState, 0.18, 0.3, 0.01);
     silenceSlots();
-    disabled = true;
-    useFallback();
     return;
   }
+  if (algoGain && algoState.v !== 0) moveTo(algoGain.gain, algoState, 0, 0.3, 0.01);
 
   const x = tier >= 2 ? blend.x : blend.x < 0.5 ? 0 : 1;
 
@@ -272,8 +303,20 @@ export function updateRooms(t: number, now: number): void {
   for (let s = 0; s < 2; s++) {
     const slot = slots[s]!;
     // parity: even issues live in slot 0, odd in slot 1
-    const want = from % 2 === s ? from : to % 2 === s ? to : -1;
+    let want = from % 2 === s ? from : to % 2 === s ? to : -1;
     const target = want === -1 ? 0 : want === from ? gFrom : gTo;
+
+    // PRELOAD. While settled inside a scene the opposite-parity slot is idle,
+    // and the next room has exactly that parity -- so its buffer can be loaded
+    // during a settled frame instead of on the gutter's first frame. Prefetching
+    // the RENDER alone was not enough: the swap itself rebuilds the FFT
+    // partition table synchronously, which is the expensive half, and the
+    // fresh-Convolver requirement made it slightly more expensive still.
+    // Silent target, so this never affects what is audible at any t.
+    if (want === -1 && to === from) {
+      const next = from + 1;
+      if (next < ROOMS.length && next % 2 === s) want = next;
+    }
 
     // Silent means the TARGET has been zero long enough for the ramp to have
     // finished, not merely that the target is zero this frame.
@@ -296,6 +339,12 @@ export function updateRooms(t: number, now: number): void {
           // has no buffer yet, and that first assignment does not trigger the
           // replace. Without this, every room after the first is equal-power
           // normalised, undoing the fixed-L2 level control in ir.ts.
+          // DO NOT merge these two statements into
+          // `new T.Convolver({ buffer, normalize: false })`. Whether that still
+          // honours normalize depends on whether Tone's constructor applies it
+          // before or after its own `if (this._buffer.loaded) this.buffer = ...`
+          // branch. Keeping them separate makes the virgin-node requirement
+          // explicit and independent of that ordering.
           const fresh = new T.Convolver({ normalize: false });
           fresh.buffer = new T.ToneAudioBuffer(buf);
           if (slot.connected) {
@@ -316,6 +365,8 @@ export function updateRooms(t: number, now: number): void {
     }
 
     const ready = slot.issue === want && want !== -1;
+    // `target` is already 0 for a preload (want !== from and !== to), so a
+    // preloaded slot loads its buffer and stays silent.
     const g = ready ? target : 0;
     moveTo(slot.gain.gain, slot.moveState, g, FADE_S, 0.01);
     slot.committed = g;
@@ -354,6 +405,9 @@ export function disposeRooms(): void {
   cache = null;
   pending = null;
   fallback = null;
+  algo = null;
+  algoGain = null;
+  algoState.v = 0;
   B = null;
   disabled = false;
 }

--- a/lib/audio/rooms.ts
+++ b/lib/audio/rooms.ts
@@ -162,6 +162,26 @@ export function buildRooms(buses: Buses): void {
   slots = [mk(), mk()];
 }
 
+/** Zero and detach both slots. Safe to call twice; never throws. */
+function silenceSlots(): void {
+  if (!slots || !B) return;
+  for (const slot of slots) {
+    try {
+      slot.gain.gain.rampTo(0, FADE_S);
+      slot.moveState.v = 0;
+      slot.committed = 0;
+      slot.zeroSince = 0;
+      slot.issue = -1;
+      if (slot.connected) {
+        B.roomIn.disconnect(slot.conv);
+        slot.connected = false;
+      }
+    } catch {
+      // best effort; this runs on an already-failing path
+    }
+  }
+}
+
 function useFallback(): void {
   if (!B || fallback) return;
   // Exactly the shipped behaviour: one shared algorithmic reverb. The worst
@@ -190,6 +210,12 @@ function ensureIR(issue: number, sampleRate: number): void {
     })
     .catch(() => {
       pending?.delete(issue);
+      // Tear the rooms DOWN before latching, or `disabled` short-circuits
+      // updateRooms on every later frame and leaves whatever was audible on
+      // this frame convolving forever -- welding one scene's room onto every
+      // scene that follows, with the fallback reverb layered on top. Failures
+      // have to degrade to the fallback, not to a frozen wrong room.
+      silenceSlots();
       disabled = true;
       useFallback();
     });
@@ -234,6 +260,13 @@ export function updateRooms(t: number, now: number): void {
       if (buf) {
         try {
           slot.conv.buffer = new T.ToneAudioBuffer(buf);
+          // Tone's `set buffer` CREATES A NEW ConvolverNode whenever the old one
+          // already had a buffer, and a fresh ConvolverNode defaults
+          // normalize = true. So the constructor's normalize:false only ever
+          // held for the first assignment; every swap after that silently
+          // re-enabled equal-power normalisation and undid the fixed-RMS level
+          // control in ir.ts. Re-assert it after every set.
+          slot.conv.normalize = false;
           slot.issue = want;
         } catch {
           // A rejected buffer must not reach the director's rAF catch, which

--- a/lib/audio/rooms.ts
+++ b/lib/audio/rooms.ts
@@ -1,0 +1,289 @@
+import type { Convolver, Gain, Reverb } from "tone";
+import { RANGES } from "@/issues/timeline";
+import { useScrollStore } from "@/lib/scrollStore";
+import { clamp01 } from "@/lib/shots";
+import { canRenderIR, renderIR, type RoomSpec } from "./ir";
+import type { Buses } from "./buses";
+import { moveTo } from "./util";
+
+/**
+ * Per-scene acoustic rooms. Replaces the single shared
+ * Reverb({decay: 2.2}) that every sound on the site fed at gain 0.18 -- which
+ * meant a rooftop, a subway tunnel and a sketchbook desk were all the same
+ * small room, and is one of the largest single reasons the mix read flat.
+ *
+ * Two convolvers crossfade across each gutter so the space MORPHS with the
+ * scene instead of switching.
+ *
+ * SLOT ASSIGNMENT IS BY PARITY -- even issue to slot A, odd to slot B. Any
+ * gutter joins consecutive issues, which always differ in parity, so the two
+ * rooms are guaranteed to land in different slots and no gutter ever needs a
+ * mid-crossfade reassignment. That holds in both scroll directions, which is
+ * what makes the whole thing scrub-safe: the gains are a pure function of t
+ * with no latches, and which buffer lives in which slot is a pure function of
+ * the issue index.
+ */
+
+const ROOMS: readonly RoomSpec[] = [
+  // 0 cover: small print shop, paper-damped
+  { id: "cover", decay: 0.9, preDelay: 0.011, bandDecay: [1, 0.9, 0.6], width: 0.75, seed: 101,
+    taps: [[0.006, 0.5, -0.3], [0.011, 0.42, 0.35], [0.018, 0.33, -0.5], [0.026, 0.28, 0.2],
+           [0.034, 0.22, 0.55], [0.045, 0.16, -0.15]] },
+  // 1 noir: wet street canyon, long low tail, a slapback off the far facade
+  { id: "noir", decay: 1.8, preDelay: 0.03, bandDecay: [1.2, 1, 0.5], width: 0.95, seed: 211,
+    taps: [[0.014, 0.44, -0.6], [0.028, 0.36, 0.5], [0.047, 0.3, -0.35], [0.062, 0.34, 0.7],
+           [0.081, 0.22, -0.7], [0.098, 0.18, 0.25], [0.115, 0.14, -0.2], [0.13, 0.1, 0.6]] },
+  // 2 desk: tight dry office, carpet and books, dense early reflections
+  { id: "desk", decay: 0.5, preDelay: 0.006, bandDecay: [1, 0.9, 0.8], width: 0.55, seed: 307,
+    taps: [[0.003, 0.55, -0.25], [0.006, 0.48, 0.3], [0.009, 0.42, -0.4], [0.012, 0.38, 0.15],
+           [0.015, 0.32, 0.45], [0.018, 0.28, -0.2], [0.022, 0.22, 0.35]] },
+  // 3 neon: city canyon, very long and dark
+  { id: "neon", decay: 2.4, preDelay: 0.045, bandDecay: [1.3, 1, 0.4], width: 1, seed: 419,
+    taps: [[0.02, 0.4, -0.75], [0.036, 0.36, 0.7], [0.055, 0.3, -0.55], [0.072, 0.26, 0.6],
+           [0.09, 0.2, -0.4], [0.108, 0.16, 0.45], [0.125, 0.12, -0.3], [0.142, 0.1, 0.2]] },
+  // 4 origin: open valley, sparse and long. Few surfaces, far away.
+  { id: "origin", decay: 2.8, preDelay: 0.06, bandDecay: [1.4, 1, 0.35], width: 0.9, seed: 523,
+    taps: [[0.04, 0.26, -0.5], [0.078, 0.2, 0.55], [0.12, 0.14, -0.3], [0.165, 0.1, 0.35],
+           [0.19, 0.07, -0.15]] },
+  // 5 press: concrete factory hall, bright slap, flutter between parallel walls
+  { id: "press", decay: 2.2, preDelay: 0.025, bandDecay: [1, 1.1, 0.7], width: 0.9, seed: 631,
+    taps: [[0.012, 0.5, -0.45], [0.024, 0.44, 0.4], [0.041, 0.38, -0.6], [0.058, 0.34, 0.55],
+           [0.074, 0.28, -0.3], [0.088, 0.3, 0.65], [0.104, 0.22, -0.5], [0.12, 0.18, 0.3],
+           [0.14, 0.14, -0.2], [0.16, 0.1, 0.45]] },
+  // 6 newsprint: open-plan newsroom, ceiling tiles
+  { id: "newsprint", decay: 1.1, preDelay: 0.012, bandDecay: [1, 1, 0.7], width: 0.7, seed: 743,
+    taps: [[0.005, 0.5, -0.3], [0.011, 0.44, 0.35], [0.018, 0.36, -0.45], [0.026, 0.3, 0.25],
+           [0.034, 0.24, 0.5], [0.043, 0.18, -0.2], [0.055, 0.12, 0.15]] },
+  // 7 screentone: tiled subway, strong flutter
+  { id: "screentone", decay: 2, preDelay: 0.02, bandDecay: [1.1, 1.2, 0.5], width: 0.85, seed: 857,
+    taps: [[0.009, 0.5, -0.5], [0.019, 0.46, 0.45], [0.031, 0.42, -0.55], [0.044, 0.38, 0.5],
+           [0.058, 0.32, -0.4], [0.073, 0.28, 0.4], [0.089, 0.22, -0.3], [0.106, 0.18, 0.3],
+           [0.118, 0.14, -0.2], [0.13, 0.1, 0.25]] },
+  // 8 pop: bright treated studio, live but small
+  { id: "pop", decay: 1.4, preDelay: 0.018, bandDecay: [1, 1, 0.8], width: 0.8, seed: 967,
+    taps: [[0.006, 0.52, -0.35], [0.012, 0.46, 0.4], [0.019, 0.4, -0.5], [0.027, 0.34, 0.3],
+           [0.035, 0.28, 0.55], [0.044, 0.22, -0.25], [0.054, 0.18, 0.2], [0.066, 0.12, -0.4]] },
+  // 9 sketch: near-anechoic, paper close to the face
+  { id: "sketch", decay: 0.35, preDelay: 0.004, bandDecay: [1, 0.9, 0.9], width: 0.35, seed: 1069,
+    taps: [[0.002, 0.5, -0.15], [0.004, 0.42, 0.2], [0.006, 0.34, -0.25], [0.009, 0.26, 0.1]] },
+  // 10 spread: cosmos. ZERO early reflections, deliberately. Early reflections
+  // are what tell the ear a wall exists; without them plus a long pre-delay
+  // this reads as "no room, infinite space" rather than "very big room".
+  { id: "spread", decay: 3.2, preDelay: 0.07, bandDecay: [1.5, 1, 0.3], width: 1, seed: 1171,
+    taps: [] },
+  // 11 terminal: small CRT room with a hard desk reflection
+  { id: "terminal", decay: 0.7, preDelay: 0.008, bandDecay: [1, 0.9, 0.8], width: 0.5, seed: 1283,
+    taps: [[0.002, 0.55, -0.2], [0.005, 0.46, 0.25], [0.009, 0.38, -0.35], [0.014, 0.3, 0.2],
+           [0.02, 0.24, 0.4], [0.027, 0.18, -0.15]] },
+];
+
+/** Longest tail we will render. Convolver cost scales with IR length. */
+const MAX_DECAY = 3.2;
+/** Crossfade ramp for a room slot's gain. */
+const FADE_S = 0.12;
+/**
+ * How long a slot's target must have been zero before it is safe to touch.
+ * Must exceed FADE_S: assigning Convolver.buffer rebuilds the FFT partition
+ * table synchronously, so doing it while the gain is still ramping down is
+ * audible as a click.
+ */
+const SILENT_MS = 220;
+/** Further wait before the convolver input is disconnected entirely. */
+const QUIET_STOP_MS = 300;
+
+interface Slot {
+  conv: Convolver;
+  gain: Gain;
+  /** issue whose IR is currently loaded, -1 when empty */
+  issue: number;
+  /** last target gain written; 0 means "fading out or already silent" */
+  committed: number;
+  /**
+   * Timestamp the target first hit 0, or 0 while audible. The buffer swap and
+   * the input disconnect both wait on this rather than on `committed`, because
+   * `committed` is the TARGET and the gain is still ramping for FADE_S after
+   * it reaches zero.
+   */
+  zeroSince: number;
+  moveState: { v: number };
+  connected: boolean;
+}
+
+let slots: [Slot, Slot] | null = null;
+let cache: Map<number, AudioBuffer> | null = null;
+let pending: Set<number> | null = null;
+let fallback: Reverb | null = null;
+let B: Buses | null = null;
+let disabled = false;
+
+/**
+ * Which rooms are audible at t, and how far between them.
+ * Pure f(t) with no latches, so scrubbing back walks the identical curve.
+ */
+export function roomBlend(t: number): { from: number; to: number; x: number } {
+  for (let i = 0; i < RANGES.length; i++) {
+    const r = RANGES[i]!;
+    if (t <= r[1]) {
+      if (t >= r[0] || i === 0) return { from: i, to: i, x: 0 };
+      // in the gutter between i-1 and i
+      const prev = RANGES[i - 1]!;
+      const span = r[0] - prev[1];
+      const x = span > 1e-6 ? clamp01((t - prev[1]) / span) : 1;
+      // smoothstep so the morph has no corner at either end
+      return { from: i - 1, to: i, x: x * x * (3 - 2 * x) };
+    }
+  }
+  return { from: RANGES.length - 1, to: RANGES.length - 1, x: 0 };
+}
+
+export function buildRooms(buses: Buses): void {
+  B = buses;
+  disabled = false;
+  cache = new Map();
+  pending = new Set();
+  const T = buses.T;
+
+  if (!canRenderIR()) {
+    useFallback();
+    return;
+  }
+
+  const mk = (): Slot => {
+    // normalize FALSE: RoomSpec controls level via the fixed-RMS normalise in
+    // ir.ts, so changing a room's decay never changes how loud the scene is.
+    const conv = new T.Convolver({ normalize: false });
+    const gain = new T.Gain(0).connect(buses.out);
+    conv.connect(gain);
+    return {
+      conv, gain, issue: -1, committed: 0,
+      zeroSince: 0, moveState: { v: 0 }, connected: false,
+    };
+  };
+  slots = [mk(), mk()];
+}
+
+function useFallback(): void {
+  if (!B || fallback) return;
+  // Exactly the shipped behaviour: one shared algorithmic reverb. The worst
+  // case for the whole room system is "we are back where we started".
+  const T = B.T;
+  fallback = new T.Reverb({ decay: 2.2, preDelay: 0.02, wet: 1 });
+  const ret = new T.Gain(0).connect(B.out);
+  B.roomIn.connect(fallback);
+  fallback.connect(ret);
+  void fallback.ready.then(() => ret.gain.rampTo(0.18, 0.5)).catch(() => {});
+}
+
+function ensureIR(issue: number, sampleRate: number): void {
+  if (!cache || !pending || disabled) return;
+  if (cache.has(issue) || pending.has(issue)) return;
+  const spec = ROOMS[issue];
+  if (!spec) return;
+  pending.add(issue);
+  // Promise chain started OUTSIDE the rAF, with its own catch, so a rendering
+  // failure can never reach the director's frame-loop try/catch and trip the
+  // global disable.
+  void renderIR({ ...spec, decay: Math.min(spec.decay, MAX_DECAY) }, sampleRate)
+    .then((buf) => {
+      cache?.set(issue, buf);
+      pending?.delete(issue);
+    })
+    .catch(() => {
+      pending?.delete(issue);
+      disabled = true;
+      useFallback();
+    });
+}
+
+/**
+ * Per-frame. Pure f(t) for the gains; the only stateful part is which buffer
+ * sits in which slot, and parity makes that a pure function of issue index too.
+ */
+export function updateRooms(t: number, now: number): void {
+  if (!B || !slots || disabled) return;
+  const T = B.T;
+  const blend = roomBlend(t);
+  const { from, to } = blend;
+
+  // S0.6 audio rung A1: below the full tier the room stops morphing and hard
+  // swaps at the gutter midpoint, so only ONE convolver is ever audible. That
+  // halves the convolution cost at exactly the moment it would otherwise
+  // double, and a gutter is the one place a hard room change is masked anyway.
+  const tier = useScrollStore.getState().audioTier;
+  const x = tier >= 2 ? blend.x : blend.x < 0.5 ? 0 : 1;
+
+  const sr = T.getContext().sampleRate;
+  ensureIR(from, sr);
+  if (to !== from) ensureIR(to, sr);
+
+  const gFrom = Math.cos((x * Math.PI) / 2);
+  const gTo = Math.sin((x * Math.PI) / 2);
+
+  for (let s = 0; s < 2; s++) {
+    const slot = slots[s]!;
+    // parity: even issues live in slot 0, odd in slot 1
+    const want = from % 2 === s ? from : to % 2 === s ? to : -1;
+    const target = want === -1 ? 0 : want === from ? gFrom : gTo;
+
+    // Silent means the TARGET has been zero long enough for the ramp to have
+    // finished, not merely that the target is zero this frame.
+    const silent = slot.committed === 0 && slot.zeroSince !== 0 && now - slot.zeroSince > SILENT_MS;
+
+    if (want !== -1 && slot.issue !== want && silent) {
+      const buf = cache?.get(want);
+      if (buf) {
+        try {
+          slot.conv.buffer = new T.ToneAudioBuffer(buf);
+          slot.issue = want;
+        } catch {
+          // A rejected buffer must not reach the director's rAF catch, which
+          // would disable all audio site-wide. Leave the slot silent instead;
+          // the next frame retries.
+          slot.issue = -1;
+        }
+      }
+    }
+
+    const ready = slot.issue === want && want !== -1;
+    const g = ready ? target : 0;
+    moveTo(slot.gain.gain, slot.moveState, g, FADE_S, 0.01);
+    slot.committed = g;
+    if (g > 0) slot.zeroSince = 0;
+    else if (slot.zeroSince === 0) slot.zeroSince = now;
+
+    // A ConvolverNode runs its FFT whenever its input is connected, regardless
+    // of downstream gain, so an idle slot is disconnected rather than merely
+    // turned down. Steady state is one convolver running; only gutters pay two.
+    if (g > 0) {
+      if (!slot.connected) {
+        B.roomIn.connect(slot.conv);
+        slot.connected = true;
+      }
+    } else if (slot.connected && slot.zeroSince !== 0 && now - slot.zeroSince > QUIET_STOP_MS) {
+      B.roomIn.disconnect(slot.conv);
+      slot.connected = false;
+    }
+  }
+}
+
+export function disposeRooms(): void {
+  if (slots) {
+    for (const s of slots) {
+      try {
+        if (s.connected) B?.roomIn.disconnect(s.conv);
+        s.conv.dispose();
+        s.gain.dispose();
+      } catch {
+        // teardown is best-effort; never throw out of dispose
+      }
+    }
+  }
+  slots = null;
+  cache = null;
+  pending = null;
+  fallback = null;
+  B = null;
+  disabled = false;
+}
+
+export { ROOMS };

--- a/lib/audio/transitions.ts
+++ b/lib/audio/transitions.ts
@@ -1,6 +1,7 @@
 import type { Filter, Gain, Noise, Oscillator } from "tone";
 import { clamp01 } from "@/lib/shots";
 import { RANGES } from "@/issues/timeline";
+import type { ToneAudioNode } from "tone";
 import type { ToneModule } from "./types";
 import { moveTo } from "./util";
 
@@ -132,7 +133,7 @@ const DOTM = win(10, 11); // 10->11 dot-match twinkle-zip
 // ---- new gutter voices ---------------------------------------------------
 
 /** 0->1 crash-through-cover: paper burst + punch body + membrane/chirp hit. */
-function buildCrash(T: ToneModule, sfx: Gain): Voice {
+function buildCrash(T: ToneModule, sfx: ToneAudioNode): Voice {
   const w = CRASH;
   const burst = new T.Noise("white");
   const burstBp = new T.Filter(900, "bandpass");
@@ -199,7 +200,7 @@ function buildCrash(T: ToneModule, sfx: Gain): Voice {
 }
 
 /** 3->4 panel-wipe: crisp high bandpass swipe, bell x |velocity|. */
-function buildPanelWipe(T: ToneModule, sfx: Gain): Voice {
+function buildPanelWipe(T: ToneModule, sfx: ToneAudioNode): Voice {
   const w = PWIPE;
   const noise = new T.Noise("white");
   const bp = new T.Filter(1500, "bandpass");
@@ -232,7 +233,7 @@ function buildPanelWipe(T: ToneModule, sfx: Gain): Voice {
 }
 
 /** 4->5 panel-portal: ethereal glide tone + air through a delay tail (no vel gate). */
-function buildPortal(T: ToneModule, sfx: Gain): Voice {
+function buildPortal(T: ToneModule, sfx: ToneAudioNode): Voice {
   const w = PORTAL;
   const delay = new T.FeedbackDelay(0.2, 0.25);
   delay.wet.value = 0.25;
@@ -278,7 +279,7 @@ function buildPortal(T: ToneModule, sfx: Gain): Voice {
 }
 
 /** 5->6 stamp cut: ka-chunk body + metal-contact transient + pneumatic hiss. */
-function buildStamp(T: ToneModule, sfx: Gain): Voice {
+function buildStamp(T: ToneModule, sfx: ToneAudioNode): Voice {
   const w = STAMP;
   const chunk = new T.Oscillator({ frequency: 220, type: "square", volume: -8 });
   const chunkBp = new T.Filter(800, "bandpass");
@@ -332,7 +333,7 @@ function buildStamp(T: ToneModule, sfx: Gain): Voice {
 }
 
 /** 6->7 paper-tear: rising bandpass tear line (ripple texture) + late flap. */
-function buildTear(T: ToneModule, sfx: Gain): Voice {
+function buildTear(T: ToneModule, sfx: ToneAudioNode): Voice {
   const w = TEAR;
   const noise = new T.Noise("pink");
   const bp = new T.Filter(1200, "bandpass");
@@ -381,7 +382,7 @@ function buildTear(T: ToneModule, sfx: Gain): Voice {
 }
 
 /** 7->8 page-flip: early flutter flap (page catching air) + late whoosh tail. */
-function buildFlip(T: ToneModule, sfx: Gain): Voice {
+function buildFlip(T: ToneModule, sfx: ToneAudioNode): Voice {
   const w = FLIP;
   const noise = new T.Noise("pink");
   const flapBp = new T.Filter(700, "bandpass");
@@ -423,7 +424,7 @@ function buildFlip(T: ToneModule, sfx: Gain): Voice {
 }
 
 /** 9->10 ink-flood: sub swell + dark liquid gulp, resolves to true silence (no vel gate). */
-function buildInk(T: ToneModule, sfx: Gain): Voice {
+function buildInk(T: ToneModule, sfx: ToneAudioNode): Voice {
   const w = INK;
   const sub = new T.Oscillator({ frequency: 50, type: "sine", volume: -6 });
   const subLp = new T.Filter(400, "lowpass");
@@ -464,7 +465,7 @@ function buildInk(T: ToneModule, sfx: Gain): Voice {
 }
 
 /** 10->11 dot-match: twinkle partials (9Hz shimmer) + zip, resolving to a cursor sine. */
-function buildDotMatch(T: ToneModule, sfx: Gain): Voice {
+function buildDotMatch(T: ToneModule, sfx: ToneAudioNode): Voice {
   const w = DOTM;
   const pa = new T.Oscillator({ frequency: 400, type: "sine", volume: -12 });
   const pb = new T.Oscillator({ frequency: 600, type: "sine", volume: -12 });
@@ -535,7 +536,7 @@ function buildDotMatch(T: ToneModule, sfx: Gain): Voice {
  * under every per-issue bed; symmetric on back-scrub. Tremolo = one pooled LFO
  * on a gain (depth 0.5 -- a page-fan flutter, never a strobe).
  */
-function buildRiffle(T: ToneModule, sfx: Gain): Voice {
+function buildRiffle(T: ToneModule, sfx: ToneAudioNode): Voice {
   const noise = new T.Noise("pink");
   const bp = new T.Filter(1600, "bandpass");
   const trem = new T.Gain(0); // LFO-driven flutter (base 0 + LFO = [0.5, 1])
@@ -594,7 +595,7 @@ const fFreq = { v: 70 };
 const fLp = { v: 320 };
 const fBp = { v: 380 };
 
-function build(T: ToneModule, sfx: Gain): Rig {
+function build(T: ToneModule, sfx: ToneAudioNode): Rig {
   const riser = new T.Oscillator({ frequency: 70, type: "sawtooth", volume: -10 });
   const riserLp = new T.Filter(320, "lowpass");
   const riserGain = new T.Gain(0);
@@ -620,7 +621,7 @@ function build(T: ToneModule, sfx: Gain): Rig {
 /** Called once per director rAF tick while audio is enabled. */
 export function scoreTransitions(
   T: ToneModule,
-  sfx: Gain,
+  sfx: ToneAudioNode,
   t: number,
   dtSec: number,
   velocity: number,

--- a/lib/audio/ui.ts
+++ b/lib/audio/ui.ts
@@ -1,6 +1,7 @@
 import type { Filter, FMSynth, Gain, MembraneSynth, Noise, NoiseSynth, Synth } from "tone";
 import { useScrollStore } from "@/lib/scrollStore";
 import { logFire } from "./debug";
+import type { ToneAudioNode } from "tone";
 import type { ToneModule } from "./types";
 import { hash } from "./util";
 
@@ -36,7 +37,7 @@ export type UiKind =
 
 interface Mod {
   T: ToneModule;
-  sfx: Gain;
+  sfx: ToneAudioNode;
 }
 
 interface Pool {
@@ -359,7 +360,7 @@ export function catPurr(): void {
  * gate because meow / uiSound / swish all early-return while `mod` is null,
  * and are silent post-disable via the director's out-gain ramp.
  */
-export function wireUi(T: ToneModule, sfx: Gain): void {
+export function wireUi(T: ToneModule, sfx: ToneAudioNode): void {
   mod = { T, sfx };
   if (subscribed) return;
   subscribed = true;

--- a/lib/audio/util.ts
+++ b/lib/audio/util.ts
@@ -10,6 +10,31 @@ export const hash = (n: number): number => Math.imul(n, 2654435761) >>> 0;
 /** Deterministic 0..1 from an integer. */
 export const h01 = (n: number): number => hash(n) / 4294967296;
 
+/**
+ * Avalanche mixer (murmur3 finalizer), for when the index is DENSE.
+ *
+ * `hash` above is Knuth multiplicative -- Math.imul(n, K) -- which is LINEAR in
+ * n, so hash(n + 1) - hash(n) is a CONSTANT. Over the step indices it was
+ * written for (a Stepper tick every ~100 ms) that is invisible and perfectly
+ * fine. Over CONSECUTIVE indices it is not noise at all: measured over
+ * i, i+1, i+2, h01 produces only TWO distinct successive deltas -- a sawtooth
+ * -- with autocorrelation 0.98 at lag 144 and a dominant spectral bin at
+ * 0.38 * rate. Filling an audio buffer with it yields a near-ultrasonic
+ * whistle, not noise.
+ *
+ * Use noise01 for anything that walks a buffer; keep h01 for step indices.
+ */
+export function mix32(n: number): number {
+  let x = n | 0;
+  x = Math.imul(x ^ (x >>> 16), 2246822507);
+  x = Math.imul(x ^ (x >>> 13), 3266489909);
+  x ^= x >>> 16;
+  return x >>> 0;
+}
+
+/** Deterministic 0..1 that stays white over consecutive indices. */
+export const noise01 = (n: number): number => mix32(n) / 4294967296;
+
 /** Structural type for anything with rampTo (Tone Param / Signal). */
 export interface RampTarget {
   rampTo(value: number, rampTime: number): unknown;

--- a/lib/scrollStore.ts
+++ b/lib/scrollStore.ts
@@ -59,6 +59,7 @@ export const useScrollStore = create<ScrollState>()((set) => ({
   setPointer: (pointerX, pointerY) => set({ pointerX, pointerY }),
   setQuality: (quality) =>
     set((s) => ({ quality, audioTier: quality === "low" ? 1 : s.audioTier })),
+  // No call sites yet -- perf-profiler owns the S0.6 ladder and drives this.
   setAudioTier: (audioTier) => set({ audioTier }),
   setReducedMotion: (reducedMotion) => set({ reducedMotion }),
   setAudioOn: (audioOn) => set({ audioOn }),

--- a/lib/scrollStore.ts
+++ b/lib/scrollStore.ts
@@ -9,7 +9,9 @@ export type Quality = "high" | "low";
  *
  *   2  full   two convolvers crossfading, the room morphs across each gutter
  *   1  A1     one convolver, hard swap at the gutter midpoint
- *   0  A2     no convolution at all, one shared algorithmic reverb
+ *   0  A2     no convolution at all -- Freeverb (comb + allpass). NOT
+ *              Tone.Reverb, which is itself convolution and would cost more
+ *              than A1 in the seven rooms shorter than its fixed 2.2 s.
  */
 export type AudioTier = 0 | 1 | 2;
 

--- a/lib/scrollStore.ts
+++ b/lib/scrollStore.ts
@@ -2,6 +2,17 @@ import { create } from "zustand";
 
 export type Quality = "high" | "low";
 
+/**
+ * Audio detail tier, the S0.6 ladder's audio rungs. Separate from `quality`
+ * because shedding audio is cheap and inaudible while shedding render targets
+ * is visible, so the two want independent control.
+ *
+ *   2  full   two convolvers crossfading, the room morphs across each gutter
+ *   1  A1     one convolver, hard swap at the gutter midpoint
+ *   0  A2     no convolution at all, one shared algorithmic reverb
+ */
+export type AudioTier = 0 | 1 | 2;
+
 interface ScrollState {
   /** Normalized global scroll progress, the single timeline driver. */
   t: number;
@@ -13,6 +24,7 @@ interface ScrollState {
   pointerX: number;
   pointerY: number;
   quality: Quality;
+  audioTier: AudioTier;
   reducedMotion: boolean;
   audioOn: boolean;
   meowCount: number;
@@ -23,6 +35,7 @@ interface ScrollState {
   setJumpCover: (i: number | null) => void;
   setPointer: (x: number, y: number) => void;
   setQuality: (q: Quality) => void;
+  setAudioTier: (v: AudioTier) => void;
   setReducedMotion: (v: boolean) => void;
   setAudioOn: (v: boolean) => void;
   meow: () => void;
@@ -35,6 +48,7 @@ export const useScrollStore = create<ScrollState>()((set) => ({
   pointerX: 0,
   pointerY: 0,
   quality: "high",
+  audioTier: 2,
   reducedMotion: false,
   audioOn: false,
   meowCount: 0,
@@ -43,7 +57,9 @@ export const useScrollStore = create<ScrollState>()((set) => ({
   setActiveIssue: (activeIssue) => set({ activeIssue }),
   setJumpCover: (jumpCover) => set({ jumpCover }),
   setPointer: (pointerX, pointerY) => set({ pointerX, pointerY }),
-  setQuality: (quality) => set({ quality }),
+  setQuality: (quality) =>
+    set((s) => ({ quality, audioTier: quality === "low" ? 1 : s.audioTier })),
+  setAudioTier: (audioTier) => set({ audioTier }),
   setReducedMotion: (reducedMotion) => set({ reducedMotion }),
   setAudioOn: (audioOn) => set({ audioOn }),
   meow: () => set((s) => ({ meowCount: s.meowCount + 1 })),


### PR DESCRIPTION
Phase 2 of the audio rebuild. **No new sound sources** - this is the mix graph the samples will land in, and it removes the largest structural reason the mix reads flat.

## Before

Every sound on the site shared **one** `Tone.Reverb({decay: 2.2})` at send 0.18. A rainy rooftop, a subway tunnel, and a sketchbook an arm's length from your face were all the same small room. Two buses shared one compressor, so a slam squashed a button click.

## What lands

| file | role |
|---|---|
| `lib/audio/buses.ts` | six named buses (music, ambience, foley, hardfx, ui, sub) into one master chain |
| `lib/audio/ir.ts` | impulse responses rendered client-side; **zero bytes ship** |
| `lib/audio/rooms.ts` | 12 rooms, 0.35s near-anechoic sketchbook to 3.2s cosmos, crossfaded per gutter |

The master chain is unchanged: same EQ3, compressor, limiter, -9 dB ceiling, single fade node. `ui` gets no room send so interface sound stays legible when the room is a tunnel; `sub` gets none because reverberating a sub only smears it.

**Why no IR files:** shipping them would be worse than merely big. Lossy codecs introduce pre-echo, and pre-echo *inside* an impulse response smears the attack of every sound convolved with it.

**Cosmos ships zero early-reflection taps, deliberately.** Early reflections are what tell the ear a wall exists; without them, plus a long pre-delay, it reads as "no room, infinite space" rather than "very big room".

## The `fx.audioPulse` contract is preserved by construction

The old graph metered `music` **pre-duck** on purpose - *"a duck must not move a visual."* Splitting the beds across music+ambience would have shown the analyser half the bed energy, so a `pulseBus` sums both back together and feeds the meter alone: same total, still pre-duck, still excluding every sfx bus. `director.ts`'s write and `PostPipeline`'s read of `uAudioPulse` are untouched.

## Scrub-safety, measured

Slot assignment is **by parity** - even issue to slot A, odd to B. Every gutter joins consecutive issues, which always differ in parity, so the two rooms are guaranteed to be in different slots and no gutter ever needs a mid-crossfade reassignment, in either direction.

Verified `roomBlend` across 20,001 samples: **zero** determinism mismatches, **zero** parity collisions, correct at `t<0`, `t=0`, every boundary, `t=1`, `t>1`.

## Three defects found by adversarial verification, all fixed

Ran a verification pass over the invariants (three lenses, every finding double-refuted before counting). It found things reading the code would not have:

**1. The IR "noise" was not noise.** `h01` is Knuth multiplicative - `Math.imul(n, K)` - which is **linear** in `n`, so `hash(n+1) - hash(n)` is a constant. Fine over the step indices it was written for (a `Stepper` tick every ~100ms); over *consecutive sample* indices it degenerates into a Weyl sawtooth.

```
before   2 distinct successive deltas | autocorr 0.98 @ lag144 | dominant bin 18334 Hz
after  199 distinct successive deltas | autocorr 0.008 @ lag144 | no dominant bin
```

Every room would have been a decaying near-ultrasonic whistle. Added `mix32`/`noise01` (murmur3 finalizer, still deterministic, still no `Math.random`) and documented the trap where `h01` lives.

**2. Tone's `Convolver.buffer` setter defeats `normalize: false`.** From `node_modules/tone/.../Convolver.js`: the setter creates a **new** `ConvolverNode` whenever the old one already had a buffer, and a fresh node defaults `normalize = true`. So the constructor option only held for the first assignment; every room swap after that silently re-enabled equal-power normalisation and undid the fixed-RMS level control. Now re-asserted after every set.

**3. A failed IR render froze the rooms instead of degrading.** The catch latched `disabled = true`, and the `updateRooms` guard then short-circuited every later frame - leaving whatever was audible convolving forever, one scene's room welded onto every following scene with the fallback layered *on top*. Since `disposeRooms` has no call sites and `buildRooms` runs once per page load, that state survived a full disable/enable cycle. Slots are now zeroed and detached before the latch.

I also caught one myself mid-write: the buffer-swap gate tested the *target* gain, not the actual one, so it would have swapped a convolver buffer while the gain was still ramping - rebuilding the FFT partition table on an audible node.

## Perf

Convolver inputs are disconnected when idle, because a `ConvolverNode` runs its FFT whenever its input is connected regardless of downstream gain. Steady state is one convolver; only gutters pay two.

**S0.6 audio rung A1:** `audioTier` (0|1|2) added to `scrollStore`, defaulted to 1 by `setQuality("low")` so tablets get it. Below the full tier the room stops morphing and hard-swaps at the gutter midpoint, so only one convolver is ever audible - halving convolution cost exactly where it would otherwise double, at the one place a hard room change is masked anyway.

## Honest gaps

- No runnable check for the whiteness property. This repo has no test runner, and `lib/audio` is TypeScript a plain node script cannot import, so a bespoke harness for one function would cost more than it protects. The measured numbers live in the `util.ts` comment instead.
- Not yet listened to on hardware. `typecheck` and `build` pass and the invariants are verified structurally, but the rooms want an ear.

Generated with [Claude Code](https://claude.com/claude-code)