### PR TITLE
Sample bank and one-shot player

### DIFF
--- a/lib/audio/bank.ts
+++ b/lib/audio/bank.ts
@@ -1,0 +1,107 @@
+import { AUDIO, type AudioName } from "./manifest";
+import type { ToneModule } from "./types";
+
+/**
+ * Sample bank: fetch, decode, keep.
+ *
+ * Deliberately loads the WHOLE manifest on first enable rather than windowing
+ * per scene. The engine plan called for a lazy `activeIssue +/- 1` window with
+ * eviction, and that is the right shape once the beds land -- twelve stereo
+ * ambience loops is where decoded memory starts to matter. Today the entire
+ * manifest is ~1.1 MB encoded, so windowing would be scheduling machinery, a
+ * cache-miss path and an eviction policy in service of a problem that does not
+ * exist. The decoded-byte accounting below is here so the moment it does start
+ * to matter is measurable rather than guessed at.
+ *
+ * Nothing here blocks: a hit whose buffer has not arrived returns false and the
+ * caller falls through to its synth path, so the site is audible from the first
+ * frame after enable and quietly gets better as buffers land.
+ *
+ * Failure is isolated. A dead network degrades to the synth soundscape with one
+ * warning; it must never reach the director's rAF catch, which disables all
+ * audio site-wide.
+ */
+
+/** Concurrent fetches. Enough to saturate a connection, few enough to be polite. */
+const CONCURRENCY = 4;
+
+const buffers = new Map<string, AudioBuffer>();
+const failed = new Set<string>();
+let started = false;
+let warned = false;
+let decoded = 0;
+
+const key = (name: string, variant: number) => `${name}:${variant}`;
+
+function warn(e: unknown): void {
+  if (warned) return;
+  warned = true;
+  // Its OWN warn latch, not the director's -- a missing asset must not consume
+  // the one warning slot reserved for an engine failure.
+  console.warn("[audio] sample bank degraded, falling back to synthesis:", e);
+}
+
+/**
+ * Every (slot, variant) pair in the manifest, flattened.
+ * UI first: it is the smallest category and the first thing a visitor hears,
+ * since enabling sound plays a toggle chime.
+ */
+function loadOrder(): { name: string; variant: number; path: string }[] {
+  const out: { name: string; variant: number; path: string }[] = [];
+  const entries = Object.entries(AUDIO) as [string, (typeof AUDIO)[AudioName]][];
+  const rank = (cat: string) => (cat === "ui" ? 0 : cat === "fol" ? 1 : cat === "imp" ? 2 : 3);
+  entries.sort((a, b) => rank(a[1].cat) - rank(b[1].cat));
+  for (const [name, slot] of entries) {
+    slot.v.forEach((v, i) => out.push({ name, variant: i, path: v.path }));
+  }
+  return out;
+}
+
+/** Idempotent; safe to call on every enable. */
+export function loadBank(T: ToneModule): void {
+  if (started) return;
+  started = true;
+
+  const queue = loadOrder();
+  let next = 0;
+
+  const worker = async (): Promise<void> => {
+    for (;;) {
+      const item = queue[next++];
+      if (!item) return;
+      const k = key(item.name, item.variant);
+      if (buffers.has(k) || failed.has(k)) continue;
+      try {
+        const res = await fetch(item.path, { cache: "force-cache" });
+        if (!res.ok) throw new Error(`${res.status} ${item.path}`);
+        const buf = await T.getContext().decodeAudioData(await res.arrayBuffer());
+        buffers.set(k, buf);
+        // decodeAudioData resamples to the context rate, so decoded size is
+        // independent of the source bitrate -- only duration and channel count
+        // move this number.
+        decoded += 4 * buf.numberOfChannels * buf.length;
+      } catch (e) {
+        failed.add(k);
+        warn(e);
+      }
+    }
+  };
+
+  // Fire and forget, with its own catch. Started OUTSIDE the rAF so a rejection
+  // can never surface inside the director's frame-loop try block.
+  void Promise.all(Array.from({ length: CONCURRENCY }, worker)).catch(warn);
+}
+
+/** The decoded buffer, or null if it has not arrived or will not. */
+export function sample(name: AudioName, variant: number): AudioBuffer | null {
+  return buffers.get(key(name, variant)) ?? null;
+}
+
+/** Decoded bytes resident. The number to watch when beds land. */
+export function bankBytes(): number {
+  return decoded;
+}
+
+export function bankStats(): { ready: number; failed: number; total: number } {
+  return { ready: buffers.size, failed: failed.size, total: loadOrder().length };
+}

--- a/lib/audio/director.ts
+++ b/lib/audio/director.ts
@@ -7,6 +7,8 @@ import { RANGES } from "@/issues/timeline";
 import { audioRecipes, type AudioRecipe, type ToneModule } from "./types";
 import { buildBuses, type Buses } from "./buses";
 import { buildRooms, updateRooms } from "./rooms";
+import { loadBank } from "./bank";
+import { buildOneshot, stopOneshots } from "./oneshot";
 import { scoreTransitions, stopTransitions } from "./transitions";
 import { scoreMoments, beatMoment, stopMoments } from "./moments";
 import { wireUi, uiSound } from "./ui";
@@ -129,6 +131,7 @@ export function disableAudio(): void {
       try {
         stopTransitions();
         stopMoments();
+        stopOneshots();
       } catch (e) {
         warn(e);
       }
@@ -141,6 +144,10 @@ export function disableAudio(): void {
 function buildMaster(T: ToneModule): Master {
   const B = buildBuses(T);
   buildRooms(B);
+  // Sample layer. loadBank is fire-and-forget: every hit() falls through to
+  // its synth voice until the buffer lands, so nothing waits on the network.
+  buildOneshot(T, B, useScrollStore.getState().quality === "low");
+  loadBank(T);
 
   const thump = new T.MembraneSynth({
     pitchDecay: 0.08,

--- a/lib/audio/moments.ts
+++ b/lib/audio/moments.ts
@@ -15,6 +15,7 @@ import { clamp01 } from "@/lib/shots";
 import { useScrollStore } from "@/lib/scrollStore";
 import { RANGES } from "@/issues/timeline";
 import type { ToneAudioNode } from "tone";
+import { hit } from "./oneshot";
 import type { ToneModule } from "./types";
 import { h01, hash, moveTo } from "./util";
 import { fireMeowVoice } from "./ui";
@@ -1229,15 +1230,22 @@ export function beatMoment(id: string, flash: number): boolean {
       return true;
     }
     case "press-stamp": {
+      // The money moment. Layered sample plus the synth sub underneath it: the
+      // baked slam carries transient, body and debris, the membrane still
+      // supplies weight below where a small speaker gives up.
+      const sampled = hit("imp.press-slam", { seed: 5, at: now, gain: v });
       // stampMembrane is shared with terminal-back-cover -> gate its start
-      k.stampMembrane.triggerAttackRelease("G0", 0.5, stampGate.at(now, 0.5), v);
-      k.stampMetal.triggerAttackRelease(0.12, now, 0.8 * v);
-      k.stampPaperLp.frequency.rampTo(1200, 0.02, now);
-      k.stampPaper.triggerAttackRelease(0.12, now, 0.6);
-      k.stampMetal.triggerAttackRelease(0.1, now + 0.07, 0.4); // rebound tick
+      k.stampMembrane.triggerAttackRelease("G0", 0.5, stampGate.at(now, 0.5), sampled ? v * 0.55 : v);
+      if (!sampled) {
+        k.stampMetal.triggerAttackRelease(0.12, now, 0.8 * v);
+        k.stampPaperLp.frequency.rampTo(1200, 0.02, now);
+        k.stampPaper.triggerAttackRelease(0.12, now, 0.6);
+        k.stampMetal.triggerAttackRelease(0.1, now + 0.07, 0.4); // rebound tick
+      }
       return true;
     }
     case "press-clank": {
+      if (hit("imp.press-clank", { seed: Math.round(now * 97), at: now })) return true;
       k.clankNoise.triggerAttackRelease(0.12, now, 0.7);
       k.clankThock.triggerAttackRelease(90, 0.15, now, 0.7);
       return true;

--- a/lib/audio/oneshot.ts
+++ b/lib/audio/oneshot.ts
@@ -1,0 +1,189 @@
+import type { Gain, Panner, ToneAudioNode, ToneBufferSource } from "tone";
+import type { Buses, BusName } from "./buses";
+import { AUDIO, type AudioName } from "./manifest";
+import { sample } from "./bank";
+import { hash, h01 } from "./util";
+import type { ToneModule } from "./types";
+
+/**
+ * The one-shot player. One entry point, `hit(name, opts)`.
+ *
+ * Returns FALSE when it cannot play -- buffer not loaded, slot missing, voice
+ * stolen, min-gap refused. That return value is the contract: every call site
+ * uses it to fall through to its existing synth voice, so a cold bank or a dead
+ * network is inaudible rather than silent.
+ *
+ * A note on why this deletes a whole class of crash: the single largest failure
+ * mode in this engine is non-monotonic synth start times. `VoiceGate` is
+ * copy-pasted in three files, plus `wheelFree` and `beatFree`, all guarding
+ * against Tone throwing a RangeError that the director's catch turns into a
+ * GLOBAL audio disable. A fresh ToneBufferSource has no such constraint -- two
+ * hits at the same timestamp are simply two sources. Everything migrated onto
+ * this path stops needing a gate.
+ */
+
+export interface HitOpts {
+  /** deterministic variant + jitter; the SAME seed always gives the same hit */
+  seed?: number;
+  bus?: BusName;
+  /** linear multiplier on the slot's authored gain */
+  gain?: number;
+  pan?: number;
+  /** extra playbackRate multiplier, for doppler */
+  rate?: number;
+  /** room send override, linear */
+  send?: number;
+  /** explicit Tone time; defaults to now */
+  at?: number;
+}
+
+interface Slot {
+  gain: Gain;
+  panner: Panner;
+  send: Gain;
+  src: ToneBufferSource | null;
+  busy: boolean;
+  /** Tone time this slot frees up */
+  endsAt: number;
+  prio: number;
+}
+
+/**
+ * Partitioned so a paw-storm can never starve a slam. Sized for the busiest
+ * plausible frame rather than the worst imaginable one; over cap, the mixer
+ * drops rather than mudding, which is what a real mix does.
+ */
+const PARTITIONS: Record<string, number> = { foley: 10, hardfx: 6, ui: 4, sub: 4 };
+const PARTITION_LOW: Record<string, number> = { foley: 5, hardfx: 3, ui: 2, sub: 2 };
+
+/** Priority by category: what survives when a partition is full. */
+const PRIO: Record<string, number> = { ui: 3, imp: 3, cin: 2, amb: 1, mus: 1, fol: 0 };
+
+const pools = new Map<string, Slot[]>();
+let mod: ToneModule | null = null;
+let B: Buses | null = null;
+/** Per-slot last fire time, so a repeated trigger cannot machine-gun. */
+const lastFire = new Map<string, number>();
+
+const MIN_GAP_S = 0.02;
+
+export function buildOneshot(T: ToneModule, buses: Buses, low: boolean): void {
+  mod = T;
+  B = buses;
+  pools.clear();
+  const sizes = low ? PARTITION_LOW : PARTITIONS;
+  for (const [busName, count] of Object.entries(sizes)) {
+    const dest = buses.in[busName as BusName];
+    const slots: Slot[] = [];
+    for (let i = 0; i < count; i++) {
+      // Built ONCE. A hit allocates exactly one ToneBufferSource -- unavoidable,
+      // since AudioBufferSourceNode is single-use by spec -- and mutates pooled
+      // params. Nothing else allocates, and nothing allocates on a frame where
+      // nothing fires.
+      const send = new T.Gain(0).connect(buses.roomIn);
+      const panner = new T.Panner(0).connect(dest);
+      panner.connect(send);
+      const gain = new T.Gain(1).connect(panner);
+      slots.push({ gain, panner, send, src: null, busy: false, endsAt: 0, prio: -1 });
+    }
+    pools.set(busName, slots);
+  }
+}
+
+function claim(busName: string, prio: number, now: number): Slot | null {
+  const slots = pools.get(busName);
+  if (!slots) return null;
+  let victim: Slot | null = null;
+  for (const s of slots) {
+    if (!s.busy || s.endsAt <= now) {
+      s.busy = false;
+      return s;
+    }
+    // steal the lowest priority, tie-broken on whichever finishes soonest
+    if (!victim || s.prio < victim.prio || (s.prio === victim.prio && s.endsAt < victim.endsAt)) {
+      victim = s;
+    }
+  }
+  if (!victim || victim.prio > prio) return null; // drop, do not mud
+  return victim;
+}
+
+export function hit(name: AudioName, o: HitOpts = {}): boolean {
+  const T = mod;
+  if (!T || !B) return false;
+  const slot = AUDIO[name];
+  if (!slot) return false;
+
+  const seed = o.seed ?? 0;
+  const h = hash(seed);
+  // Deterministic round robin. No Math.random anywhere (engine law), so the
+  // same scroll position always produces the same hit -- which is what keeps
+  // scrubbing reproducible.
+  const variant = slot.v.length > 0 ? h % slot.v.length : 0;
+  const buf = sample(name, variant);
+  if (!buf) return false;
+
+  const now = o.at ?? T.now();
+  const gapKey = `${name}`;
+  const last = lastFire.get(gapKey) ?? -1;
+  if (now - last < MIN_GAP_S) return false;
+
+  const busName = o.bus ?? slot.bus;
+  const s = claim(busName, PRIO[slot.cat] ?? 1, now);
+  if (!s) return false;
+
+  // Jitter, both hashed. Gain jitter is always DOWNWARD so a hit can never
+  // exceed its authored level and blow the loudness budget the bake set.
+  const rate = (1 + (h01(seed * 7 + 1) - 0.5) * 0.05) * (o.rate ?? 1);
+  const jitter = 1 - h01(seed * 13 + 3) * 0.2;
+  const level = Math.pow(10, slot.gain / 20) * jitter * (o.gain ?? 1);
+  const send = o.send ?? Math.pow(10, slot.send / 20);
+
+  try {
+    s.gain.gain.setValueAtTime(level, now);
+    s.panner.pan.setValueAtTime(o.pan ?? 0, now);
+    s.send.gain.setValueAtTime(send, now);
+
+    const src = new T.ToneBufferSource(buf).connect(s.gain);
+    src.playbackRate.value = rate;
+    src.start(now);
+    s.src = src;
+    s.busy = true;
+    s.prio = PRIO[slot.cat] ?? 1;
+    s.endsAt = now + slot.v[variant]!.dur / rate;
+    lastFire.set(gapKey, now);
+    // Tone disposes the source on ended; releasing the slot here keeps the pool
+    // honest even if that callback is late.
+    src.onended = () => {
+      s.busy = false;
+      s.src = null;
+    };
+    return true;
+  } catch {
+    // Never throw toward the director's rAF catch, which would disable all
+    // audio site-wide. A failed hit is just a hit that did not happen.
+    s.busy = false;
+    return false;
+  }
+}
+
+/** Stop everything and free the pool's sources. Used on disable. */
+export function stopOneshots(): void {
+  for (const slots of pools.values()) {
+    for (const s of slots) {
+      try {
+        s.src?.stop();
+      } catch {
+        // already stopped
+      }
+      s.src = null;
+      s.busy = false;
+    }
+  }
+  lastFire.clear();
+}
+
+/** Bus input for anything that wants to route around the pool. */
+export function busOf(name: BusName): ToneAudioNode | null {
+  return B ? B.in[name] : null;
+}

--- a/lib/audio/ui.ts
+++ b/lib/audio/ui.ts
@@ -2,6 +2,7 @@ import type { Filter, FMSynth, Gain, MembraneSynth, Noise, NoiseSynth, Synth } f
 import { useScrollStore } from "@/lib/scrollStore";
 import { logFire } from "./debug";
 import type { ToneAudioNode } from "tone";
+import { hit } from "./oneshot";
 import type { ToneModule } from "./types";
 import { hash } from "./util";
 
@@ -230,6 +231,9 @@ export function uiSound(kind: UiKind, seed = 0): void {
       break;
     }
     case "key": {
+      // Sample first, synth as the fallback. hit() returns false until the bank
+      // lands, so typing is audible from the first frame and quietly improves.
+      if (hit("ui.key", { seed, at: now })) break;
       // organic mechanical click; deterministic per-position jitter
       p.uiTick.triggerAttackRelease(1400 + (hash(seed) % 120), 0.008, now, 0.6);
       break;


### PR DESCRIPTION
Phase 3. The baked assets start actually playing.

**Stacked on #59** (`audio-buses-rooms`), which owns the buses this routes into. Base is set to that branch, so this diff shows only Phase 3.

## `lib/audio/bank.ts`

`fetch` + `decodeAudioData`, fire-and-forget on enable.

**Deliberately loads the whole manifest rather than windowing per scene.** The engine plan called for a lazy `activeIssue +/- 1` window with eviction, and that is the right shape once twelve stereo ambience beds land. Today the entire manifest is **~1.1 MB encoded**, so a window would be scheduling machinery, a cache-miss path and an eviction policy in service of a problem that does not exist yet. Decoded-byte accounting is in place so the moment it *does* start to matter is measurable rather than guessed at.

## `lib/audio/oneshot.ts`

One entry point, `hit(name, opts)`, over pooled channel strips - foley 10 / hardfx 6 / ui 4 / sub 4, halved on the low tier.

- Deterministic round robin from `hash(seed)`; rate and gain jitter from `h01`. **Gain jitter is always downward**, so a hit can never exceed the level the bake authored and blow the loudness budget.
- Voice stealing takes the lowest priority, tie-broken on earliest end, and **drops rather than mudding** when a partition is full of higher-priority voices.
- One `ToneBufferSource` allocated per *hit* - unavoidable, `AudioBufferSourceNode` is single-use by spec. Everything else is pooled, and nothing allocates on a frame where nothing fires.

**`hit()` returning `false` is the contract, not an error path.** Every call site falls through to its existing synth voice, so a cold bank or a dead network is *inaudible* rather than silent, and the site is fully audible from the first frame after enable while buffers land behind it.

## This deletes a crash class rather than adding one

The single largest failure mode in this engine is non-monotonic synth start times. `VoiceGate` is copy-pasted in three files, plus `wheelFree` and `beatFree` - all guarding a Tone `RangeError` that the director's catch turns into a **global audio disable**. A fresh `ToneBufferSource` has no such constraint: two hits at the same timestamp are simply two sources. Everything migrated onto this path stops needing a gate.

## Wired into three call sites

Sample-first, synth as fallback:

| slot | why |
|---|---|
| `ui.key` | the most-heard sound on the site, and the one the audition showed as an 8 ms bare square |
| `imp.press-slam` | layered **under** the existing membrane, not replacing it - the baked slam carries transient, body and debris, the membrane still supplies weight below where a small speaker gives up (dropped to 0.55 when the sample lands) |
| `imp.press-clank` | straight replacement |

## Failure isolation

`bank.ts` keeps its **own** warn latch, so a missing asset cannot consume the single warning slot reserved for an engine failure. Every async path is started outside the rAF with its own catch, because the director's frame-loop catch calls `disableAudio()` site-wide.

## Verification

`npm run typecheck` and `npm run build` pass; source pure ASCII; assets confirmed present in the static export (`out/audio`, 1.2 MB) so the manifest paths resolve.

Still unheard on hardware - same honest gap as #59, and it applies to the same listen.

Generated with [Claude Code](https://claude.com/claude-code)
