### PR TITLE
Put the dev at the desk on the cover

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,3 +15,13 @@ Route (delegate, don't do):
 - how does the engine fit together / orient a new session -> graphify MCP (mcp__graphify__*; CLI `graphify query` / graphify-out/wiki as fallback)
 
 Rules: bounded agent reports (<=20 lines); never ask the user (S0.7 only); log rulings with /decision; phase branch + PR per phase (never commit to main directly; after opening the PR, comment "@claude review" on it); source files stay pure ASCII (Turbopack rope bug); refresh graphs after each phase commit (post-commit hook does it - verify it fired).
+
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/components/PrintEdition.module.css
+++ b/components/PrintEdition.module.css
@@ -297,7 +297,9 @@
   font-size: 0.8rem;
   opacity: 0.75;
 }
-.catMotif {
+/* Small floated portrait beside a section lead. Cover uses the desk plate,
+   the other two use Harley -- hence the neutral name. */
+.motif {
   float: right;
   width: clamp(64px, 14vw, 110px);
   margin: 0 0 0.75rem 1rem;

--- a/components/PrintEdition.tsx
+++ b/components/PrintEdition.tsx
@@ -110,10 +110,12 @@ export default function PrintEdition() {
       <main id="print-main" className={styles.main}>
         {/* 0 -- Cover */}
         <Panel index={0} pal={PAL[0]} dark={DARK[0]} title={T[0].title} kicker={T[0].kicker}>
+          {/* the same plate the animated cover prints as its hero, so both
+              editions agree on what Issue #0 depicts */}
           <img
-            className={styles.catMotif}
-            src="/images/backcover-harley.png"
-            alt={printEdition.altText.mascot}
+            className={styles.motif}
+            src="/images/noir-window-figure.png"
+            alt={printEdition.altText.coverDesk}
             loading="lazy"
             decoding="async"
           />
@@ -181,7 +183,7 @@ export default function PrintEdition() {
         {/* 4 -- Origin */}
         <Panel index={4} pal={PAL[4]} dark={DARK[4]} title={T[4].title} kicker={T[4].kicker}>
           <img
-            className={styles.catMotif}
+            className={styles.motif}
             src="/images/backcover-harley.png"
             alt={printEdition.altText.mascot}
             loading="lazy"
@@ -327,7 +329,7 @@ export default function PrintEdition() {
         {/* 10 -- Spread */}
         <Panel index={10} pal={PAL[10]} dark={DARK[10]} title={T[10].title} kicker={T[10].kicker}>
           <img
-            className={styles.catMotif}
+            className={styles.motif}
             src="/images/backcover-harley.png"
             alt={printEdition.altText.mascot}
             loading="lazy"

--- a/issues/00-cover/Cover.tsx
+++ b/issues/00-cover/Cover.tsx
@@ -3,13 +3,12 @@
 import { Suspense, useMemo, useRef } from "react";
 import { useFrame } from "@react-three/fiber";
 import { Text } from "@react-three/drei";
-import type { Group, Mesh } from "three";
+import type { Group } from "three";
 import IssueShell from "../_IssueShell";
 import { ISSUES } from "../registry";
 import { RANGES } from "../timeline";
-import CatModel, { HARLEY, type CatPalette } from "@/components/CatModel";
+import { ArtPanel } from "../04-origin/Origin";
 import { toonRamp } from "@/lib/toon";
-import { stepTime } from "@/lib/steppedClock";
 import { useScrollStore } from "@/lib/scrollStore";
 import { lettering } from "@/lib/content";
 import { clamp01, easeOutCubic } from "@/lib/shots";
@@ -20,8 +19,8 @@ import { clamp01, easeOutCubic } from "@/lib/shots";
  * whole thing reads as a flat print; as t moves 0->0.030 the layers
  * separate in z (pure f(t)) while the camera crash-dollies in, feeding the
  * crash-through tear in the 0.030-0.040 gutter. Attract mode (before
- * scroll) breathes the layers and flicks the cat tail on 12fps stepTime;
- * the DOM attract prompt lives in components/Lettering.tsx -- not here.
+ * scroll) breathes the layers; the DOM attract prompt lives in
+ * components/Lettering.tsx -- not here.
  *
  * All copy comes from lettering.cover (lib/content.ts). In-scene cover
  * type is drei Text INSIDE the post pipeline deliberately: the print
@@ -33,15 +32,15 @@ const PAPER = "#F2EAD9";
 const INK = "#201D18";
 const RED = "#E2574C";
 const TEAL = "#2BB3A3";
+const AMBER = "#FFB347"; // hero-panel stand-in while its texture loads
 
 const BANGERS = "/fonts/Bangers-Regular.ttf";
 const COVER_END = RANGES[0]![1];
 
-// The hero cat sits ON the teal sunburst disc, and the default Harley collar
-// is that exact teal -- the band reads as a hole punched through the neck
-// (audit 2026-07-27). Same teal family, two steps darker: identity mark kept,
-// separation gained. Cover-local; every other issue keeps HARLEY as-is.
-const COVER_CAT: CatPalette = { ...HARLEY, collar: "#12695F" };
+// Hero panel = the desk-figure art (same plate the Noir window prints), sized
+// to the source 4:5 so ArtPanel's aspect crop is a no-op, and small enough
+// that the framed corners stay inside the sunburst's paper ring (r 2.28).
+const HERO = { w: 2.5, h: 3.125, border: 0.08 };
 
 // Masthead splits into a small kicker line + a big main line so long names
 // ("SAEED KOLIVAND", 14 chars) never clip or collide with the price box.
@@ -68,8 +67,6 @@ export default function Cover({ index }: { index: number }) {
   const art = useRef<Group>(null);
   const hero = useRef<Group>(null);
   const letter = useRef<Group>(null);
-  const tail = useRef<Group>(null);
-  const shadow = useRef<Mesh>(null);
 
   // barcode bars derived deterministically from the GitHub handle
   const barcode = useMemo(() => {
@@ -98,27 +95,14 @@ export default function Cover({ index }: { index: number }) {
     // paper board (z < 0) and flat shapes vanish for half of every cycle.
     // ONE shared phase for all layers: with per-layer phases the art sine
     // can overtake the hero sine and the burst disc plane rises INTO the
-    // cat's intra-group z span, slicing the cat (flat torso/head circles
-    // hide behind the disc while capsule legs / torus tail bulge through).
-    // Shared phase + amplitudes that grow with the layer keep
-    // art < hero < letter invariant for every t and every breath.
+    // hero panel's z span, clipping it. Shared phase + amplitudes that grow
+    // with the layer keep art < hero < letter invariant for every t and
+    // every breath.
     const z = (l: { base: number; depth: number }, amp: number) =>
       l.base + l.depth * sep + breathe * amp * (0.5 + 0.5 * Math.sin(el * 0.85));
     if (art.current) art.current.position.z = z(LAYER.art, 0.05);
     if (hero.current) hero.current.position.z = z(LAYER.hero, 0.09);
     if (letter.current) letter.current.position.z = z(LAYER.letter, 0.13);
-    if (shadow.current) {
-      // pounce shadow shrinks away as the print separates (stays attached
-      // to the composition -- no orphaned ink blob during the crash push)
-      const k = 1 - sep;
-      shadow.current.scale.set(1.3 * k + 0.001, 0.22 * k + 0.001, 1);
-    }
-    if (tail.current) {
-      const s = stepTime(el, 12); // S2.8 -- 12fps tail flick, camera stays smooth
-      tail.current.rotation.z = reducedMotion
-        ? 0
-        : Math.sin(s * 2.6) * 0.28 + Math.sin(s * 0.6) * 0.1;
-    }
   });
 
   return (
@@ -183,48 +167,46 @@ export default function Cover({ index }: { index: number }) {
           </mesh>
         </group>
 
-        {/* L2 -- hero art: the cat, mid-pounce toward the masthead (S1
-            through-line; clickable meow, S5b.5). Flat-print silhouette:
-            overlapping ink shapes stay connected, paper face details, teal
-            collar + red tag (identity marks shared with the Desk cat),
-            torus-arc tail that flicks on stepped time. */}
+        {/* L2 -- hero art: the dev at the desk (user directive 2026-09-07,
+            replacing the pounce cat). Same baked plate the Noir window
+            prints, tipped onto the sunburst as a cover photo: ink border,
+            slight tilt for the comic-cover energy, centered on the disc so
+            the paper ring reads all the way round. Click still meows --
+            Harley is off-panel now, but the S5b.5 gag stays. */}
         <group
           ref={hero}
-          position={[0, -0.75, 0.03]}
+          position={[0, -0.4, 0.03]}
+          rotation={[0, 0, -0.035]}
           onClick={(e) => {
             e.stopPropagation();
             useScrollStore.getState().meow();
           }}
         >
-          {/* pounce shadow -- rides the SAME layer as the cat (never
-              spatially detaches under parallax); just behind the body ink
-              yet always in front of the burst (hero-art base gap 0.015).
-              Shrinks with separation, pure f(t). */}
-          <mesh ref={shadow} position={[-0.15, -1.3, -0.008]} scale={[1.3, 0.22, 1]}>
-            <circleGeometry args={[1, 32]} />
+          {/* printed ink border, one plane behind the art */}
+          <mesh position={[0, 0, -0.004]}>
+            <planeGeometry args={[HERO.w + HERO.border * 2, HERO.h + HERO.border * 2]} />
             <meshToonMaterial color={INK} gradientMap={ramp} />
           </mesh>
-          <group scale={1.3} rotation={[0, 0, 0.42]}>
-            {/* shared mascot (components/CatModel): flat-print pounce build,
-                Harley default palette (golden tabby, user directive
-                2026-07-03); tail rig ref is flicked on stepped time in the
-                useFrame above, its pivot sits INSIDE the haunch */}
-            <CatModel mode="flat" pose="leaping" palette={COVER_CAT} rig={{ tail }} />
-
-            {/* speed dashes trailing the pounce (technique vocabulary, S1) */}
-            <mesh position={[-1.8, -0.55, 0.001]}>
-              <planeGeometry args={[0.8, 0.06]} />
-              <meshToonMaterial color={RED} gradientMap={ramp} />
-            </mesh>
-            <mesh position={[-2.0, -0.2, 0.001]}>
-              <planeGeometry args={[0.6, 0.05]} />
-              <meshToonMaterial color={RED} gradientMap={ramp} />
-            </mesh>
-            <mesh position={[-1.7, -0.9, 0.001]}>
-              <planeGeometry args={[0.5, 0.045]} />
-              <meshToonMaterial color={RED} gradientMap={ramp} />
-            </mesh>
-          </group>
+          {/* amber fill stands in while the texture loads -- LOCAL Suspense,
+              the rest of the cover never unmounts */}
+          <Suspense
+            fallback={
+              <mesh>
+                <planeGeometry args={[HERO.w, HERO.h]} />
+                <meshToonMaterial color={AMBER} gradientMap={ramp} />
+              </mesh>
+            }
+          >
+            {/* trim eats the plate's own baked canvas-edge ink so it cannot
+                double the border plane behind it */}
+            <ArtPanel
+              url="/images/noir-window-figure.png"
+              w={HERO.w}
+              h={HERO.h}
+              z={0}
+              trim={0.012}
+            />
+          </Suspense>
         </group>
 
         {/* L3 -- lettering plate: masthead, issue line, price box, blurb, barcode */}

--- a/issues/00-cover/Cover.tsx
+++ b/issues/00-cover/Cover.tsx
@@ -32,7 +32,11 @@ const PAPER = "#F2EAD9";
 const INK = "#201D18";
 const RED = "#E2574C";
 const TEAL = "#2BB3A3";
-const AMBER = "#FFB347"; // hero-panel stand-in while its texture loads
+
+// Not a cover-row color: this is the hero plate's own field amber (the same
+// value Noir lights its window with), used ONLY as the stand-in fill while
+// that plate decodes, so the swap is a content change and not a color step.
+const AMBER = "#FFB347";
 
 const BANGERS = "/fonts/Bangers-Regular.ttf";
 const COVER_END = RANGES[0]![1];
@@ -171,8 +175,9 @@ export default function Cover({ index }: { index: number }) {
             replacing the pounce cat). Same baked plate the Noir window
             prints, tipped onto the sunburst as a cover photo: ink border,
             slight tilt for the comic-cover energy, centered on the disc so
-            the paper ring reads all the way round. Click still meows --
-            Harley is off-panel now, but the S5b.5 gag stays. */}
+            the paper ring reads all the way round. The click still meows:
+            an unsignposted gag now that the cat it sat on is gone, which is
+            what the rest of the S5b.5 cats are too. */}
         <group
           ref={hero}
           position={[0, -0.4, 0.03]}
@@ -188,12 +193,14 @@ export default function Cover({ index }: { index: number }) {
             <meshToonMaterial color={INK} gradientMap={ramp} />
           </mesh>
           {/* amber fill stands in while the texture loads -- LOCAL Suspense,
-              the rest of the cover never unmounts */}
+              the rest of the cover never unmounts. Unlit basic material to
+              match the ArtPanel it hands off to (a toon+ramp fill would make
+              the swap a luminance step, not just a content change). */}
           <Suspense
             fallback={
               <mesh>
                 <planeGeometry args={[HERO.w, HERO.h]} />
-                <meshToonMaterial color={AMBER} gradientMap={ramp} />
+                <meshBasicMaterial color={AMBER} />
               </mesh>
             }
           >

--- a/issues/04-origin/Origin.tsx
+++ b/issues/04-origin/Origin.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useEffect, useLayoutEffect, useRef, type ReactNode } from "react";
+import { Suspense, useEffect, useLayoutEffect, useMemo, useRef, type ReactNode } from "react";
 import { useFrame, useLoader } from "@react-three/fiber";
 import { Text } from "@react-three/drei";
 import {
@@ -248,7 +248,13 @@ function PanelFrame({ p, children }: { p: PanelDef; children?: ReactNode }) {
  * Mount under a LOCAL Suspense: while loading, the PanelFrame's PAPER_DIM
  * interior fill (z 0.03) is the placeholder, and the rest of the page
  * never unmounts.
+ *
+ * ONE url can have several live consumers -- SceneManager keeps three issues
+ * mounted, and the cover hero and the noir window print the same plate -- so
+ * neither the UV transform nor the teardown may be shared. See ART_USERS.
  */
+const ART_USERS = new Map<string, number>();
+
 export function ArtPanel({
   url,
   w,
@@ -262,7 +268,19 @@ export function ArtPanel({
   trim?: number;
   z?: number;
 }) {
-  const tex = useLoader(TextureLoader, url);
+  const src = useLoader(TextureLoader, url);
+  // Own Texture per consumer over the SHARED Source. useLoader caches by url,
+  // so without this the live consumers write repeat/offset onto ONE object and
+  // the last effect to run wins for every mesh -- a crop that depends on
+  // scroll history. Verified against the pinned three 0.185.1: copy() assigns
+  // `this.source = source.source` (image never duplicated) while offset/repeat
+  // land in the clone's own vectors, and WebGLTextures keys uploads by
+  // source + cacheKey with a usedTimes count, so N clones are still ONE
+  // upload and one dispose cannot delete a live texture. offset/repeat are
+  // NOT part of that cacheKey -- but colorSpace is, so every consumer of a
+  // url must keep setting the same one (they all set SRGBColorSpace below) or
+  // the upload forks in two.
+  const tex = useMemo(() => src.clone(), [src]);
 
   useLayoutEffect(() => {
     const img = tex.image as { width: number; height: number };
@@ -275,16 +293,26 @@ export function ArtPanel({
     tex.needsUpdate = true;
   }, [tex, w, h, trim]);
 
-  // useLoader caches by url: clear the cache entry AND free the GPU copy on
-  // unmount (SceneManager remount reloads clean); the JSX material is
-  // auto-disposed by fiber like the scene's other resources
-  useEffect(
-    () => () => {
-      useLoader.clear(TextureLoader, url);
+  // Free THIS consumer's GPU copy on unmount (three drops the shared upload
+  // only when the last texture over that source goes), but clear the loader
+  // cache -- and with it the decoded image -- only when the last consumer
+  // leaves. Disposing unconditionally would yank the plate out from under an
+  // issue still drawing it: a re-upload hitch on the gutter, then the amber
+  // stand-in again on the next remount. SceneManager remount still reloads
+  // clean, because by then the count is zero.
+  useEffect(() => {
+    ART_USERS.set(url, (ART_USERS.get(url) ?? 0) + 1);
+    return () => {
       tex.dispose();
-    },
-    [tex, url],
-  );
+      const left = (ART_USERS.get(url) ?? 1) - 1;
+      if (left > 0) {
+        ART_USERS.set(url, left);
+        return;
+      }
+      ART_USERS.delete(url);
+      useLoader.clear(TextureLoader, url);
+    };
+  }, [tex, url]);
 
   return (
     <mesh position={[0, 0, z]}>

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -290,6 +290,7 @@ export const printEdition = {
   toReaderLabel: "Read the Print Edition",
   toExperienceLabel: "Watch the animated version",
   altText: {
+    coverDesk: "Cover art: a developer at a desk in headphones, silhouetted against a lit monitor.",
     mascot: "Harley, the fluffy golden-brown tabby cat mascot, seated and watching the desk.",
     noirWindow: "A lone figure at a single lit window on a dark, rain-streaked block.",
     originKid: "A child at a hand-me-down computer, one cursor blinking in the dark.",


### PR DESCRIPTION
The cover hero was Harley mid-pounce. It is now the desk-figure plate -- the same baked art the Noir window prints -- tipped onto the sunburst as a cover photo.

**What changed** (`issues/00-cover/Cover.tsx`)
- L2 hero is an `ArtPanel` on `/images/noir-window-figure.png`, ink border plane behind it, `-0.035` rad tilt, centered on the teal disc at `y=-0.4` so the paper ring (r 2.28) reads all the way round and the framed corners stay inside it.
- Sized 2.5 x 3.125 -- the source is exactly 4:5, so ArtPanel's aspect crop is a no-op. `trim={0.012}` eats the plate's own baked canvas-edge ink so it cannot double our border.
- Local `Suspense` with an amber stand-in fill while the texture loads; the rest of the cover never unmounts.
- Deleted with the cat: pounce shadow (+ its `shadow` ref and shrink branch), speed dashes, the 12fps `tail` flick branch, `COVER_CAT`, and the `CatModel` / `stepTime` / `Mesh` imports only it used.
- Click still meows. Harley is off-panel now, but the S5b.5 gag stays.

**Verified**
- `tsc --noEmit` clean, `next build` clean, source stays pure ASCII.
- Screenshots at t=0 and mid-crash t=0.024: layer separation (art < hero < letter) holds, no clipping into the burst, no z-fight, no new console errors.

**Not in this PR**
- The Print Edition cover panel still uses the Harley motif (`components/PrintEdition.tsx:115`) -- say the word if the two should match.

CLAUDE.md carries the agent-rules block `next dev` re-adds to itself; committed so the tree stays clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)