### PR TITLE
The panel that never made it to print

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,4 +1,5 @@
-import { lettering, notFound } from "@/lib/content";
+import type { Metadata } from "next";
+import { notFound } from "@/lib/content";
 import styles from "@/components/PrintEdition.module.css";
 
 /*
@@ -17,6 +18,15 @@ import styles from "@/components/PrintEdition.module.css";
  * URL -- reading it needs "use client" + an effect to dodge the hydration
  * mismatch. Swap in usePathname() if the exact path ever has to be shown.
  */
+// Verified against the emitted out/404.html: `not-found.tsx` DOES honour a
+// metadata export under `output: export` (PR #76 review, finding 3). No robots
+// field -- Next already injects `<meta name="robots" content="noindex">` here,
+// and setting it again only emits a second, duplicate tag.
+export const metadata: Metadata = {
+  title: notFound.metaTitle,
+  description: notFound.dek,
+};
+
 export default function NotFound() {
   return (
     <div className={styles.root}>
@@ -37,31 +47,29 @@ export default function NotFound() {
             where the caption would be, and the sound of it hitting the floor. */}
         <div className={styles.donationAlert}>
           <span className={styles.hand}>{notFound.gutterNote}</span>
-          <p className={styles.boom}>{lettering.onomatopoeia.impact[2]}</p>
+          <p className={styles.boom}>{notFound.boom}</p>
         </div>
 
+        {/* One exchange, not two: the letters page prints bare commands, so a
+            request line and a command line stacked as sibling prompts read as
+            an inconsistency rather than a joke (PR #76 review, finding 4). */}
         <dl className={styles.terminal}>
           <div>
             <dt>{notFound.terminal.request}</dt>
             <dd>{notFound.terminal.response}</dd>
           </div>
-          <div>
-            <dt>{notFound.terminal.suggestion}</dt>
-            <dd>{notFound.terminal.suggestionBody}</dd>
-          </div>
         </dl>
 
+        {/*
+         * One exit, deliberately. Deep links like /#projects are dead on the
+         * experience path: when ExperienceGate mounts the 3D stack it puts the
+         * Print Edition in `.behind` (1px, clipped) and nothing in the app reads
+         * location.hash, so the reader would land on the cover at t=0 anyway
+         * (PR #76 review, finding 1). The cover is where they were going.
+         */}
         <a className={styles.ctaLink} href="/">
           {notFound.cta}
         </a>
-        <div className={styles.newsBtns}>
-          <a className={styles.newsBtn} href="/#projects">
-            {notFound.ctaProjects}
-          </a>
-          <a className={styles.newsBtn} href="/#contact">
-            {notFound.ctaContact}
-          </a>
-        </div>
       </main>
 
       {/* ponytail: no Harley cameo here -- the mascot PNGs are 1.5-4 MB each,

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,75 @@
+import { lettering, notFound } from "@/lib/content";
+import styles from "@/components/PrintEdition.module.css";
+
+/*
+ * 404 -- the panel that never made it to print.
+ *
+ * `output: export` emits this as out/404.html, which GitHub Pages serves for
+ * every unknown path. No WebGL, no client JS: a lost reader gets the paper
+ * edition instantly, which is the point.
+ *
+ * It borrows the Print Edition stylesheet rather than owning one -- that sheet
+ * IS the design language (paper + Ben-Day halftone, 4px ink borders, hard
+ * offset shadows, Bangers lettering, Caveat hand, mono terminal), and a second
+ * copy of it would only drift. Copy lives in lib/content (S0.5).
+ *
+ * ponytail: the terminal prints a fixed "GET /this-page" rather than the real
+ * URL -- reading it needs "use client" + an effect to dodge the hydration
+ * mismatch. Swap in usePathname() if the exact path ever has to be shown.
+ */
+export default function NotFound() {
+  return (
+    <div className={styles.root}>
+      <header className={styles.masthead}>
+        <p className={styles.kicker}>{notFound.kicker}</p>
+        <h1 className={styles.mastheadTitle}>404</h1>
+        <p className={styles.dek}>{notFound.dek}</p>
+        <p className={styles.intro}>{notFound.intro}</p>
+      </header>
+
+      <main className={styles.issue}>
+        <div className={styles.issueHead}>
+          <p className={styles.kicker}>{notFound.gutterKicker}</p>
+          <h2 className={styles.issueTitle}>{notFound.title}</h2>
+        </div>
+
+        {/* The empty panel itself: dashed hold-for-art box, a handwritten note
+            where the caption would be, and the sound of it hitting the floor. */}
+        <div className={styles.donationAlert}>
+          <span className={styles.hand}>{notFound.gutterNote}</span>
+          <p className={styles.boom}>{lettering.onomatopoeia.impact[2]}</p>
+        </div>
+
+        <dl className={styles.terminal}>
+          <div>
+            <dt>{notFound.terminal.request}</dt>
+            <dd>{notFound.terminal.response}</dd>
+          </div>
+          <div>
+            <dt>{notFound.terminal.suggestion}</dt>
+            <dd>{notFound.terminal.suggestionBody}</dd>
+          </div>
+        </dl>
+
+        <a className={styles.ctaLink} href="/">
+          {notFound.cta}
+        </a>
+        <div className={styles.newsBtns}>
+          <a className={styles.newsBtn} href="/#projects">
+            {notFound.ctaProjects}
+          </a>
+          <a className={styles.newsBtn} href="/#contact">
+            {notFound.ctaContact}
+          </a>
+        </div>
+      </main>
+
+      {/* ponytail: no Harley cameo here -- the mascot PNGs are 1.5-4 MB each,
+          which is not a bill to hand someone who already took a wrong turn. */}
+      <footer className={styles.backCover}>
+        <p className={styles.nextIssue}>{notFound.nextIssue}</p>
+        <p>{notFound.barcode}</p>
+      </footer>
+    </div>
+  );
+}

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -309,3 +309,28 @@ export const printEdition = {
     ],
   },
 } as const;
+
+// The 404 page (app/not-found.tsx -- emitted as out/404.html by the static
+// export, which GitHub Pages serves for any unknown path). Styled from the
+// Print Edition sheet: same paper, same lettering, no WebGL. The barcode line
+// answers lettersPage.backCover.barcode ("this issue never 404s") with the one
+// page that does. PURE ASCII (Turbopack rope bug); same dry, first-person tone.
+export const notFound = {
+  kicker: "Issue 404 -- panel not printed",
+  title: "MISSING PANEL",
+  dek: "This page fell out of the binding.",
+  intro: "The address is real; the art is not. Somewhere between the plate and the press this panel came out blank -- so here is the gutter where it should have been.",
+  gutterKicker: "the gutter -- nothing printed here",
+  gutterNote: "art was supposed to go here",
+  terminal: {
+    request: "GET /this-page",
+    response: "404 -- not in this printing.\nNothing was lost. It was never drawn.",
+    suggestion: "cover",
+    suggestionBody: "Go back to the front page and start the run from panel one.",
+  },
+  cta: "BACK TO THE COVER",
+  ctaProjects: "THE PROJECTS",
+  ctaContact: "THE DESK",
+  nextIssue: "NEXT PANEL: THE COVER",
+  barcode: "404 | the one page that does | still no refunds",
+} as const;

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -322,15 +322,17 @@ export const notFound = {
   intro: "The address is real; the art is not. Somewhere between the plate and the press this panel came out blank -- so here is the gutter where it should have been.",
   gutterKicker: "the gutter -- nothing printed here",
   gutterNote: "art was supposed to go here",
+  // Named, not sampled: lettering.onomatopoeia.impact is a pool the scenes draw
+  // from at random, so indexing it would let an ordinary content edit silently
+  // reletter this page (PR #76 review, finding 2).
+  boom: "KRAKA-THOOM",
   terminal: {
     request: "GET /this-page",
-    response: "404 -- not in this printing.\nNothing was lost. It was never drawn.",
-    suggestion: "cover",
-    suggestionBody: "Go back to the front page and start the run from panel one.",
+    response:
+      "404 -- not in this printing.\nNothing was lost. It was never drawn.\nTry the cover; the run starts at panel one.",
   },
   cta: "BACK TO THE COVER",
-  ctaProjects: "THE PROJECTS",
-  ctaContact: "THE DESK",
   nextIssue: "NEXT PANEL: THE COVER",
+  metaTitle: "404 -- Missing Panel",
   barcode: "404 | the one page that does | still no refunds",
 } as const;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2105,9 +2105,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Adds a 404 page in the portfolio's own design language.

`app/not-found.tsx` is emitted as `out/404.html` by the static export, which
GitHub Pages serves for every unknown path.

It borrows `PrintEdition.module.css` rather than owning a stylesheet -- that
sheet IS the design language (paper + Ben-Day halftone, 4px ink borders, hard
offset shadows, Bangers lettering, Caveat hand, mono terminal), and a second
copy of it would only drift. Copy lives in `lib/content` (S0.5), pure ASCII,
same dry first-person voice; the barcode line answers the letters page's
"this issue never 404s" with the one page that does.

Layout: masthead frame with the 404, a dashed hold-for-art box where the panel
should have been (Caveat margin note + KRAKA-THOOM), the letters-page terminal
answering `GET /this-page`, three exits back into the run, back-cover barcode.

No WebGL and no client JS: a lost reader gets the paper edition instantly. No
mascot cameo either -- the Harley PNGs are 1.5-4 MB each, which is not a bill
to hand someone who already took a wrong turn.

Deliberately skipped: the real URL in the terminal. Reading it needs
`"use client"` + an effect to dodge the hydration mismatch, so it prints a
fixed `GET /this-page`; `usePathname()` if the exact path ever has to show.

Verified: `next build` emits `out/404.html`, typecheck clean, screenshotted at
1280x900 and 390x844.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
