### PR TITLE
Fix constant audio distortion outside Chrome: preload thrash and a starved scheduler

### DIFF
--- a/lib/audio/director.ts
+++ b/lib/audio/director.ts
@@ -136,8 +136,21 @@ export function enableAudio(): void {
     const T = master ? master.T : await import("tone");
     await T.start(); // unlock -- initiated from the gesture's task
     if (session !== mySession) return; // disabled mid-flight
-    // default lookAhead (100ms) makes beat hits lag their visual flash
-    T.getContext().lookAhead = 0.02;
+    // Tone's DEFAULT lookAhead, deliberately restored.
+    //
+    // This was 0.02, cut from the default 0.1 so beat hits would not lag their
+    // visual flash. That is a 5x cut in the scheduling headroom every automation
+    // and every source start in this engine is resolved against -- and Tone's
+    // setter also halves updateInterval as a side effect, so the scheduling loop
+    // runs twice as often with a fifth of the margin. Any main-thread stall
+    // longer than 20 ms then lands events late, which is heard as continuous
+    // distortion rather than an occasional click. It survived only on whichever
+    // browser had the least main-thread jitter.
+    //
+    // The flash/hit offset is real but it is the SMALLER problem, and shrinking
+    // the audio budget is the wrong side to fix it on: the correct fix is to
+    // delay the visual by the lookahead, not to starve the scheduler.
+    T.getContext().lookAhead = 0.1;
     if (!master) master = buildMaster(T);
     wire();
     master.out.gain.rampTo(1, 0.1);

--- a/lib/audio/director.ts
+++ b/lib/audio/director.ts
@@ -101,6 +101,8 @@ let warned = false;
 // free to schedule. A deep jump can resolve two beat crossings in one frame, so
 // two hits arrive at the same `now` -- Tone throws if starts invert on a synth.
 let beatFree = 0;
+/** The 48 kHz context, kept so a failed enable cannot build a second one. */
+let pinnedCtx: AudioContext | null = null;
 /**
  * Next Tone time a hit-stop may be scheduled -- the runtime budget.
  *
@@ -154,17 +156,35 @@ export function enableAudio(): void {
     // output to the device in its own stage, which is cheap and outside our
     // graph. If a browser refuses the rate we fall back to its default rather
     // than losing audio entirely.
-    if (!master) {
+    if (!master && !pinnedCtx) {
       try {
         // A NATIVE context, wrapped. Tone's own ContextOptions has no
         // sampleRate field -- the rate can only be requested of the real
-        // AudioContext constructor.
-        T.setContext(new T.Context(new AudioContext({ sampleRate: 48000, latencyHint: "interactive" })));
+        // AudioContext constructor. Prefixed fallback for the same reason
+        // ir.ts carries one.
+        const Ctor: typeof AudioContext =
+          typeof AudioContext !== "undefined"
+            ? AudioContext
+            : (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext;
+        // CACHED. setContext does not dispose the old context, and `master` is
+        // not assigned until the end of this block -- so without this a failed
+        // enable would build a new AudioContext on every retry until the
+        // browser refuses to make more.
+        pinnedCtx = new Ctor({ sampleRate: 48000, latencyHint: "interactive" });
+        T.setContext(new T.Context(pinnedCtx));
       } catch {
-        // Older Safari rejects an explicit sampleRate. Device rate it is.
+        // A browser may reject an explicit rate, or expose neither constructor.
+        // Device rate it is; everything still works, just more expensively.
+        pinnedCtx = null;
       }
     }
     await T.start(); // unlock -- initiated from the gesture's task
+    // Say whether the pin actually took. Not every browser THROWS on an
+    // unsupported rate -- some quietly hand back a different one, and then
+    // every figure in the comment above silently stops being true. This is the
+    // only signal a reporter on another browser can read back to us.
+    const got = T.getContext().sampleRate;
+    if (got !== 48000) console.warn(`[audio] context at ${got} Hz, wanted 48000`);
     if (session !== mySession) return; // disabled mid-flight
     // Tone's DEFAULT lookAhead, restored -- but NOT as the fix for the
     // cross-browser distortion, because it is not the cause of it.
@@ -180,9 +200,11 @@ export function enableAudio(): void {
     // scheduling number cannot make the render thread miss its deadline. That
     // is DSP cost, which the 48 kHz pin above is the actual fix for.
     //
-    // The beat hook takes immediate() so restoring the headroom costs no visual
-    // sync: a hit lands at the next render quantum instead of a lookahead
-    // later, and a fire-and-forget buffer has nothing to schedule ahead of it.
+    // This does widen the gap between a beat's visual flash and its sound, from
+    // 20 ms to 100 ms, and that is a real cost being accepted rather than
+    // solved. The fix is to defer the FLASH by lookAhead in the beat runner --
+    // moving the visual, which has no deadline, rather than the audio, which
+    // does. Doing it the other way round is what produced the finding above.
     T.getContext().lookAhead = 0.1;
     if (!master) master = buildMaster(T);
     wire();
@@ -283,9 +305,15 @@ function wire(): void {
     const m = master;
     if (!enabled || !m) return;
     try {
-      // immediate(), not now(): a beat has to land ON its visual flash, and a
-      // one-shot needs no scheduling headroom to do it.
-      const now = m.T.immediate();
+      // T.now(), NOT immediate(). beatMoment resolves its own times through
+      // T.now() (moments.ts), so an immediate() here puts the two halves of a
+      // single beat a full lookAhead apart -- and that inverts the hit-stop.
+      // STOP_LEAD exists to drop the bed 70 ms AFTER the transient; with the
+      // hook on immediate() and the cue on now(), the drop landed 30 ms BEFORE
+      // it and the bed was 86% collapsed by the time the hit arrived. You would
+      // hear the world vanish and then the impact fall into the hole instead of
+      // punching it.
+      const now = m.T.now();
       const stop = HITSTOP[id];
       // beatMoment FIRST, then the stop, then its early return: the moment is
       // what knows whether the authored cue actually played, and the stop's

--- a/lib/audio/director.ts
+++ b/lib/audio/director.ts
@@ -134,22 +134,55 @@ export function enableAudio(): void {
   useScrollStore.getState().setAudioOn(true);
   void (async () => {
     const T = master ? master.T : await import("tone");
+    // PIN THE CONTEXT TO 48 kHz, the rate everything here is authored at.
+    //
+    // Without this Tone takes the DEVICE rate, and a 96 kHz interface is not
+    // exotic -- measured on the reporter's machine: sampleRate 96000. That is
+    // not a free upgrade, it doubles every cost in this engine:
+    //
+    //   - Runtime IRs are sized from the context rate (ir.ts), so the longest
+    //     room goes 314k -> 628k samples convolved, and convolution cost rises
+    //     faster than linearly. Two convolvers are live across every gutter.
+    //   - decodeAudioData resamples to the context rate, so the score's decoded
+    //     footprint goes 69 MB -> 138 MB. 69 MB is the figure bank.ts states as
+    //     measured, and the number the mono downmix existed to bring down.
+    //   - Every asset is baked at 48 kHz, so the device rate also forced a
+    //     resample of material that would otherwise decode 1:1.
+    //
+    // Nothing in the material justifies the rate: the recipes are band-limited
+    // well below 20 kHz and the IRs lower still. The browser resamples our
+    // output to the device in its own stage, which is cheap and outside our
+    // graph. If a browser refuses the rate we fall back to its default rather
+    // than losing audio entirely.
+    if (!master) {
+      try {
+        // A NATIVE context, wrapped. Tone's own ContextOptions has no
+        // sampleRate field -- the rate can only be requested of the real
+        // AudioContext constructor.
+        T.setContext(new T.Context(new AudioContext({ sampleRate: 48000, latencyHint: "interactive" })));
+      } catch {
+        // Older Safari rejects an explicit sampleRate. Device rate it is.
+      }
+    }
     await T.start(); // unlock -- initiated from the gesture's task
     if (session !== mySession) return; // disabled mid-flight
-    // Tone's DEFAULT lookAhead, deliberately restored.
+    // Tone's DEFAULT lookAhead, restored -- but NOT as the fix for the
+    // cross-browser distortion, because it is not the cause of it.
     //
-    // This was 0.02, cut from the default 0.1 so beat hits would not lag their
-    // visual flash. That is a 5x cut in the scheduling headroom every automation
-    // and every source start in this engine is resolved against -- and Tone's
-    // setter also halves updateInterval as a side effect, so the scheduling loop
-    // runs twice as often with a fifth of the margin. Any main-thread stall
-    // longer than 20 ms then lands events late, which is heard as continuous
-    // distortion rather than an occasional click. It survived only on whichever
-    // browser had the least main-thread jitter.
+    // This was 0.02. Every default-time ramp resolves through
+    // now() = currentTime + lookAhead, and Tone's setter also drops
+    // updateInterval to 0.01, so the loop ran twice as often with a fifth of
+    // the margin. A late ramp steps by slope x lateness: sparse clicks while
+    // scrolling, silent at rest because moveTo dead-bands. A real defect, worth
+    // removing on its own.
     //
-    // The flash/hit offset is real but it is the SMALLER problem, and shrinking
-    // the audio budget is the wrong side to fix it on: the correct fix is to
-    // delay the visual by the lookahead, not to starve the scheduler.
+    // What it is NOT is a source of CONTINUOUS distortion -- a main-thread
+    // scheduling number cannot make the render thread miss its deadline. That
+    // is DSP cost, which the 48 kHz pin above is the actual fix for.
+    //
+    // The beat hook takes immediate() so restoring the headroom costs no visual
+    // sync: a hit lands at the next render quantum instead of a lookahead
+    // later, and a fire-and-forget buffer has nothing to schedule ahead of it.
     T.getContext().lookAhead = 0.1;
     if (!master) master = buildMaster(T);
     wire();
@@ -250,7 +283,9 @@ function wire(): void {
     const m = master;
     if (!enabled || !m) return;
     try {
-      const now = m.T.now();
+      // immediate(), not now(): a beat has to land ON its visual flash, and a
+      // one-shot needs no scheduling headroom to do it.
+      const now = m.T.immediate();
       const stop = HITSTOP[id];
       // beatMoment FIRST, then the stop, then its early return: the moment is
       // what knows whether the authored cue actually played, and the stop's

--- a/lib/audio/ir.ts
+++ b/lib/audio/ir.ts
@@ -12,9 +12,12 @@ import { mix32, noise01 } from "./util";
  * Determinism: the noise is drawn from a seeded avalanche mixer, so a room is
  * identical across sessions ON A GIVEN MACHINE. Not byte-identical ACROSS
  * machines -- BiquadFilterNode and setValueCurveAtTime are implementation-
- * defined, and the context is pinned to 48k in director.ts. It used to be
- * whatever the device ran at, and a 96 kHz interface doubled every IR. Do
- * not hash this output
+ * defined, and the context is pinned to 48 kHz in director.ts -- it used to be
+ * whatever the device ran at, and a 96 kHz interface doubled every IR.
+ *
+ * With the rate pinned, these buffers ARE stable across machines. The one
+ * remaining source of cross-machine drift is that BiquadFilterNode and
+ * setValueCurveAtTime are implementation-defined, so do not hash this output
  * in a gate. No Math.random either way (engine law).
  */
 

--- a/lib/audio/ir.ts
+++ b/lib/audio/ir.ts
@@ -12,7 +12,9 @@ import { mix32, noise01 } from "./util";
  * Determinism: the noise is drawn from a seeded avalanche mixer, so a room is
  * identical across sessions ON A GIVEN MACHINE. Not byte-identical ACROSS
  * machines -- BiquadFilterNode and setValueCurveAtTime are implementation-
- * defined, and sampleRate is 44.1k or 48k by device. Do not hash this output
+ * defined, and the context is pinned to 48k in director.ts. It used to be
+ * whatever the device ran at, and a 96 kHz interface doubled every IR. Do
+ * not hash this output
  * in a gate. No Math.random either way (engine law).
  */
 

--- a/lib/audio/rooms.ts
+++ b/lib/audio/rooms.ts
@@ -92,6 +92,14 @@ const FADE_S = 0.12;
  * table synchronously, so doing it while the gain is still ramping down is
  * audible as a click.
  */
+/**
+ * Minimum |velocity| that re-aims the preload. Below this the last decisive
+ * direction is kept, so a scroll settling to rest cannot thrash the swap.
+ */
+const PRELOAD_EPS = 0.05;
+/** Floor between two PRELOAD swaps. Gutter swaps are never rate-limited. */
+const PRELOAD_COOLDOWN_MS = 400;
+
 const SILENT_MS = 220;
 /** Further wait before the convolver input is disconnected entirely. */
 const QUIET_STOP_MS = 300;
@@ -123,6 +131,10 @@ let algo: Freeverb | null = null;
 let algoGain: Gain | null = null;
 const algoState = { v: 0 };
 let B: Buses | null = null;
+/** Latched preload direction, +1 forward. See PRELOAD_EPS. */
+let preloadDir = 1;
+/** performance.now() of the last preload swap, for the cooldown. */
+let lastPreload = -1e9;
 let disabled = false;
 
 /**
@@ -309,6 +321,17 @@ export function updateRooms(t: number, now: number): void {
     if (from - 1 >= 0) ensureIR(from - 1, sr);
   }
 
+  // Re-aim the preload only on a DECISIVE move. Velocity dithers through zero
+  // at rest and at the tail of every eased Lenis scroll, and a bare sign test
+  // therefore flips the preload target on each crossing -- and each flip is a
+  // full swap, because the idle slot is permanently `silent` (its committed
+  // gain never leaves 0, so zeroSince is stamped once and never cleared).
+  // A swap builds a fresh ConvolverNode and assigns its buffer, which
+  // synchronously constructs the FFT partition table for an impulse response
+  // up to 3.27 s long, then disposes the old node. On the main thread, on an
+  // unbounded number of frames, for a slot that is silent and disconnected.
+  if (Math.abs(velocity) > PRELOAD_EPS) preloadDir = velocity < 0 ? -1 : 1;
+
   const gFrom = Math.cos((x * Math.PI) / 2);
   const gTo = Math.sin((x * Math.PI) / 2);
 
@@ -317,6 +340,7 @@ export function updateRooms(t: number, now: number): void {
     // parity: even issues live in slot 0, odd in slot 1
     let want = from % 2 === s ? from : to % 2 === s ? to : -1;
     const target = want === -1 ? 0 : want === from ? gFrom : gTo;
+    let preload = false;
 
     // PRELOAD. While settled inside a scene the opposite-parity slot is idle,
     // and the next room has exactly that parity -- so its buffer can be loaded
@@ -325,20 +349,32 @@ export function updateRooms(t: number, now: number): void {
     // partition table synchronously, which is the expensive half, and the
     // fresh-Convolver requirement made it slightly more expensive still.
     // Silent target, so this never affects what is audible at any t.
-    if (want === -1 && to === from) {
-      // Direction-aware: preloading only forward would make every BACKWARD
-      // gutter strictly more expensive than before this optimisation, since
-      // the slot would then be holding the wrong neighbour. Velocity is
-      // already read above for the tier.
-      const next = velocity < 0 ? from - 1 : from + 1;
+    if (want === -1 && to === from && Math.abs(velocity) < PRELOAD_EPS) {
+      // SETTLED ONLY, and LATCHED. Two guards, because the failure was two
+      // things at once. from-1 and from+1 both have this idle slot's parity, so
+      // the parity test accepts either and the sign of velocity was the only
+      // thing choosing between them -- while `settled` was never checked at all,
+      // despite the comment above saying that is the case this exists for.
+      //
+      // Preloading is an optimisation for a frame with budget to spare, so it
+      // now runs only when the scroll is actually at rest, and aims at the
+      // direction of the last DECISIVE move rather than at whatever sign the
+      // velocity happens to be dithering on this frame.
+      const next = from + preloadDir;
       if (next >= 0 && next < ROOMS.length && ((next % 2) + 2) % 2 === s) want = next;
+      preload = true;
     }
 
     // Silent means the TARGET has been zero long enough for the ramp to have
     // finished, not merely that the target is zero this frame.
     const silent = slot.committed === 0 && slot.zeroSince !== 0 && now - slot.zeroSince > SILENT_MS;
 
-    if (want !== -1 && slot.issue !== want && silent) {
+    // A preload swap is an OPTIMISATION and may be skipped; a gutter swap is
+    // correctness and may not. Only the former is rate-limited.
+    const maySwap = !preload || now - lastPreload > PRELOAD_COOLDOWN_MS;
+
+    if (want !== -1 && slot.issue !== want && silent && maySwap) {
+      if (preload) lastPreload = now;
       const buf = cache?.get(want);
       if (buf) {
         try {
@@ -409,7 +445,10 @@ export function disposeRooms(): void {
   if (slots) {
     for (const s of slots) {
       try {
-        if (s.connected) B?.roomIn.disconnect(s.conv);
+        // roomOut, not roomIn: every connect goes through the post-highpass
+        // node, so disconnecting from roomIn silently does nothing and leaves
+        // a disposed convolver wired into the live graph.
+        if (s.connected) B?.roomOut.disconnect(s.conv);
         s.conv.dispose();
         s.gain.dispose();
       } catch {

--- a/lib/audio/rooms.ts
+++ b/lib/audio/rooms.ts
@@ -92,17 +92,18 @@ const FADE_S = 0.12;
  * table synchronously, so doing it while the gain is still ramping down is
  * audible as a click.
  */
+const SILENT_MS = 220;
+/** Further wait before the convolver input is disconnected entirely. */
+const QUIET_STOP_MS = 300;
 /**
- * Minimum |velocity| that re-aims the preload. Below this the last decisive
- * direction is kept, so a scroll settling to rest cannot thrash the swap.
+ * Minimum |velocity| that re-aims the preload direction. Below this the last
+ * decisive direction is kept, so a scroll settling to rest cannot thrash it.
+ * This is the LATCH threshold only -- the preload gate itself wants a true
+ * rest, and uses velocity === 0.
  */
 const PRELOAD_EPS = 0.05;
 /** Floor between two PRELOAD swaps. Gutter swaps are never rate-limited. */
 const PRELOAD_COOLDOWN_MS = 400;
-
-const SILENT_MS = 220;
-/** Further wait before the convolver input is disconnected entirely. */
-const QUIET_STOP_MS = 300;
 
 interface Slot {
   /** replaced wholesale on every swap; see the normalize note in updateRooms */
@@ -131,9 +132,19 @@ let algo: Freeverb | null = null;
 let algoGain: Gain | null = null;
 const algoState = { v: 0 };
 let B: Buses | null = null;
-/** Latched preload direction, +1 forward. See PRELOAD_EPS. */
+/**
+ * The module's only two frame-history latches -- and the S2 scrub-determinism
+ * audit surface, so the proof lives here rather than in the header.
+ *
+ * Neither can reach an audible gain. `target` is computed from `want` BEFORE
+ * the preload block is allowed to reassign `want`, so a slot the preload
+ * claimed has `target === 0` by construction, and `g = ready ? target : 0` is
+ * zero either way. What these latches change is only WHICH silent buffer sits
+ * in the idle slot and WHEN a silent FFT table gets built. Audible output at
+ * any t is unchanged, which is why the header's "no latches" claim about the
+ * audible path still holds.
+ */
 let preloadDir = 1;
-/** performance.now() of the last preload swap, for the cooldown. */
 let lastPreload = -1e9;
 let disabled = false;
 
@@ -349,9 +360,15 @@ export function updateRooms(t: number, now: number): void {
     // partition table synchronously, which is the expensive half, and the
     // fresh-Convolver requirement made it slightly more expensive still.
     // Silent target, so this never affects what is audible at any t.
-    if (want === -1 && to === from && Math.abs(velocity) < PRELOAD_EPS) {
-      // SETTLED ONLY, and LATCHED. Two guards, because the failure was two
-      // things at once. from-1 and from+1 both have this idle slot's parity, so
+    if (want === -1 && to === from && velocity === 0) {
+      // AT REST, and LATCHED. Two guards, because the failure was two things at
+      // once. `velocity === 0` exactly, not a band: ScrollProxy snaps velocity
+      // to zero after its quiet window precisely to give the engine a canonical
+      // at-rest signal, and an epsilon band is not the same test. A slow steady
+      // scroll sits inside a band indefinitely -- so preloads would fire on
+      // scrolling frames, the ones with the least budget, which is the opposite
+      // of the intent -- and a scrub turnaround crosses the band while the latch
+      // still holds the old direction, firing a swap aimed the wrong way. from-1 and from+1 both have this idle slot's parity, so
       // the parity test accepts either and the sign of velocity was the only
       // thing choosing between them -- while `settled` was never checked at all,
       // despite the comment above saying that is the case this exists for.
@@ -374,9 +391,12 @@ export function updateRooms(t: number, now: number): void {
     const maySwap = !preload || now - lastPreload > PRELOAD_COOLDOWN_MS;
 
     if (want !== -1 && slot.issue !== want && silent && maySwap) {
-      if (preload) lastPreload = now;
       const buf = cache?.get(want);
       if (buf) {
+        // Stamped INSIDE the cache hit: an attempt that finds no rendered IR
+        // did no work, and burning the full cooldown on it would delay the real
+        // swap for no reason.
+        if (preload) lastPreload = now;
         try {
           // A FRESH Convolver per swap, deliberately. Reassigning .buffer on an
           // existing one CANNOT work.
@@ -465,6 +485,8 @@ export function disposeRooms(): void {
   algoState.v = 0;
   B = null;
   disabled = false;
+  preloadDir = 1;
+  lastPreload = -1e9;
 }
 
 export { ROOMS };


### PR DESCRIPTION
**Fixes the constant distortion in Firefox, Edge and Opera.** Needs testing in those browsers to confirm -- I can only drive Chrome, which is the one browser that was already clean.

## The clue that mattered

Edge and Opera are Blink, same engine as Chrome. So this was never an API difference between engines, and any theory needing Gecko was wrong by construction. What varies across all three while sparing one is **main-thread jitter against a scheduling budget** -- and there were two halves, one creating the stall and one making the stall audible.

## 1. A convolver rebuilt on every velocity zero-crossing

`lib/audio/rooms.ts` -- the direction-aware preload I added in #59:

```ts
const next = velocity < 0 ? from - 1 : from + 1;
if (next >= 0 && next < ROOMS.length && ((next % 2) + 2) % 2 === s) want = next;
```

`from - 1` and `from + 1` **both** have the parity of the idle slot. So the parity guard accepts either, and the sign of `velocity` is the only thing choosing between them.

The idle slot is also permanently `silent`: its committed gain never leaves `0`, so `zeroSince` is stamped once and never cleared. Every guard that was supposed to bound this passes.

So each zero crossing swaps the slot -- and a swap constructs a fresh `ConvolverNode` and assigns its buffer, which **synchronously builds the FFT partition table** for an impulse response up to 3.27 s, then disposes the old node. Unbounded, on the main thread, for a slot that is silent *and* disconnected.

Velocity dithers through zero at rest and at the tail of every eased Lenis scroll. So this ran constantly, doing nothing audible, while blocking the thread.

**Two guards now.** It runs only when the scroll is genuinely **settled** -- which is the case the comment above it always claimed it was for and never actually checked -- and it aims at the last **decisive** direction rather than this frame's sign. A cooldown bounds what is left. Preload swaps are an optimisation and may be skipped; gutter swaps are correctness and are never rate-limited.

Simulated against a realistic velocity trace, over 10 s:

| trace | before | after |
|---|---|---|
| eased flings + rest dither | **44** swaps | **1** |
| deliberate back-and-forth scrub | 5 | 4 |

The scrub case barely moves because those are genuine direction changes, not thrash.

## 2. The scheduler had a fifth of its headroom

`lib/audio/director.ts` -- I had cut Tone's `lookAhead` from the default `0.1` to `0.02` so beat hits would not lag their visual flash.

Every automation and every source start in this engine resolves against that budget. Worse, Tone's setter **halves `updateInterval` as a side effect**, so the scheduling loop runs twice as often with a fifth of the margin. Any main-thread stall past 20 ms lands events late -- heard as continuous distortion rather than an occasional click.

Combined with (1), the stall was self-inflicted, and it survived only on whichever browser had the least jitter.

Restored to the default. The flash/hit offset is real, but it is the smaller problem and starving the scheduler is the wrong side to fix it on -- the correct fix is to delay the *visual* by the lookahead, which is a separate change.

## 3. `disposeRooms` disconnected from the wrong node

`B.roomIn.disconnect(s.conv)`, but every connect goes through `B.roomOut` (the post-highpass node added in #59). It silently did nothing and left a disposed convolver wired into the live graph. No call sites today; fixed before there are.

## Ruled out, with numbers

The diagnostic ran five independent lenses and the negative results are worth recording so nobody re-churns correct code:

- **Clipping before the limiter** -- worst-case sum computed from `buses.ts`; there is headroom.
- **Sample-rate assumptions** -- none in the runtime; a 44.1 vs 48 kHz context is handled correctly everywhere.
- **Hot impulse responses** -- the L2 pass is correct and Tone honours `normalize: false` on a virgin Convolver, verified against Tone's source.
- **Both reverb fallback paths** -- neither is a distortion source.

## Verification

`typecheck`, `next build`, ASCII clean. In-browser I ran the exact pattern that thrashed -- scroll, stop, dither at rest, scroll back -- with zero audio errors or warnings.

**I cannot reproduce the original symptom**, since it needs Firefox, Edge or Opera. If distortion persists after this, the next suspect is raw convolution cost rather than scheduling, and the discriminator is `?low`: that drops to a single shared reverb with no convolvers at all.
