### PR TITLE
Tell the crawlers what the canvas cannot

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,45 @@
+# Saeed Kolivand
+
+> Senior Frontend Developer based in Germany, building AI-powered and agentic
+> tools. Portfolio at https://iamsaeed.dev, presented as a scroll-driven comic
+> book (WebGL) with a complete server-rendered text edition underneath.
+
+Stack: React, TypeScript, Next.js, Tauri, Node.js, GraphQL, AI.
+
+The site renders two ways from one source. The animated version is a WebGL
+comic: twelve issues, an original score, a cat. The Print Edition is the same
+run set flat as semantic HTML -- it ships in the initial server response, so
+the full content is readable without JavaScript, WebGL, or motion.
+
+## Work
+
+- [AI Job Hunter](https://aijobhunter.app): Local-first desktop app. Covers 16
+  job boards, writes the cover letters, does everything but hit submit. AI
+  agents, semantic search, local models via Ollama, Tauri backend, React
+  frontend. [Repo](https://github.com/saeedkolivand/ai-job-hunter-app)
+- [AI Engineering Hub](https://github.com/saeedkolivand/ai-engineering-hub):
+  Local-first ops room for the AI toolchain. Swallows metrics from every tool,
+  serves the local API the desktop app and Stream Deck plugins read.
+- [Claude Usage Stream Deck Plugin](https://github.com/saeedkolivand/claude-usage-streamdeck-plugin):
+  Claude session and weekly burn, lit up on a Stream Deck key. JavaScript.
+- [TokenSaver Stream Deck Plugin](https://github.com/saeedkolivand/tokensaver-streamdeck-plugin):
+  Tallies the AI tokens you didn't spend, measured and estimated. JavaScript.
+- [Vocal Remover](https://github.com/saeedkolivand/vocal-remover): Splits the
+  vocals out of a track from the backing instrumental. Python.
+
+## Background
+
+Started on a hand-me-down machine, studied CS, took a first job, then moved to
+Germany. Now Senior Frontend Engineer working on AI and agentic tooling, with
+open source on the side and occasional streaming on Twitch and YouTube.
+
+## Links
+
+- [GitHub](https://github.com/saeedkolivand)
+- [LinkedIn](https://www.linkedin.com/in/saeedkolivand/)
+
+## Optional
+
+- Contact: the email address is assembled at runtime on the site rather than
+  written into any static file, including this one. Use the contact affordance
+  on https://iamsaeed.dev or reach out via LinkedIn.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,6 @@
+User-agent: *
+Allow: /
+
+# The site is one page. The full text lives in the Print Edition, which is
+# server-rendered on first paint -- no JS or WebGL needed to read it.
+# Curated summary for language models: /llms.txt


### PR DESCRIPTION
Two static files in `public/`. `output: "export"` copies them to `out/` verbatim, so there is no config change and no build step.

**`robots.txt`** — there wasn't one. Read by every real crawler (Googlebot, GPTBot, ClaudeBot). Allows everything and points at `llms.txt`.

**`llms.txt`** — the [llmstxt.org](https://llmstxt.org) convention: a curated markdown summary for language models. Honest about its value: no major AI crawler officially honors it yet, and the site already server-renders the full Print Edition on first paint, so a crawler was never staring at an empty canvas. This is cheap insurance, not a fix for a broken thing.

Content traces to `lib/content.ts` — no invented biography. The email is deliberately absent: it assembles at runtime as anti-scrape (`lib/content.ts:26`), and writing it into a static text file would hand it straight back to the scrapers.

**Not included:** a sitemap. One URL, Google finds the root regardless. Worth adding when a second route exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
