### PR TITLE
Make audio rung A2 reachable: ?audio=0|1|2

### DIFF
--- a/components/ExperienceGate.tsx
+++ b/components/ExperienceGate.tsx
@@ -135,6 +135,20 @@ export default function ExperienceGate() {
       const gate = readDeviceGate();
       store.setReducedMotion(gate.reduced);
       if (gate.low) store.setQuality("low");
+      // ?audio=0|1|2 forces an audio rung, for profiling and for answering
+      // "is it convolution cost?" without a local build.
+      //
+      // This exists because ?low alone could not answer it. ?low sets tier 1,
+      // which only stops the room MORPHING -- both convolvers still run, so it
+      // sheds almost none of the DSP that a struggling machine is struggling
+      // with. Tier 0 is the rung that detaches them for a single shared
+      // algorithmic reverb, and until now nothing could reach it:
+      // setAudioTier had no call sites, so rung A2 of the S0.6 ladder was
+      // unreachable in a shipped build.
+      const forcedTier = new URLSearchParams(location.search).get("audio");
+      if (forcedTier === "0" || forcedTier === "1" || forcedTier === "2") {
+        store.setAudioTier(Number(forcedTier) as 0 | 1 | 2);
+      }
       setReduced(gate.reduced);
       setNarrow(gate.narrow);
       // && short-circuits, so the print path still never creates a WebGL context.

--- a/lib/scrollStore.ts
+++ b/lib/scrollStore.ts
@@ -61,7 +61,10 @@ export const useScrollStore = create<ScrollState>()((set) => ({
   setPointer: (pointerX, pointerY) => set({ pointerX, pointerY }),
   setQuality: (quality) =>
     set((s) => ({ quality, audioTier: quality === "low" ? 1 : s.audioTier })),
-  // No call sites yet -- perf-profiler owns the S0.6 ladder and drives this.
+  // Driven by ?audio=0|1|2 (ExperienceGate) and by setQuality's low tier.
+  // There is deliberately NO auto-detector: Web Audio exposes no reliable
+  // glitch counter, and inferring load from rAF dt conflates audio cost with
+  // GPU cost. The rungs are exposed; the S0.6 ladder owns when to drop.
   setAudioTier: (audioTier) => set({ audioTier }),
   setReducedMotion: (reducedMotion) => set({ reducedMotion }),
   setAudioOn: (audioOn) => set({ audioOn }),


### PR DESCRIPTION
**I gave you a diagnostic that does not do what I said it does.** This fixes that.

In #66 I asked you to use `?low` to answer *"is it convolution cost?"*. But `?low` sets `audioTier` **1**, and tier 1 only stops the room from *morphing* across gutters — both convolvers still run. It sheds almost none of the DSP a struggling machine is struggling with, so it could never have discriminated anything.

Tier **0** is the rung that actually detaches them and falls back to a single shared algorithmic reverb. And nothing could reach it: `setAudioTier` had zero call sites, so **rung A2 of the S0.6 ladder was unreachable in a shipped build.**

`?audio=0|1|2` now forces a rung.

| flag | what it sheds |
|---|---|
| `?audio=2` | nothing — full room morph, two convolvers across every gutter |
| `?audio=1` | the morph. Hard swap at the gutter midpoint. Convolvers still running |
| `?audio=0` | **both convolvers detached.** One shared algorithmic reverb |

So the real test is `?audio=0` in Firefox or Edge. If the distortion stops there and not at `?audio=2`, it is convolution cost on the render thread, confirmed.

## Still no auto-detector, deliberately

The store comment used to say `// No call sites yet -- perf-profiler owns the S0.6 ladder and drives this.` — which read like an oversight waiting to be filled in. It now states the actual reason: Web Audio exposes no reliable glitch counter, and inferring load from rAF `dt` conflates audio cost with GPU cost. The rungs are exposed; the ladder owns when to drop.

## Verified

At `?audio=0` in the browser: audio enables, 130 fires across a scroll, zero errors — and **no sample-rate warning**, so the 48 kHz pin from #66 holds on this path too.

`typecheck`, `next build`, ASCII clean.
